### PR TITLE
improve mpi4py for num hess/nac

### DIFF
--- a/pyoqp/oqp/__init__.py
+++ b/pyoqp/oqp/__init__.py
@@ -15,6 +15,11 @@ try:
 except KeyError:
     exit('\nPyQOP: cannot find environment variable $OPENQP_ROOT\n')
 
+try:
+    int(os.environ['OMP_NUM_THREADS'])
+except (KeyError, ValueError):
+    os.environ['OMP_NUM_THREADS'] = '1'
+
 
 def _oqp_wrapper(func):
     """Decorator for OQP library functions"""

--- a/pyoqp/oqp/library/libdlfind.py
+++ b/pyoqp/oqp/library/libdlfind.py
@@ -148,7 +148,8 @@ class DLFindMin(DLFinder):
         # store energy and coordinates
         self.pre_energy = energy
         self.pre_coord = coordinates.copy()
-        dump_data((self.itr, self.atoms, coordinates, energy, de, rmsd_step, max_step, rmsd_grad, max_grad),
+        dump_data(self.mol,
+                  (self.itr, self.atoms, coordinates, energy, de, rmsd_step, max_step, rmsd_grad, max_grad),
                   title='OPTIMIZATION', fpath=self.mol.log_path)
 
         return energy, grad.reshape((self.natom, 3))
@@ -233,7 +234,8 @@ class DLFindMECI(DLFinder):
         # store energy and coordinates
         self.pre_energy = sum_e
         self.pre_coord = coordinates.copy()
-        dump_data((self.itr, self.atoms, coordinates, sum_e, de, gap_e, rmsd_step, max_step, rmsd_grad, max_grad, 0, 0),
+        dump_data(self.mol,
+                  (self.itr, self.atoms, coordinates, sum_e, de, gap_e, rmsd_step, max_step, rmsd_grad, max_grad, 0, 0),
                   title='MECI', fpath=self.mol.log_path)
 
         return (energy_1, energy_2), (grad_1.reshape((self.natom, 3)), grad_2.reshape((self.natom, 3)))

--- a/pyoqp/oqp/library/libscipy.py
+++ b/pyoqp/oqp/library/libscipy.py
@@ -255,6 +255,7 @@ class ConstrainOpt(Optimizer):
         self.pre_energy = energy
         self.pre_coord = coordinates.copy()
         dump_data(
+            self.mol,
             (self.itr, self.atoms, coordinates, energy, de, rmsd_step, max_step, rmsd_grad, max_grad, radius, distance),
             title='CONS_SPHERE',
             fpath=self.mol.log_path,
@@ -472,11 +473,12 @@ class MECIOpt(Optimizer):
         # store energy and coordinates
         self.pre_energy = f
         self.pre_coord = coordinates.copy()
-        dump_data((self.itr, self.atoms,
-                   coordinates, f, de, gap_e, rmsd_step, max_step, rmsd_grad, max_grad, rmsd_df_1, max_df_1),
-                  title='MECI',
-                  fpath=self.mol.log_path,
-                  )
+        dump_data(
+            self.mol,
+            (self.itr, self.atoms, coordinates, f, de, gap_e, rmsd_step, max_step, rmsd_grad, max_grad, rmsd_df_1, max_df_1),
+            title='MECI',
+            fpath=self.mol.log_path,
+        )
 
         return f, df
 
@@ -564,11 +566,12 @@ class MECIOpt(Optimizer):
         # store energy and coordinates
         self.pre_energy = f
         self.pre_coord = coordinates.copy()
-        dump_data((self.itr, self.atoms,
-                   coordinates, f, de, gap_e, rmsd_step, max_step, rmsd_grad, max_grad, rmsd_df, max_df),
-                  title='MECI',
-                  fpath=self.mol.log_path,
-                  )
+        dump_data(
+            self.mol,
+            (self.itr, self.atoms, coordinates, f, de, gap_e, rmsd_step, max_step, rmsd_grad, max_grad, rmsd_df, max_df),
+            title='MECI',
+            fpath=self.mol.log_path,
+        )
 
         return f, df
 
@@ -718,11 +721,12 @@ class MECPOpt(Optimizer):
         # store energy and coordinates
         self.pre_energy = f
         self.pre_coord = coordinates.copy()
-        dump_data((self.itr, self.atoms,
-                   coordinates, f, de, gap_e, rmsd_step, max_step, rmsd_grad, max_grad, rmsd_df2, max_df2),
-                  title='MECP',
-                  fpath=self.mol.log_path,
-                  )
+        dump_data(
+            self.mol,
+            (self.itr, self.atoms, coordinates, f, de, gap_e, rmsd_step, max_step, rmsd_grad, max_grad, rmsd_df2, max_df2),
+            title='MECP',
+            fpath=self.mol.log_path,
+        )
 
         return f, df
 
@@ -815,8 +819,9 @@ class StateSpecificOpt(Optimizer):
         # store energy and coordinates
         self.pre_energy = energy
         self.pre_coord = coordinates.copy()
-        dump_data((self.itr, self.atoms, coordinates, energy, de, rmsd_step, max_step, rmsd_grad, max_grad),
-                  title='OPTIMIZATION', fpath=self.mol.log_path)
+        dump_data(
+            self.mol, (self.itr, self.atoms, coordinates, energy, de, rmsd_step, max_step, rmsd_grad, max_grad),
+            title='OPTIMIZATION', fpath=self.mol.log_path)
 
         return energy, grad
 
@@ -863,8 +868,10 @@ class MEP:
         self.mep_energies.append(self.optimizer.last_energy)
 
         if self.mep_itr == 1:
-            dump_data((0, self.atoms, self.optimizer.init_xyz, self.optimizer.init_energy, self.optimizer.init_energy),
-                      title='MEP', fpath=self.mol.log_path)
+            dump_data(self.mol,
+                      (0, self.atoms, self.optimizer.init_xyz, self.optimizer.init_energy, self.optimizer.init_energy),
+                      title='MEP',
+                      fpath=self.mol.log_path)
             de = self.optimizer.init_energy - self.optimizer.last_energy
         else:
             de = self.mep_energies[-2] - self.mep_energies[-1]
@@ -881,6 +888,7 @@ class MEP:
 
         dump_log(self.mol, title='MEP Convergence %s' % self.mep_itr, section='mep', info=results)
         dump_data(
+            self.mol,
             (self.mep_itr, self.atoms, self.optimizer.last_xyz, self.optimizer.last_energy, de),
             title='MEP',
             fpath=self.mol.log_path,

--- a/pyoqp/oqp/library/runfunc.py
+++ b/pyoqp/oqp/library/runfunc.py
@@ -162,6 +162,34 @@ def compute_properties(mol):
     else:
         pass
 
+def compute_data(mol):
+    # prepare guess orbital
+    prep_guess(mol)
+
+    # compute reference energy
+    SinglePoint(mol).energy()
+
+    # compute gradient
+    Gradient(mol).gradient()
+
+    # compute dftd4
+    LastStep(mol).compute(mol, grad_list=mol.config['properties']['grad'])
+
+    # compute nac or nacme
+    nac_type = mol.config['properties']['nac']
+    if nac_type == 'nac':
+        NAC(mol).nac()
+    else:
+        pass
+
+    # compute soc
+    soc_type = mol.config['properties']['soc']
+    if soc_type:
+        pass
+    else:
+        pass
+
+
 def get_optimizer(mol):
     runtype = mol.config['input']['runtype']
     lib = mol.config['optimize']['lib']

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -9,6 +9,7 @@ from oqp.utils.input_parser import OQPConfigParser
 from oqp.molden.moldenwriter import MoldenWriter
 from .oqpdata import OQPData, OQP_CONFIG_SCHEMA
 from oqp.utils.mpi_utils import MPIManager
+from oqp.utils.mpi_utils import mpi_get_attr, mpi_write
 from oqp import ffi
 class Molecule:
     """
@@ -17,6 +18,8 @@ class Molecule:
 
     def __init__(self, project_name, input_file, log,
                  xyz=None, elem=None, mass=None, charge=0, mult=1, silent=0, idx=1):
+        self.mpi_manager = MPIManager()
+        self.usempi = True
         self.silent = silent
         self.idx = idx
 
@@ -37,7 +40,6 @@ class Molecule:
         self.input_file = input_file
         self.log = log
         self.log_path = os.path.dirname(input_file)
-
         self.energies = None
         self.grads = None
         self.dcm = []  # Nstate, Nstate
@@ -61,7 +63,6 @@ class Molecule:
 
         self.start_time = None
         self.back_door = None
-        self.mpi_manager = MPIManager()
 
     def get_atoms(self):
         """
@@ -179,12 +180,16 @@ class Molecule:
 
         return data
 
+    @mpi_get_attr
+    def get_coord(self, coordinates):
+        return coordinates
+
     def update_system(self, coordinates):
         """
         Modify coordinates in memory
         """
+        coordinates = self.get_coord(coordinates)
         coordinates = coordinates.reshape((-1, 3))
-        coordinates = self.mpi_manager.bcast(coordinates)
         natom = self.data['natom']
         coord = np.frombuffer(
             oqp.ffi.buffer(self.xyz, 3 * natom * oqp.ffi.sizeof("double")),
@@ -223,42 +228,37 @@ class Molecule:
         """Deallocate oqp data object"""
         self.data = None
 
+    @mpi_get_attr
+    def get_config(self, input_source):
+        parser = OQPConfigParser(schema=OQP_CONFIG_SCHEMA, allow_no_value=True)
+
+        # Determine the type of the input source and process accordingly
+        if isinstance(input_source, str):  # Assuming input is a filename
+            parser.read(input_source)
+        elif isinstance(input_source, dict):  # Assuming input is a dictionary
+            parser.load_dict(input_source)
+        else:
+            raise ValueError("Input must be a filename (str) or a configuration dictionary (dict)")
+
+        # Print configuration if not in silent mode
+        if not self.silent:
+            parser.print_config()
+
+        # Validate the configuration and apply it
+        config = parser.validate()
+
+        return config
 
     def load_config(self, input_source):
         """
         Load calculation parameters from a file or a dictionary based on the input type.
 
-        :param input_source: filename (str) or config dictionary (dict)
+        input_source: filename (str) or config dictionary (dict)
         """
         self.mpi_manager.set_mpi_comm(self.data)
-
-        if self.mpi_manager.rank == 0:
-            parser = OQPConfigParser(schema=OQP_CONFIG_SCHEMA, allow_no_value=True)
-
-            # Determine the type of the input source and process accordingly
-            if isinstance(input_source, str):  # Assuming input is a filename
-                parser.read(input_source)
-            elif isinstance(input_source, dict):  # Assuming input is a dictionary
-                parser.load_dict(input_source)
-            else:
-                raise ValueError("Input must be a filename (str) or a configuration dictionary (dict)")
-
-            # Print configuration if not in silent mode
-            if not self.silent:
-                parser.print_config()
-
-            # Validate the configuration and apply it
-            self.config = parser.validate()
-        else:
-            parser = None
-            self.config = None
-        # Broadcast the validated configuration to all ranks
-        self.config = self.mpi_manager.bcast(self.config)
-
-        # Apply the configuration to the data handler
+        self.config = self.get_config(input_source)
         self.data.apply_config(self.config)
-        self.mpi_manager.barrier()
-        # Extract relevant data from the data handler
+        self.data['usempi'] = int(self.usempi)
         self.xyz = self.data._data.xyz
         self.elem = self.data._data.qn
         self.mass = self.data._data.mass
@@ -266,6 +266,7 @@ class Molecule:
 
         return self
 
+    @mpi_write
     def write_molden(self, filename):
         """Write calculation results in Molden format"""
 
@@ -322,14 +323,15 @@ class Molecule:
 
         return log_c
 
+    @mpi_write
     def save_data(self):
         """
         Save mol data and computed results to json
         """
         if self.idx != 1:
-            jsonfile = self.log.replace('.log', f'_{self.idx}.json')
+            jsonfile = self.input_file.replace('.inp', f'_{self.idx}.json')
         else:
-            jsonfile = self.log.replace('.log', '.json')
+            jsonfile = self.input_file.replace('.inp', '.json')
 
         data = self.get_data()
         data.update(self.get_results())
@@ -337,8 +339,9 @@ class Molecule:
         with open(jsonfile, 'w') as outdata:
             json.dump(data, outdata, indent=2)
 
+    @mpi_write
     def save_freqs(self, state):
-        jsonfile = self.log.replace('.log', '.hess.json')
+        jsonfile = self.input_file.replace('.inp', '.hess.json')
         data = {
             'atoms': self.get_atoms().tolist(),
             'coord': self.get_system().tolist(),
@@ -388,7 +391,7 @@ class Molecule:
                 continue
 
     def read_freqs(self):
-        jsonfile = self.log.replace('.log', '.hess.json')
+        jsonfile = self.input_file.replace('.inp', '.hess.json')
 
         if not os.path.exists(jsonfile):
             exit(f'hess file {jsonfile} does not exist')

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -15,9 +15,11 @@ from oqp.utils.input_checker import check_input_values
 from oqp.molecule import Molecule
 from oqp.library.runfunc import (
    compute_energy, compute_grad, compute_nac, compute_soc, compute_geom,
-   compute_nacme, compute_properties, compute_hess, compute_thermo
+   compute_nacme, compute_properties, compute_data, compute_hess, compute_thermo
 )
 from oqp.utils.mpi_utils import MPIManager
+
+
 class Runner:
     """
     OQP main class for running calculations and tests.
@@ -34,7 +36,7 @@ class Runner:
     """
 
     def __init__(self, project=None, input_file=None, log=None,
-                 input_dict=None, silent=0):
+                 input_dict=None, silent=0, usempi=True):
         """
         Initialize the OQP Runner.
 
@@ -44,24 +46,41 @@ class Runner:
             log (str): Path to the log file.
             input_dict (dict): Dictionary containing input parameters.
             silent (int): Flag to run in silent mode (0 or 1).
+            usempi (bool): Flag to enable MPI functions
         """
         start_time = time.time()
 
-        signal(SIGINT, SIG_DFL)
-
-        if os.path.exists(log):
-            try:
-                os.remove(log)
-                print(f"Removed log file: {log}")
-            except Exception as e:
-                pass
+        # Define the mapping of run types to their respective functions
+        self.run_func = {
+            'energy': compute_energy,
+            'grad': compute_grad,
+            'nac': compute_nac,
+            'nacme': compute_nacme,
+            'soc': compute_soc,
+            'optimize': compute_geom,
+            'meci': compute_geom,
+            'mecp': compute_geom,
+            'mep': compute_geom,
+            'ts': compute_geom,
+            'hess': compute_hess,
+            'thermo': compute_thermo,
+            'prop': compute_properties,
+            'data': compute_data,
+        }
 
         signal(SIGINT, SIG_DFL)
 
         self.mpi_manager = MPIManager()
+
         # initialize mol
-        self.mol = Molecule(project, input_file, log, silent=silent).load_config(input_file)
-        # check input values
+        self.mol = Molecule(project, input_file, log, silent=silent)
+        self.mol.usempi = usempi
+        if input_dict:
+            self.mol.load_config(input_dict)
+        else:
+            self.mol.load_config(input_file)
+
+        # check input values set default omp_num_threads
         check_input_values(self.mol.config)
 
         # Reload mol if possible
@@ -69,7 +88,6 @@ class Runner:
 
         # Attach the starting time to mol
         self.mol.start_time = start_time
-
 
         dump_log(self.mol, title='', section='start')
 
@@ -92,29 +110,12 @@ class Runner:
         # Get the run type from mol configuration
         run_type = self.mol.config["input"]["runtype"]
 
-        # Define the mapping of run types to their respective functions
-        run_func = {
-            'energy': compute_energy,
-            'grad': compute_grad,
-            'nac': compute_nac,
-            'nacme': compute_nacme,
-            'soc': compute_soc,
-            'optimize': compute_geom,
-            'meci': compute_geom,
-            'mecp': compute_geom,
-            'mep': compute_geom,
-            'ts': compute_geom,
-            'hess': compute_hess,
-            'thermo': compute_thermo,
-            'prop': compute_properties,
-        }
-
         # Turn off convergence check for test
         if test_mod:
             self.mol.config['tests']['exception'] = True
 
         # Run calculations
-        run_func[run_type](self.mol)
+        self.run_func[run_type](self.mol)
 
         dump_log(self.mol, title='', section='end')
 
@@ -175,7 +176,6 @@ def main():
     """
     Main function to handle command-line arguments and run OQP.
     """
-    mpi_manager = MPIManager()
     parser = argparse.ArgumentParser(description='OQP Runner',
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('input', nargs='?', help='Input file')
@@ -185,6 +185,7 @@ def main():
                              '  all    - Run all tests in examples\n'
                              '  other  - Run tests in examples/other')
     parser.add_argument('--silent', action='store_true', help='run silently')
+    parser.add_argument('--nompi', action='store_true', help='disable mpi functions')
     args = parser.parse_args()
 
     if args.run_tests:
@@ -194,27 +195,26 @@ def main():
     if not args.input:
         parser.print_help()
         sys.exit(1)
-    if mpi_manager.rank == 0:
-        input_file = os.path.abspath(args.input)
-        if not os.path.exists(input_file):
-            print(f'\n   PyOQP input file {input_file} not found\n')
-            sys.exit(1)
 
-        input_path = os.path.dirname(input_file)
-        project_name = os.path.basename(input_file).replace('.inp', '')
+    input_file = os.path.abspath(args.input)
+    if not os.path.exists(input_file):
+        print(f'\n   PyOQP input file {input_file} not found\n')
+        sys.exit(1)
 
-        log = f'{input_path}/{project_name}.log'
-    else:
-        input_file = None
-        input_path = None
-        project_name = None
-        if os.name == 'nt':  # Windows
-            log = 'NUL'
-        else :
-            log = '/dev/null'
-    input_file = mpi_manager.bcast(input_file)
-    input_path = mpi_manager.bcast(input_path)
-    project_name = mpi_manager.bcast(project_name)
+    input_path = os.path.dirname(input_file)
+    project_name = os.path.basename(input_file).replace('.inp', '')
+    log = f'{input_path}/{project_name}.log'
+
+    usempi = True if not args.nompi else False
+    mpi_manager = MPIManager()
+    if usempi:
+        input_file = mpi_manager.bcast(input_file)
+        project_name = mpi_manager.bcast(project_name)
+        if mpi_manager.rank != 0:
+            if os.name == 'nt':  # Windows
+                log = 'NUL'
+            else:
+                log = '/dev/null'
 
     silent = 1 if args.silent else 0
 
@@ -222,7 +222,9 @@ def main():
     oqp_runner = Runner(project=project_name,
                         input_file=input_file,
                         log=log,
-                        silent=silent)
+                        silent=silent,
+                        usempi=usempi,
+                        )
 
     # Run OQP
     oqp_runner.run()

--- a/pyoqp/oqp/utils/file_utils.py
+++ b/pyoqp/oqp/utils/file_utils.py
@@ -7,7 +7,8 @@ import numpy as np
 from oqp.molden.moldenwriter import write_frequency
 from oqp.periodic_table import SYMBOL_MAP, ELEMENTS_NAME
 from oqp.utils.constants import ANGSTROM_TO_BOHR
-from oqp.utils.mpi_utils import MPIManager
+from oqp.utils.mpi_utils import MPIManager, mpi_dump
+
 
 def try_basis(basis, path=None, fallback='6-31g'):
     """try various basis file locations and return the matching one"""
@@ -54,8 +55,8 @@ def how_long(start, end):
         int(((walltime % 86400) % 3600) % 60))
     return walltime
 
-
-def dump_log(mol, title=None, section=None, info=None):
+@mpi_dump
+def dump_log(mol, title=None, section=None, info=None, must_print=False):
     # function to write information to main log
     logfile = mol.log
     method = mol.config['input']['method']
@@ -396,19 +397,23 @@ def dump_log(mol, title=None, section=None, info=None):
         )
 
     if section == 'num_nacv':
-        ndim, dx, restart = info
+        ndim, dx, restart, jobs, nproc, threads = info
         loginfo = """
    PyOQP nac type                  %14s
    PyOQP number of displacements       %14s
    PyOQP size of displacements         %14s
    PyOQP calculation restart           %14s
-
-""" % ('numerical', ndim, dx, restart)
+   PyOQP number of nacme               %14s
+   PyOQP number of processes           %14s
+   PyOQP number of threads             %14s
+   
+""" % ('numerical', ndim, dx, restart, jobs, nproc, threads)
 
     if section == 'nacv_worker':
         order, idx, flag, timing = info
-        start, end = timing
-        loginfo = f'   PyOQP step: {order:<8} displacement: {idx:<8} {flag:<10} in {end - start:<16.0f} sec\n'
+        start, end, rank, threads, host = timing
+        loginfo = f'   PyOQP step: {order:<8} displacement: {idx:<8} {flag:<10} in {end - start:<16.0f} sec' \
+                  f' from rank {rank:<3} with {threads:<3} threads on node {host}\n'
 
     if section == 'nacv':
         atoms = mol.get_atoms()
@@ -452,20 +457,24 @@ def dump_log(mol, title=None, section=None, info=None):
 """ % hess_file
 
     if section == 'num_hess':
-        state, ndim, dx, restart = info
+        state, ndim, dx, restart, jobs, nproc, threads = info
         loginfo = """
    PyOQP hessian type                  %14s
    PyOQP hessian follow state          %14s
    PyOQP number of displacements       %14s
    PyOQP size of displacements         %14s
    PyOQP calculation restart           %14s
+   PyOQP number of grad                %14s
+   PyOQP number of processes           %14s
+   PyOQP number of threads             %14s
 
-""" % ('numerical', state, ndim, dx, restart)
+""" % ('numerical', state, ndim, dx, restart, jobs, nproc, threads)
 
     if section == 'hess_worker':
         order, idx, flag, timing = info
-        start, end = timing
-        loginfo = f'   PyOQP step: {order:<8} displacement: {idx:<8} {flag:<10} in {end - start:<16.0f} sec\n'
+        start, end, rank, threads, host = timing
+        loginfo = f'   PyOQP step: {order:<8} displacement: {idx:<8} {flag:<10} in {end - start:<16.0f} sec' \
+                  f' from rank {rank:<3} with {threads:<3} threads on node {host}\n'
 
     if section == 'freq':
         for n, f in enumerate(info):
@@ -569,11 +578,9 @@ def dump_log(mol, title=None, section=None, info=None):
     with open(logfile, mode) as out:
         out.write(loginfo)
 
-
-def dump_data(data, title=None, fpath='.'):
+@mpi_dump
+def dump_data(mol, data, title=None, fpath='.'):
     # function to write data in specific logs
-    mpi_manager = MPIManager()
-    if mpi_manager.rank != 0: return
     if title == 'ENERGY':
         energies, title = data
         filename = 'energies'
@@ -766,36 +773,36 @@ def dump_data(data, title=None, fpath='.'):
 
     if title == 'NUM_NACV':
         order, idx, norm, timing = data
-        start, end = timing
+        start, end, rank, threads, node = timing
 
         if order == 1:
             mode = 'w'
-            status = """%8s %8s %16s %16s
-------------------------------------------------------------
-%8s %8s %16.8f %16d
-""" % ('Step', 'Index', 'Norm', 'Time', order, idx, norm, end - start)
+            status = """%8s %8s %8s %8s %8s %16s %16s
+----------------------------------------------------------------------------------
+%8s %8s %8s %8s %8s %16d %16.8f
+""" % ('Step', 'Index', 'Rank', 'Threads', 'Node', 'Time', 'Norm', order, idx, rank, threads, node, end - start, norm)
 
         else:
             mode = 'a'
-            status = '%8s %8s %16.8f %16d\n' % (order, idx, norm, end - start)
+            status = '%8s %8s %8s %8s %8s %16d %16.8f\n' % (order, idx, rank, threads, node, end - start, norm)
 
         with open(f'{fpath}/nacv.status', mode) as out:
             out.write(status)
 
     if title == 'NUM_HESS':
         order, idx, norm, timing = data
-        start, end = timing
+        start, end, rank, threads, node = timing
 
         if order == 1:
             mode = 'w'
-            status = """%8s %8s %16s %16s
-------------------------------------------------------------
-%8s %8s %16.8f %16d
-""" % ('Step', 'Index', 'Norm', 'Time', order, idx, norm, end - start)
+            status = """%8s %8s %8s %8s %8s %16s %16s
+----------------------------------------------------------------------------------
+%8s %8s %8s %8s %8s %16d %16.8f
+""" % ('Step', 'Index', 'Rank', 'Threads', 'Node', 'Time', 'Norm', order, idx, rank, threads, node, end - start, norm)
 
         else:
             mode = 'a'
-            status = '%8s %8s %16.8f %16d\n' % (order, idx, norm, end - start)
+            status = '%8s %8s %8s %8s %8s %16d %16.8f\n' % (order, idx, rank, threads, node, end - start, norm)
 
         with open(f'{fpath}/hess.status', mode) as out:
             out.write(status)
@@ -840,12 +847,13 @@ def write_grad(atoms, grad):
 
 def write_config(config):
     input_file = ''
-
+    input_dict = {}
     for section in config.keys():
         if section == 'test':
             continue
 
         input_file += f'[{section}]\n'
+        input_dict[section] = {}
         for key, value in config[section].items():
             if not value:
                 continue
@@ -861,9 +869,11 @@ def write_config(config):
                     continue
 
             input_file += f'{key}={value}\n'
+            input_dict[section][key] = str(value)
+
         input_file += '\n'
 
-    return input_file
+    return input_file, input_dict
 
 
 DL_FIND_PARAMS = {

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -2,6 +2,8 @@
 
 import os
 import multiprocessing
+from oqp.utils.mpi_utils import MPIManager
+
 
 def check_input_values(config):
     runtype = config['input']['runtype']
@@ -21,10 +23,12 @@ def check_input_values(config):
         'hess': check_hess_input,
         'nacme': check_nacme_input,
         'prop': skip_check,
+        'data': skip_check,
     }
 
     info = f'\nPyOQP checking input\n\n[input] runtype={runtype}'
     check_func[runtype](config, info)
+
 
 def skip_check(config, info):
     pass
@@ -189,16 +193,18 @@ def check_nac_input(config, info):
     check_energy_input(config, info)
     check_energy_input(config, info)
     method = config['input']['method']
+    save = config['guess']['save_mol']
+    nac_type = config['nac']['type']
     td = config['tdhf']['type']
     nproc = config['nac']['nproc']
     ncpu = multiprocessing.cpu_count()
-
-    try:
-        omp = int(os.environ['OMP_NUM_THREADS'])
-    except KeyError:
-        omp = 0
+    mpi = MPIManager().size
+    omp = int(os.environ['OMP_NUM_THREADS'])
 
     info += f'\n[input] method={method}'
+
+    if nac_type == 'numerical' and not save:
+        exit(f'{info}\nPyOQP: numerical nac requires [guess]save_mol=True\n')
 
     if method == 'hf':
         exit(f'{info}\nPyOQP: scf cannot compute nac for hf calculations\n')
@@ -206,18 +212,18 @@ def check_nac_input(config, info):
     if method == 'tdhf' and td != 'mrsf':
         exit(f'{info}\nPyOQP: tdhf cannot compute nac for non-mrsf calculations\n')
 
-        info += f'\n[hess] nproc={nproc}'
-
-    if omp > 0 and omp*nproc > ncpu:
+    if MPIManager().use_mpi:
+        info += f'\nMPI process={mpi}'
         info += f'\nOMP_NUM_THREADS={omp}'
-        exit(f'{info}\nPyOQP: nac requested {nproc * omp} cpu, exceeding available {ncpu} cpus')
-
-    if omp == 0 and nproc > 1:
-        info += f'\nOMP_NUM_THREADS not set, using all threads'
-        exit(f'{info}\nPyOQP: nac requested {nproc * ncpu}, exceeding available {ncpu} cpus')
+        print(f'{info}\nPyOQP: nac requested {mpi * omp} cpus! {ncpu} available on a single node')
+    else:
+        info += f'\n[nac] nproc={nproc}'
+        info += f'\nOMP_NUM_THREADS={omp}'
+        print(f'{info}\nPyOQP: nac requested {nproc * omp} cpus! {ncpu} available')
 
     if nproc < 1:
-        exit(f'{info}\nPyOQP: nac requested {nproc} process is illegal ')
+        exit(f'{info}\nPyOQP: nac requested {nproc} process is illegal')
+
 
 def check_soc_input(config, info):
     not_available('soc', info)
@@ -230,18 +236,22 @@ def check_neb_input(config, info):
 def check_hess_input(config, info):
     check_energy_input(config, info)
     method = config['input']['method']
+    save = config['guess']['save_mol']
+    hess_type = config['hess']['type']
     state = config['hess']['state']
     nproc = config['hess']['nproc']
     restart = config['hess']['restart']
     ncpu = multiprocessing.cpu_count()
-
-    try:
-        omp = int(os.environ['OMP_NUM_THREADS'])
-    except KeyError:
-        omp = 0
+    mpi = MPIManager().size
+    omp = int(os.environ['OMP_NUM_THREADS'])
 
     info += f'\n[input] method={method}'
+    info += f'\n[guess] save_mol={save}'
+    info += f'\n[hess] type={hess_type}'
     info += f'\n[hess] state={state}'
+
+    if hess_type == 'numerical' and not save:
+        exit(f'{info}\nPyOQP: numerical hess requires [guess]save_mol=True\n')
 
     if method == 'hf' and state > 0:
         exit(f'{info}\nPyOQP: scf cannot compute hessian for state > 0\n')
@@ -250,18 +260,17 @@ def check_hess_input(config, info):
         exit(f'{info}\nPyOQP: tdhf cannot compute hessian for state = 0 \n')
 
     if restart != 'read':
-        info += f'\n[hess] nproc={nproc}'
-
-        if omp > 0 and omp*nproc > ncpu:
+        if MPIManager().use_mpi:
+            info += f'\nMPI process={mpi}'
             info += f'\nOMP_NUM_THREADS={omp}'
-            exit(f'{info}\nPyOQP: hessian requested {nproc * omp} cpu, exceeding available {ncpu} cpus')
-
-        if omp == 0 and nproc > 1:
-            info += f'\nOMP_NUM_THREADS not set, using all threads'
-            exit(f'{info}\nPyOQP: hessian requested {nproc * ncpu}, exceeding available {ncpu} cpus')
+            print(f'{info}\nPyOQP: hessian requested {mpi * omp} cpus! {ncpu} available on a single node')
+        else:
+            info += f'\n[hess] nproc={nproc}'
+            info += f'\nOMP_NUM_THREADS={omp}'
+            print(f'{info}\nPyOQP: hessian requested {nproc * omp} cpus! {ncpu} available')
 
         if nproc < 1:
-            exit(f'{info}\nPyOQP: hessian requested {nproc} process is illegal ')
+            exit(f'{info}\nPyOQP: hessian requested {nproc} process is illegal')
 
 
 def check_nacme_input(config, info):

--- a/pyoqp/oqp/utils/mpi_utils.py
+++ b/pyoqp/oqp/utils/mpi_utils.py
@@ -1,6 +1,7 @@
-import platform
-import sys
 import os
+import sys
+from collections.abc import Iterator
+
 try:
     from mpi4py import MPI
     mpi4py_available = True
@@ -10,6 +11,7 @@ except (ImportError, OSError) as e:
 class MPIManager:
 
     _instance = None
+
     def __new__(cls):
         if cls._instance is None:
             if mpi4py_available:
@@ -43,8 +45,8 @@ class MPIManager:
             try:
                 self.comm.Barrier()
                 MPI.Finalize()
-            except Exception as e:
-                print(f"Failed to finalize MPI: {str(e)}")
+            except Exception as err:
+                print(f"Failed to finalize MPI: {str(err)}")
 
     def set_mpi_comm(self, data):
         if self.use_mpi:
@@ -55,7 +57,90 @@ class MPIManager:
         else:
             data["usempi"] = 0
 
-    def bcast(self, data, root=0):
-        if self.use_mpi :
+    def bcast(self, data, root=0, barrier=True):
+        if self.use_mpi:
             data = self.comm.bcast(data, root=root)
+            if barrier:
+                self.comm.Barrier()
         return data
+
+
+class MPIPool:
+
+    def __init__(self, processes):
+        self.processes = processes
+
+    def imap_unordered(self, func, inp):
+        return MPIMap(func, inp, self.processes)
+
+    def close(self):
+        pass
+
+class MPIMap(Iterator):
+
+    def __init__(self, func, var, processes):
+        self.a = -1
+        self.func = func
+        self.var = var
+        self.processes = processes
+        self.mpi_manager = MPIManager()
+
+    def __next__(self):
+        self.a += 1
+
+        if self.a == len(self.var):
+            raise StopIteration
+
+        slot = self.a % self.processes
+
+        if slot == self.mpi_manager.rank:
+            data = self.func(self.var[self.a])
+
+        else:
+            data = None
+
+        if self.mpi_manager.rank == 0:
+            if slot != 0:
+                data = self.mpi_manager.comm.irecv(source=slot).wait()
+
+            return data
+        else:
+            if slot == self.mpi_manager.rank:
+                self.mpi_manager.comm.isend(data, dest=0).wait()
+
+def mpi_get_attr(func):
+    # mpi decorator to get values then broadcast before return values
+    def wrapper(self, *args):
+        if self.mpi_manager.rank == 0 or not self.usempi:
+            attr = func(self, *args)
+        else:
+            attr = None
+
+        if self.usempi:
+            attr = self.mpi_manager.bcast(attr)
+        return attr
+    return wrapper
+
+def mpi_update_attr(func):
+    # mpi decorator to update values then broadcast without return values
+    def wrapper(self, *args):
+        if self.mpi_manager.rank == 0 or not self.usempi:
+            func(self, *args)
+
+        if self.usempi:
+            self.data = self.mpi_manager.bcast(self.data)
+    return wrapper
+
+def mpi_write(func):
+    # mpi decorator to write files
+    def wrapper(self, *args):
+        if self.mpi_manager.rank == 0 or not self.usempi:
+            func(self, *args)
+    return wrapper
+
+def mpi_dump(func):
+    # mpi decorator to write logs
+    def wrapper(mol, *args, **kwargs):
+        if MPIManager().rank == 0 or not mol.usempi:
+            func(mol, *args, **kwargs)
+    return wrapper


### PR DESCRIPTION
Numerical hessian and nac vector calculations distribute numerical calculation to N process, each running with M threads.
For MPI case:
  export OMP_NUM_THREADS=M
  mpirun -np N openqp input

For OMP case:
  set [hess]nproc=N in input
  export OMP_NUM_THREADS=M
  openqp input

Other changes: decoupling mpi4py and molecule class as much as possible.
Adding mpi decorator to mpi_util.py:
mpi_get_attr()              
synchronize the return values on all ranks

mpi_update_attr()        
synchronize mol.data on all ranks

mpi_write()                    
control mpi logging depending on rank, accept *args

mpi_dump()                   
control mpi logging depending on rank, accept *args, **kwargs
