### PR TITLE
pFON methods for SCF

### DIFF
--- a/examples/other/ati_rohf_mrsf-s_bhhlyp_pfon.inp
+++ b/examples/other/ati_rohf_mrsf-s_bhhlyp_pfon.inp
@@ -1,0 +1,65 @@
+# Example: Using the Pseudo-Fractional Occupation Number (pFON) Method 
+# for systems with SCF convergence issues.
+#
+# The pFON method helps achieve smoother convergence during SCF cycles 
+# by introducing fractional orbital occupations and gradually reducing 
+# the smearing temperature.
+#
+# - To enable pFON, set `pfon = true` in the [scf] section.
+# - `pfon_start_temp` specifies the initial temperature for smearing 
+#    (default: 2000 K).
+# - `pfon_cooling_rate` sets the temperature reduction per iteration 
+#    (default: 50 K).
+# - `pfon_nsmear` controls the number of orbitals above and below 
+#    the HOMO and LUMO for smearing (default: 5 orbitals).
+#
+# This method is particularly useful for systems with problematic SCF 
+# convergence, such as those with near-degenerate orbitals or metallic 
+# character, by gradually refining the electron distribution.
+[input]
+system=
+    8        2.172465619     -1.092631299     -0.069082281
+    7       -3.231209707     -0.943525947      0.783274807
+    6       -1.286076036     -0.031447436     -0.344217684
+    6       -2.651929090     -0.486573768     -0.523819693
+    6       -0.154661043     -0.785255166     -0.290927202
+    6       -1.081058863      1.434774626     -0.156690831
+    6        1.196038991     -0.210349666      0.032352563
+    6        0.130482439      1.918856223      0.172702989
+    6        1.247093409      1.142664376      0.125600845
+    6        3.443626554     -0.673271133      0.237714273
+    1       -3.427290385      0.092324008     -0.952001275
+    1       -2.550933812     -1.423551032     -1.119473617
+    1       -0.237170721     -1.825441406     -0.484553562
+    1       -1.872752565      2.024140981     -0.076675141
+    1       -3.281107141     -0.214082946      1.315978678
+    1       -2.408964691     -1.532275484      1.132746179
+    1       -4.151987364     -1.500177065      0.686673681
+    1        0.337633600      3.151021524      0.248720473
+    1        2.206118037      1.593170963      0.411119505
+    1        3.745267002      0.068524056      1.031145846
+    1        3.954403561     -0.335349123     -0.550247614
+    1        4.061101539     -1.548016202      0.348017598
+runtype=energy
+functional=bhhlyp
+charge=1
+method=tdhf
+basis=maug-cc-pv(d+d)z
+
+[guess]
+type=huckel
+save_mol=True
+continue_geom=false
+
+[scf]
+type=rohf
+maxit=500
+multiplicity=3
+pfon=true 
+pfon_start_temp=5000
+pfon_cooling_rate=50 
+pfon_nsmear=5
+
+[tdhf]
+type=mrsf
+nstate=6

--- a/include/oqp.h
+++ b/include/oqp.h
@@ -114,6 +114,7 @@ struct control_parameters {
     double    vshift_cdiis_switch;
     double    vshift;
     bool      mom;
+    bool      pfon;
     double    mom_switch;
     double    conv;
     int64_t   scf_incremental;

--- a/include/oqp.h
+++ b/include/oqp.h
@@ -117,6 +117,7 @@ struct control_parameters {
     bool      pfon;
     double    mom_switch;
     double    pfon_start_temp;
+    double    pfon_cooling_rate;
     double    conv;
     int64_t   scf_incremental;
     double    int2e_cutoff;

--- a/include/oqp.h
+++ b/include/oqp.h
@@ -118,6 +118,7 @@ struct control_parameters {
     double    mom_switch;
     double    pfon_start_temp;
     double    pfon_cooling_rate;
+    double    pfon_nsmear;
     double    conv;
     int64_t   scf_incremental;
     double    int2e_cutoff;

--- a/include/oqp.h
+++ b/include/oqp.h
@@ -116,6 +116,7 @@ struct control_parameters {
     bool      mom;
     bool      pfon;
     double    mom_switch;
+    double    pfon_start_temp;
     double    conv;
     int64_t   scf_incremental;
     double    int2e_cutoff;

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -78,6 +78,7 @@ OQP_CONFIG_SCHEMA = {
         'pfon': {'type': bool, 'default': 'False'},
         'pfon_start_temp': {'type': float, 'default': '2000.0'},
         'pfon_cooling_rate': {'type': float, 'default': '50.0'},
+        'pfon_nsmear': {'type': float, 'default': '0.0'},
         'multiplicity': {'type': int, 'default': '1'},
         'conv': {'type': float, 'default': '1.0e-6'},
         'incremental': {'type': bool, 'default': 'True'},
@@ -229,6 +230,7 @@ class OQPData:
             "pfon": "set_scf_pfon",
             "pfon_start_temp": "set_scf_pfon_start_temp",
             "pfon_cooling_rate": "set_scf_pfon_cooling_rate",
+            "pfon_nsmear": "set_scf_pfon_nsmear",
             "multiplicity": "set_mol_multiplicity",
             "conv": "set_scf_conv",
             "incremental": "set_scf_incremental",
@@ -458,6 +460,10 @@ class OQPData:
     def set_scf_pfon_cooling_rate(self, pfon_cooling_rate): 
         """pfon_cooling_rate """
         self._data.control.pfon_cooling_rate = pfon_cooling_rate
+
+    def set_scf_pfon_nsmear(self, pfon_nsmear): 
+        """pfon_cooling_rate """
+        self._data.control.pfon_nsmear = pfon_nsmear
 
     def set_scf_conv(self, conv):
         """Set SCF convergence threshold"""

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -75,6 +75,7 @@ OQP_CONFIG_SCHEMA = {
         'vshift': {'type': float, 'default': '0.0'},
         'mom': {'type': bool, 'default': 'False'},
         'mom_switch': {'type': float, 'default': '0.003'},
+        'pfon': {'type': bool, 'default': 'Flase'},
         'multiplicity': {'type': int, 'default': '1'},
         'conv': {'type': float, 'default': '1.0e-6'},
         'incremental': {'type': bool, 'default': 'True'},
@@ -223,6 +224,7 @@ class OQPData:
             "vshift": "set_scf_vshift",
             "mom": "set_scf_mom",
             "mom_switch": "set_scf_mom_switch",
+            "pfon": "set_scf_pfon", 
             "multiplicity": "set_mol_multiplicity",
             "conv": "set_scf_conv",
             "incremental": "set_scf_incremental",
@@ -440,6 +442,10 @@ class OQPData:
     def set_scf_mom_switch(self, mom_switch):
         """Set MOM turn on criteria of DIIS error """
         self._data.control.mom_switch = mom_switch
+
+    def set_scf_pfon(self, pfon): 
+        """pFON """
+        self._data.control.pfon = pfon 
 
     def set_scf_conv(self, conv):
         """Set SCF convergence threshold"""
@@ -728,3 +734,4 @@ def read_system(system):
     mass = [MASSES[int(SYMBOL_MAP[atoms[i][0]])] for i in range(0, num_atoms)]
 
     return num_atoms, x, y, z, q, mass
+

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -75,7 +75,7 @@ OQP_CONFIG_SCHEMA = {
         'vshift': {'type': float, 'default': '0.0'},
         'mom': {'type': bool, 'default': 'False'},
         'mom_switch': {'type': float, 'default': '0.003'},
-        'pfon': {'type': bool, 'default': 'Flase'},
+        'pfon': {'type': bool, 'default': 'False'},
         'multiplicity': {'type': int, 'default': '1'},
         'conv': {'type': float, 'default': '1.0e-6'},
         'incremental': {'type': bool, 'default': 'True'},

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -78,7 +78,7 @@ OQP_CONFIG_SCHEMA = {
         'pfon': {'type': bool, 'default': 'False'},
         'pfon_start_temp': {'type': float, 'default': '2000.0'},
         'pfon_cooling_rate': {'type': float, 'default': '50.0'},
-        'pfon_nsmear': {'type': float, 'default': '0.0'},
+        'pfon_nsmear': {'type': float, 'default': '5.0'},
         'multiplicity': {'type': int, 'default': '1'},
         'conv': {'type': float, 'default': '1.0e-6'},
         'incremental': {'type': bool, 'default': 'True'},

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -77,6 +77,7 @@ OQP_CONFIG_SCHEMA = {
         'mom_switch': {'type': float, 'default': '0.003'},
         'pfon': {'type': bool, 'default': 'False'},
         'pfon_start_temp': {'type': float, 'default': '2000.0'},
+        'pfon_cooling_rate': {'type': float, 'default': '50.0'},
         'multiplicity': {'type': int, 'default': '1'},
         'conv': {'type': float, 'default': '1.0e-6'},
         'incremental': {'type': bool, 'default': 'True'},
@@ -227,6 +228,7 @@ class OQPData:
             "mom_switch": "set_scf_mom_switch",
             "pfon": "set_scf_pfon",
             "pfon_start_temp": "set_scf_pfon_start_temp",
+            "pfon_cooling_rate": "set_scf_pfon_cooling_rate",
             "multiplicity": "set_mol_multiplicity",
             "conv": "set_scf_conv",
             "incremental": "set_scf_incremental",
@@ -452,6 +454,10 @@ class OQPData:
     def set_scf_pfon_start_temp(self, pfon_start_temp): 
         """pfon_start_temp """
         self._data.control.pfon_start_temp = pfon_start_temp 
+
+    def set_scf_pfon_cooling_rate(self, pfon_cooling_rate): 
+        """pfon_cooling_rate """
+        self._data.control.pfon_cooling_rate = pfon_cooling_rate
 
     def set_scf_conv(self, conv):
         """Set SCF convergence threshold"""

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -76,6 +76,7 @@ OQP_CONFIG_SCHEMA = {
         'mom': {'type': bool, 'default': 'False'},
         'mom_switch': {'type': float, 'default': '0.003'},
         'pfon': {'type': bool, 'default': 'False'},
+        'pfon_start_temp': {'type': float, 'default': '2000.0'},
         'multiplicity': {'type': int, 'default': '1'},
         'conv': {'type': float, 'default': '1.0e-6'},
         'incremental': {'type': bool, 'default': 'True'},
@@ -224,7 +225,8 @@ class OQPData:
             "vshift": "set_scf_vshift",
             "mom": "set_scf_mom",
             "mom_switch": "set_scf_mom_switch",
-            "pfon": "set_scf_pfon", 
+            "pfon": "set_scf_pfon",
+            "pfon_start_temp": "set_scf_pfon_start_temp",
             "multiplicity": "set_mol_multiplicity",
             "conv": "set_scf_conv",
             "incremental": "set_scf_incremental",
@@ -444,8 +446,12 @@ class OQPData:
         self._data.control.mom_switch = mom_switch
 
     def set_scf_pfon(self, pfon): 
-        """pFON """
+        """pfon """
         self._data.control.pfon = pfon 
+
+    def set_scf_pfon_start_temp(self, pfon_start_temp): 
+        """pfon_start_temp """
+        self._data.control.pfon_start_temp = pfon_start_temp 
 
     def set_scf_conv(self, conv):
         """Set SCF convergence threshold"""

--- a/source/modules/oqp_banner.F90
+++ b/source/modules/oqp_banner.F90
@@ -72,6 +72,7 @@ contains
     write(iw, '(10x,   "*   Mr. Igor Gerasimov                                    *")')
     write(iw, '(10x,   "*   Dr. Hiroya Nakata                                     *")')
     write(iw, '(10x,   "*   Dr. Mohsen Mazaherifar                                *")')
+    write(iw, '(10x,   "*   Mr. Alireza Lashkaripour                              *")')
     write(iw, '(10x,   "*                                                         *")')
     write(iw, '(10x,   "*   In 2024, Prof. Jingbai Li at Hoffmann Institute of    *")')
     write(iw, '(10x,   "*   Advanced Materials began developing PyOQP.            *")')

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -578,10 +578,10 @@ contains
             write(iw,'(" END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
                   end_temp, electron_sum_a, electron_sum_b
 
-            do i = 1, nbf
-                write(iw,'(" Occ a(",I3,")=",F9.2,", Occ b(",I3,")=",F9.2)') &
-                     i, occ_a(i), i, occ_b(i)
-            end do
+!            do i = 1, nbf
+!                write(iw,'(" Occ a(",I3,")=",F9.2,", Occ b(",I3,")=",F9.2)') &
+!                     i, occ_a(i), i, occ_b(i)
+!            end do
         end if
 !>-------------------------------------------------------------------------
 
@@ -1070,12 +1070,16 @@ contains
      eF = 0.5_dp * (mo_energy(i_homo) + mo_energy(i_lumo))
 
      ! pre-normalizrion occupation 
-
+    print *, "Occ(i) Before ", occ(i)
+    print *, "tmp Before ", tmp
      do i = 1, nbf
         tmp = beta_pfon * (mo_energy(i) - eF)
+    print *, "tmp in loop ", tmp
         occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
+    print *, "Occ(i) in loop ", occ(i)
      end do 
-    print *, "Occ(i) ", occ(i)  
+    print *, "tmp After ", tmp
+    print *, "Occ(i) After ", occ(i)  
      ! Re-normalization to total number of electrons for rhf (alpha) 
 
      sum_occ = 0.0_dp 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -528,7 +528,7 @@ contains
                 end do
             end if
 
-            write(iw,'(" pFON: Temp=",F7.4,", Beta=",ES11.4,", sumOcc(a)=",F8.3,", sumOcc(b)=",F8.3)') &
+            write(iw,'(" pFON: Temp=",F9.2,", Beta=",ES11.4,", sumOcc(a)=",F8.3,", sumOcc(b)=",F8.3)') &
                 temp_pfon, beta_pfon, sum_occ_alpha, sum_occ_beta
         end if
 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -549,14 +549,14 @@ contains
 
             write(iw,'(T7," pFON: Temp=",F9.2,", Beta=",ES11.4)') temp_pfon, beta_pfon
             
-            select case (scf_type)
-            case (scf_rhf)
-                write(iw,'(T7," Total electron count = ",F12.6)') sum_occ_alpha
-            case (scf_uhf, scf_rohf)
-                write(iw,'(T7," Alpha electron count = ",F12.6)') sum_occ_alpha
-                write(iw,'(T7," Beta electron count  = ",F12.6)') sum_occ_beta
-                write(iw,'(T7," Total electron count = ",F12.6)') sum_occ_alpha + sum_occ_beta
-            end select
+!            select case (scf_type)
+!            case (scf_rhf)
+!                write(iw,'(T7," Total electron count = ",F12.6)') sum_occ_alpha
+!            case (scf_uhf, scf_rohf)
+!                write(iw,'(T7," Alpha electron count = ",F12.6)') sum_occ_alpha
+!                write(iw,'(T7," Beta electron count  = ",F12.6)') sum_occ_beta
+!                write(iw,'(T7," Total electron count = ",F12.6)') sum_occ_alpha + sum_occ_beta
+!           end select
 
         end if
 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -333,13 +333,20 @@ contains
                 infos%control%pfon, infos%control%pfon_start_temp, &
                 infos%control%pfon_cooling_rate, infos%control%pfon_nsmear
      !  Initial message
-     write(IW,fmt="&
-          &(/3x,'Direct SCF iterations begin.'/, &
-          &  3x,93('='),/ &
-          &  4x,'Iter',9x,'Energy',12x,'Delta E',9x,'Int Skip',5x,'DIIS Error',5x,'Shift',5x,'Method'/ &
-          &  3x,93('='))")
+     if (infos%control%pfon) then
+           write(IW,fmt="&
+                 &(/3x,'Direct SCF iterations begin.'/, &
+                 &  3x,113('='),/ &
+                 &  4x,'Iter',9x,'Energy',12x,'Delta E',9x,'Int Skip',5x,'DIIS Error',5x,'Shift',5x,'Method',5x,'pFON'/ &
+                 &  3x,113('='))")
+     else
+          write(IW,fmt="&
+                 &(/3x,'Direct SCF iterations begin.'/, &
+                 &  3x,93('='),/ &
+                 &  4x,'Iter',9x,'Energy',12x,'Delta E',9x,'Int Skip',5x,'DIIS Error',5x,'Shift',5x,'Method'/ &
+                 &  3x,93('='))")
+     endif
      call flush(iw)
-
      do iter = 1, maxit
 
   !     The main SCF iteration loop
@@ -441,9 +448,16 @@ contains
         diis_error = conv_res%error
   !     Checking the convergency
         diffe = etot-e_old
-        write(iw,'(4x,i4.1,2x,f17.10,1x,f17.10,1x,i13,1x,f14.8,5x,f5.3,5x,a)') &
-                iter, etot, diffe, nschwz, &
-                diis_error, vshift, trim(conv_res%active_converger_name)
+        if (infos%control%pfon) then
+           write(IW,fmt="(4x,i4.1,2x,f17.10,1x,f17.10,1x,i13,1x,f14.8,5x,f5.3,5x,a,5x,a,f9.2)") &
+                 iter, etot, diffe, nschwz, diis_error, vshift, &
+                 trim(conv_res%active_converger_name), "Temp:", temp_pfon
+           write(IW,fmt="(100x,a,f9.2)") "Beta:", beta_pfon
+        else
+           write(iw,'(4x,i4.1,2x,f17.10,1x,f17.10,1x,i13,1x,f14.8,5x,f5.3,5x,a)') &
+                 iter, etot, diffe, nschwz, diis_error, vshift, &
+                 trim(conv_res%active_converger_name)
+        endif
         call flush(iw)
   !     VDIIS option
         if ((infos%control%diis_type.eq.5) &
@@ -547,7 +561,7 @@ contains
                 sum_occ_beta = sum(occ_b(1:nbf))
             end if
 
-            write(iw,'(T7," pFON: Temp=",F9.2,", Beta=",ES11.4)') temp_pfon, beta_pfon
+!            write(iw,'(T7," pFON: Temp=",F9.2,", Beta=",ES11.4)') temp_pfon, beta_pfon
             
 !            select case (scf_type)
 !            case (scf_rhf)

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -515,44 +515,53 @@ contains
         if (do_pfon) then
             if (.not. allocated(occ_a)) allocate(occ_a(nbf))
             if (.not. allocated(occ_b)) allocate(occ_b(nbf))
-        nsmear = infos%control%pfon_nsmear
+            nsmear = infos%control%pfon_nsmear
+
             select case (scf_type)
             case (scf_rhf)
                 call pfon_occupations(mo_energy_a, nbf, nelec, occ_a, beta_pfon, scf_type, nsmear)
 
             case (scf_uhf)
-                call pfon_occupations(mo_energy_a, nbf, nelec_a, occ_a, beta_pfon, scf_type, nsmear)
+                call pfon_occupations(mo_energy_a, nbf, nelec, occ_a, beta_pfon, scf_type, nsmear, &
+                                    is_beta=.false., nelec_a=nelec_a, nelec_b=nelec_b)
                 if (nelec_b > 0) then
-                    call pfon_occupations(mo_energy_b, nbf, nelec_b, occ_b, beta_pfon, scf_type, nsmear)
+                    call pfon_occupations(mo_energy_b, nbf, nelec, occ_b, beta_pfon, scf_type, nsmear, &
+                                        is_beta=.true., nelec_a=nelec_a, nelec_b=nelec_b)
                 end if
 
             case (scf_rohf)
-                call pfon_occupations(mo_energy_a, nbf, nelec_a, occ_a, beta_pfon, scf_type, nsmear)
+                call pfon_occupations(mo_energy_a, nbf, nelec, occ_a, beta_pfon, scf_type, nsmear, &
+                                    is_beta=.false., nelec_a=nelec_a, nelec_b=nelec_b)
                 if (nelec_b > 0) then
-                    call pfon_occupations(mo_energy_a, nbf, nelec_b, occ_b, beta_pfon, scf_type, nsmear)
+                    call pfon_occupations(mo_energy_a, nbf, nelec, occ_b, beta_pfon, scf_type, nsmear, &
+                                        is_beta=.true., nelec_a=nelec_a, nelec_b=nelec_b)
                 end if
             end select
 
-            ! (Alpha)
-            sum_occ_alpha = 0.0_dp
-            do i = 1, nbf
-                sum_occ_alpha = sum_occ_alpha + occ_a(i)
-            end do
+            ! Alpha occupations
+            sum_occ_alpha = sum(occ_a(1:nbf))
 
-            ! (Beta)
+            ! Beta occupations
             sum_occ_beta = 0.0_dp
             if (scf_type == scf_uhf .or. scf_type == scf_rohf) then
-                do i = 1, nbf
-                    sum_occ_beta = sum_occ_beta + occ_b(i)
-                end do
+                sum_occ_beta = sum(occ_b(1:nbf))
             end if
 
-            write(iw,'(T7, " pFON: Temp=",F9.2,", Beta=",ES11.4)') &
-                 temp_pfon, beta_pfon
+            write(iw,'(T7," pFON: Temp=",F9.2,", Beta=",ES11.4)') temp_pfon, beta_pfon
+            
+            select case (scf_type)
+            case (scf_rhf)
+                write(iw,'(T7," Total electron count = ",F12.6)') sum_occ_alpha
+            case (scf_uhf, scf_rohf)
+                write(iw,'(T7," Alpha electron count = ",F12.6)') sum_occ_alpha
+                write(iw,'(T7," Beta electron count  = ",F12.6)') sum_occ_beta
+                write(iw,'(T7," Total electron count = ",F12.6)') sum_occ_alpha + sum_occ_beta
+            end select
+
+        end if
 
 !            write(iw,'(" Start: ",F9.2,", END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
 !                  start_temp ,end_temp, electron_sum_a, electron_sum_b
-        end if
 
 
   !     MOM option works for RHF and ROHF
@@ -1016,126 +1025,242 @@ contains
 !> method into SCF calculations, ensuring smooth occupation numbers using 
 !> Fermi-Dirac distribution. It dynamically adjusts temperature and beta 
 !> factors to enhance SCF convergence, particularly for near-degenerate states.
- subroutine pfon_occupations(mo_energy, nbf, nelec, occ, beta_pfon, scf_type, nsmear)
-     use precision, only: dp 
-     implicit none 
+    subroutine pfon_occupations(mo_energy, nbf, nelec, occ, beta_pfon, scf_type, nsmear, is_beta, nelec_a, nelec_b)
+        use precision, only: dp 
+        implicit none 
 
-     integer, intent(in) :: nbf 
-     integer, intent(in) :: nelec, nsmear
-     real(kind=dp), intent(in) :: beta_pfon
-     real(kind=dp), intent(in) :: mo_energy(nbf)
-     real(kind=dp), intent(inout) :: occ(nbf)
-     integer, intent(in) :: scf_type ! 1,2,3 RHF,UHF,ROHF 
-     real(kind=dp) :: eF, sum_occ
-     integer :: i, i_homo, i_lumo, i_low, i_high
-     real(kind=dp) :: tmp
+        integer, intent(in) :: nbf 
+        integer, intent(in) :: nelec, nsmear
+        real(kind=dp), intent(in) :: beta_pfon
+        real(kind=dp), intent(in) :: mo_energy(nbf)
+        real(kind=dp), intent(inout) :: occ(nbf)
+        integer, intent(in) :: scf_type ! 1,2,3 RHF,UHF,ROHF 
+        logical, intent(in), optional :: is_beta
+        integer, intent(in), optional :: nelec_a, nelec_b
+        real(kind=dp) :: eF, sum_occ
+        integer :: i, i_homo, i_lumo, i_low, i_high
+        real(kind=dp) :: tmp
+        logical :: is_beta_calc
+        integer :: n_electrons, n_double, n_single
 
-     select case (scf_type)
-     case(1) ! RHF 
-         i_homo = max(1, nelec/2) 
-     case(2) ! UHF 
-         i_homo = max(1, nelec)
-     case(3) ! ROHF 
-         i_homo = max(1, nelec) 
-     end select 
+        is_beta_calc = .false.
+        if (present(is_beta)) is_beta_calc = is_beta
 
-     i_lumo = i_homo + 1 
-     if (i_lumo > nbf) i_lumo = nbf 
+        select case (scf_type)
+        case(1) ! RHF 
+            i_homo = max(1, nelec/2)
+            n_electrons = nelec
 
-     ! Fermi level!
-     eF = 0.5_dp * (mo_energy(i_homo) + mo_energy(i_lumo))
-     ! If smear <= 0 --> smear all orbitals 
-     if (nsmear <= 0) then 
-     ! pre-normalizrion occupation 
-         do i = 1, nbf
-            tmp = beta_pfon * (mo_energy(i) - eF)
-            occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
-         end do 
-     else
-         i_low = max(1, i_homo - nsmear)
-         i_high = min(nbf, i_lumo + nsmear)
+        case(2) ! UHF 
+            if (.not. present(nelec_a) .or. .not. present(nelec_b)) then
+                stop 'UHF requires nelec_a and nelec_b'
+            endif
+            ! UHF: completely independent alpha and beta
+            if (is_beta_calc) then
+                i_homo = max(1, nelec_b)
+                n_electrons = nelec_b
+            else
+                i_homo = max(1, nelec_a)
+                n_electrons = nelec_a
+            endif
 
-         do i = 1, i_low - 1 
-            if (scf_type == 1) then 
-                occ(i) = 2.0_dp 
-            else 
-                occ(i) = 1.0_dp
-            end if 
-        end do 
+        case(3) ! ROHF 
+            if (.not. present(nelec_a) .or. .not. present(nelec_b)) then
+                stop 'ROHF requires nelec_a and nelec_b'
+            endif
+            ! ROHF: same spatial orbitals, different occupations
+            n_double = nelec_b           
+            n_single = nelec_a - nelec_b 
+            if (is_beta_calc) then
+                i_homo = n_double
+                n_electrons = nelec_b
+            else
+                i_homo = n_double + n_single
+                n_electrons = nelec_a
+            endif
+        end select 
 
-        do i = i_high + 1, nbf 
-            occ(i) = 0.0_dp 
-        end do 
-        ! Apply Fermi-Dirac
-        do i = i_low, i_high
-            tmp = beta_pfon * (mo_energy(i) - eF)
-            if (scf_type == 1) then  
-                occ(i) = 2.0_dp / (1.0_dp + exp(tmp))
-            else 
-                occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
-            end if 
-        end do 
-     end if 
+        i_lumo = i_homo + 1 
+        if (i_lumo > nbf) i_lumo = nbf 
 
-     ! Re-normalization  
-     sum_occ = 0.0_dp 
-     do i = 1, nbf 
-        sum_occ = sum_occ + occ(i) 
-     end do 
-     if (sum_occ < 1.0e-14_dp) then
-        sum_occ = 1.0_dp 
-     end if 
-     do i = 1, nbf 
-        occ(i) = occ(i) * (real(nelec,dp) / sum_occ)
-     end do 
- end subroutine pfon_occupations
- 
- ! pFON Density
- subroutine build_pfon_density(pdmat, mo_a, mo_b, occ_a, occ_b, scf_type, nbf, nelec_a, nelec_b)
-    use precision, only: dp 
-    use mathlib, only: pack_matrix
-    implicit none 
+        ! Calculate Fermi level
+        eF = 0.5_dp * (mo_energy(i_homo) + mo_energy(i_lumo))
 
-    real(kind=dp), intent(inout) :: pdmat(:,:)
-    real(kind=dp), intent(in) :: mo_a(:,:), mo_b(:,:)
-    real(kind=dp), intent(in) :: occ_a(:), occ_b(:)
-    integer, intent(in) :: nbf, scf_type, nelec_a, nelec_b
-
-    real(kind=dp), allocatable :: dtmp(:,:), cmo(:,:)
-    integer :: i, mu, nu 
-
-    allocate(dtmp(nbf, nbf), source=0.0_dp)
-    pdmat(:,1) = 0.0_dp 
-    if (size(pdmat,2) > 1) pdmat(:,2) = 0.0_dp 
-
-    ! build alpha density 
-    do i = 1, nbf 
-        if (occ_a(i) > 1.0e-14_dp) then 
-            do mu = 1, nbf
-                do nu = 1, nbf 
-                    dtmp(mu,nu) = dtmp(mu,nu) + occ_a(i) * mo_a(mu,i)*mo_a(nu,i)
-                end do 
+        if (nsmear <= 0) then 
+            do i = 1, nbf
+                tmp = beta_pfon * (mo_energy(i) - eF)
+                if (scf_type == 1) then  ! RHF
+                    occ(i) = 2.0_dp / (1.0_dp + exp(tmp))
+                else  ! UHF or ROHF
+                    occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
+                endif
             end do 
-        end if 
-    end do 
+        else
+            i_low = max(1, i_homo - nsmear)
+            i_high = min(nbf, i_lumo + nsmear)
 
-    call pack_matrix(dtmp, pdmat(:,1))
+            ! Special handling for ROHF
+            if (scf_type == 3) then
+                if (is_beta_calc) then
+                    do i = 1, n_double
+                        occ(i) = 1.0_dp
+                    end do
+                    do i = n_double + 1, nbf
+                        occ(i) = 0.0_dp
+                    end do
+                else
+                    do i = 1, n_double
+                        occ(i) = 1.0_dp
+                    end do
+                    do i = n_double + 1, n_double + n_single
+                        occ(i) = 1.0_dp
+                    end do
+                    do i = n_double + n_single + 1, nbf
+                        occ(i) = 0.0_dp
+                    end do
+                endif
 
-    ! bulid beta density
-    if (scf_type == 2 .or. scf_type == 3) then 
-        dtmp(:,:) = 0.0_dp 
-        do i = 1, nbf 
-            if (occ_b(i) > 1.0e-14_dp) then 
-                do mu = 1, nbf 
-                    do nu = 1, nbf 
-                        dtmp(mu,nu) = dtmp(mu,nu) + occ_b(i)*mo_b(mu,i)*mo_b(nu,i)
-                    end do 
+                ! Apply smearing only around the Fermi level
+                do i = i_low, i_high
+                    tmp = beta_pfon * (mo_energy(i) - eF)
+                    occ(i) = occ(i) / (1.0_dp + exp(tmp))
+                end do
+            else
+                ! RHF/UHF handling
+                do i = 1, i_low - 1 
+                    if (scf_type == 1) then 
+                        occ(i) = 2.0_dp 
+                    else 
+                        occ(i) = 1.0_dp
+                    endif
                 end do 
-            end if 
-        end do
-        call pack_matrix(dtmp, pdmat(:,2))
-    end if 
- end subroutine build_pfon_density 
+
+                do i = i_high + 1, nbf 
+                    occ(i) = 0.0_dp 
+                end do 
+
+                do i = i_low, i_high
+                    tmp = beta_pfon * (mo_energy(i) - eF)
+                    if (scf_type == 1) then  
+                        occ(i) = 2.0_dp / (1.0_dp + exp(tmp))
+                    else 
+                        occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
+                    endif
+                end do 
+            endif
+        endif 
+
+        ! Normalize occupations
+        sum_occ = sum(occ(1:nbf))
+        if (sum_occ < 1.0e-14_dp) then
+            sum_occ = 1.0_dp 
+        endif 
+        occ(1:nbf) = occ(1:nbf) * (real(n_electrons,dp) / sum_occ)
+
+    end subroutine pfon_occupations
+ ! pFON Density
+    subroutine build_pfon_density(pdmat, mo_a, mo_b, occ_a, occ_b, scf_type, nbf, nelec_a, nelec_b)
+        use precision, only: dp 
+        use mathlib, only: pack_matrix
+        implicit none 
+
+        real(kind=dp), intent(inout) :: pdmat(:,:)
+        real(kind=dp), intent(in) :: mo_a(:,:), mo_b(:,:)
+        real(kind=dp), intent(in) :: occ_a(:), occ_b(:)
+        integer, intent(in) :: nbf, scf_type, nelec_a, nelec_b
+
+        real(kind=dp), allocatable :: dtmp(:,:)
+        integer :: i, mu, nu
+        integer :: n_double, n_single
+        real(kind=dp) :: occ_factor
+
+        allocate(dtmp(nbf, nbf), source=0.0_dp)
+        
+        pdmat(:,:) = 0.0_dp
+
+        select case(scf_type)
+        case(1)  ! RHF
+            do i = 1, nbf 
+                if (occ_a(i) > 1.0e-14_dp) then 
+                    do mu = 1, nbf
+                        do nu = 1, nbf 
+                            dtmp(mu,nu) = dtmp(mu,nu) + occ_a(i) * mo_a(mu,i)*mo_a(nu,i)
+                        end do 
+                    end do 
+                end if 
+            end do 
+            call pack_matrix(dtmp, pdmat(:,1))
+
+        case(2)  ! UHF
+            do i = 1, nbf 
+                if (occ_a(i) > 1.0e-14_dp) then 
+                    do mu = 1, nbf
+                        do nu = 1, nbf 
+                            dtmp(mu,nu) = dtmp(mu,nu) + occ_a(i) * mo_a(mu,i)*mo_a(nu,i)
+                        end do 
+                    end do 
+                end if 
+            end do 
+            call pack_matrix(dtmp, pdmat(:,1))
+
+            dtmp(:,:) = 0.0_dp 
+            do i = 1, nbf 
+                if (occ_b(i) > 1.0e-14_dp) then 
+                    do mu = 1, nbf 
+                        do nu = 1, nbf 
+                            dtmp(mu,nu) = dtmp(mu,nu) + occ_b(i) * mo_b(mu,i)*mo_b(nu,i)
+                        end do 
+                    end do 
+                end if 
+            end do
+            call pack_matrix(dtmp, pdmat(:,2))
+
+        case(3)  ! ROHF
+            n_double = nelec_b           
+            n_single = nelec_a - nelec_b 
+
+            dtmp(:,:) = 0.0_dp
+            do i = 1, nbf 
+                if (occ_a(i) > 1.0e-14_dp) then 
+                    if (i <= n_double) then
+                        occ_factor = occ_a(i)  
+                    else if (i <= n_double + n_single) then
+                        occ_factor = 1.0_dp  
+                    else
+                        occ_factor = occ_a(i)  ! Virtual orbitals
+                    endif
+
+                    do mu = 1, nbf
+                        do nu = 1, nbf 
+                            dtmp(mu,nu) = dtmp(mu,nu) + occ_factor * mo_a(mu,i)*mo_a(nu,i)
+                        end do 
+                    end do 
+                end if 
+            end do 
+            call pack_matrix(dtmp, pdmat(:,1))
+
+            dtmp(:,:) = 0.0_dp 
+            do i = 1, nbf 
+                if (occ_b(i) > 1.0e-14_dp) then 
+                    if (i <= n_double) then
+                        occ_factor = occ_b(i)
+                    else
+                        occ_factor = 0.0_dp
+                    endif
+
+                    do mu = 1, nbf 
+                        do nu = 1, nbf 
+                            dtmp(mu,nu) = dtmp(mu,nu) + occ_factor * mo_a(mu,i)*mo_a(nu,i)
+                        end do 
+                    end do 
+                end if 
+            end do
+            call pack_matrix(dtmp, pdmat(:,2))
+        end select
+
+        deallocate(dtmp)
+
+    end subroutine build_pfon_density
 
 !> @brief      This routine reorders orbitals to maximum overlap.
  subroutine reordermos(v,e,smo,l0,nbf,lr1,lr2)

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -74,7 +74,6 @@ contains
 
      type(int2_compute_t) :: int2_driver
      class(int2_fock_data_t), allocatable :: int2_data
-!>-------------------------------------------------------------------------
 !    pFON 
      logical :: do_pfon
      real(kind=dp) :: beta_pfon, start_temp, end_temp, temp_pfon
@@ -83,7 +82,6 @@ contains
      real(kind=dp) :: sum_occ_alpha, sum_occ_beta, cooling_rate
      real(kind=dp) :: pfon_cooling_rate
      real(kind=dp), parameter :: kB_HaK = 3.166811563e-6_dp
-!>-------------------------------------------------------------------------
   ! tagarray
      real(kind=dp), contiguous, pointer :: &
        dmat_a(:), dmat_b(:), fock_a(:), fock_b(:), hcore(:), mo_b(:,:), &
@@ -106,7 +104,7 @@ contains
      vshift = infos%control%vshift
      vshift_last_iter=.false.
      H_U_gap_crit=0.02_dp
-!>-------------------------------------------------------------------------
+
   !  pFON settings
      do_pfon = .false. 
      do_pfon = infos%control%pfon 
@@ -119,7 +117,6 @@ contains
      if (temp_pfon < 1.0_dp) temp_pfon = 1.0_dp
 
      beta_pfon = 1.0_dp / (kB_HaK * temp_pfon)
-!>-------------------------------------------------------------------------
 
   !  DIIS options
   !  none IS NOT recommended!
@@ -346,7 +343,7 @@ contains
      do iter = 1, maxit
 
   !     The main SCF iteration loop
-!>------------------------------------------------------------------------- 
+
   !     pFON Cooling
         if (cooling_rate <= 0.0_dp) then
             cooling_rate = 50_dp 
@@ -364,7 +361,6 @@ contains
                 beta_pfon = 1.0e20_dp 
             end if
         end if 
-!>-------------------------------------------------------------------------
  
         pfock = 0.0_dp
 
@@ -513,9 +509,9 @@ contains
         end if
         call int2_driver%pe%bcast(mo_a, size(mo_a))
         call int2_driver%pe%bcast(mo_energy_a, size(mo_energy_a))
-        do_pfon = infos%control%pfon
-!>-------------------------------------------------------------------------
+
         ! pFON section
+        do_pfon = infos%control%pfon
         if (do_pfon) then
             if (.not. allocated(occ_a)) allocate(occ_a(nbf))
             if (.not. allocated(occ_b)) allocate(occ_b(nbf))
@@ -557,7 +553,6 @@ contains
 !            write(iw,'(" Start: ",F9.2,", END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
 !                  start_temp ,end_temp, electron_sum_a, electron_sum_b
         end if
-!>-------------------------------------------------------------------------
 
 
   !     MOM option works for RHF and ROHF
@@ -1012,7 +1007,7 @@ contains
    call reorderMOs(Vb, Eb, Smo, nbf, nbf, 1, na+1)
 
  end subroutine mo_reorder
-!>-------------------------------------------------------------------------
+
 !> @brief      pFON Implementation in SCF Module
 !> Author: Alireza Lashkaripour
 !> Date: January 2025
@@ -1069,7 +1064,7 @@ contains
      end do 
  end subroutine pfon_occupations
  
- ! pfon density
+ ! pFON Density
  subroutine build_pfon_density(pdmat, mo_a, mo_b, occ_a, occ_b, scf_type, nbf, nelec_a, nelec_b)
     use precision, only: dp 
     use mathlib, only: pack_matrix
@@ -1115,7 +1110,6 @@ contains
         call pack_matrix(dtmp, pdmat(:,2))
     end if 
  end subroutine build_pfon_density 
-!>-------------------------------------------------------------------------
 
 !> @brief      This routine reorders orbitals to maximum overlap.
  subroutine reordermos(v,e,smo,l0,nbf,lr1,lr2)

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -74,6 +74,12 @@ contains
 
      type(int2_compute_t) :: int2_driver
      class(int2_fock_data_t), allocatable :: int2_data
+     ! pFON 
+     logical :: do_pfon
+     real(kind=dp) :: beta_pfon, start_temp, end_temp, temp_pfon
+     real(kind=dp) :: electron_sum_a, electron_sum_b 
+     real(kind=dp), allocatable :: occ_a(:), occ_b(:)
+     real(kind=dp) :: sum_occ_alpha, sum_occ_beta
   ! tagarray
      real(kind=dp), contiguous, pointer :: &
        dmat_a(:), dmat_b(:), fock_a(:), fock_b(:), hcore(:), mo_b(:,:), &
@@ -97,13 +103,7 @@ contains
      vshift_last_iter=.false.
      H_U_gap_crit=0.02_dp
   ! pFON settings
-     logical :: do_pfon
-     real(kind=dp) :: beta_pfon, start_temp, end_temp, temp_pfon
-     real(kind=dp) :: electron_sum_a, electron_sum_b 
-     real(kind=dp), allocatable :: occ_a(:), occ_b(:)
-
      do_pfon = .false. 
-
      do_pfon = infos%control%pfon 
 
   !  pFON parameters (can be input by user in future)
@@ -1062,7 +1062,7 @@ contains
     call pack_matrix(dtmp, pdmat(:,1))
 
     ! needs to be rechecked 
-    if (scf_type == 2 .or. scf_type == 3)
+    if (scf_type == 2 .or. scf_type == 3) then 
         dtmp(:,:) = 0.0_dp 
         do i = 1, nbf 
             if (occ_b(i) > 1.0e-14_dp) then 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -575,13 +575,13 @@ contains
             write(iw,'(" pFON: Temp=",F9.2,", Beta=",ES11.4,", sumOcc(a)=",F8.3,", sumOcc(b)=",F8.3)') &
                  temp_pfon, beta_pfon, sum_occ_alpha, sum_occ_beta
 
-            write(iw,'(" Start: Temp=",F9.2,", END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
-                 start_temp, end_temp, electron_sum_a, electron_sum_b
+            write(iw,'(" END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
+                  end_temp, electron_sum_a, electron_sum_b
 
-!            do i = 1, nbf
-!                write(iw,'(" Occ a(",I3,")=",F9.2,", Occ b(",I3,")=",F9.2)') &
-!                     i, occ_a(i), i, occ_b(i)
-!            end do
+            do i = 1, nbf
+                write(iw,'(" Occ a(",I3,")=",F9.2,", Occ b(",I3,")=",F9.2)') &
+                     i, occ_a(i), i, occ_b(i)
+            end do
         end if
 !>-------------------------------------------------------------------------
 
@@ -1043,7 +1043,7 @@ contains
 !> Author: Alireza Lashkaripour
 !> Date: January 2025
 !> Reference paper: https://doi.org/10.1063/1.478177
-!> This module incorporates the Partial Fractional Occupation Number (pFON) 
+!> This subroutine incorporates the Partial Fractional Occupation Number (pFON) 
 !> method into SCF calculations, ensuring smooth occupation numbers using 
 !> Fermi-Dirac distribution. It dynamically adjusts temperature and beta 
 !> factors to enhance SCF convergence, particularly for near-degenerate states.
@@ -1075,7 +1075,7 @@ contains
         tmp = beta_pfon * (mo_energy(i) - eF)
         occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
      end do 
-     
+    print *, "Occ(i) ", occ(i)  
      ! Re-normalization to total number of electrons for rhf (alpha) 
 
      sum_occ = 0.0_dp 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -342,6 +342,7 @@ contains
 
   !     The main SCF iteration loop
 !>------------------------------------------------------------------------- 
+  !     pFON Cooling
         if (do_pfon) then
             if ( (iter == maxit ) .or. (abs(diis_error) < 10.0_dp * infos%control%conv) ) then 
                 temp_pfon = 0.0_dp 
@@ -542,8 +543,8 @@ contains
                 end do
             end if
 
-            write(iw,'(" pFON: Temp=",F9.2,", Beta=",ES11.4,", Start Temp=",F8.3)') &
-                 temp_pfon, beta_pfon, start_temp
+            write(iw,'(T7, " pFON: Temp=",F9.2,", Beta=",ES11.4)') &
+                 temp_pfon, beta_pfon
 
 !            write(iw,'(" Start: ",F9.2,", END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
 !                  start_temp ,end_temp, electron_sum_a, electron_sum_b

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -110,7 +110,7 @@ contains
      do_pfon = infos%control%pfon 
 
   !  pFON parameters (can be input by user in future) temp in Kelvin
-     start_temp = 2000.0_dp 
+     start_temp = 1000.0_dp 
 !     end_temp   = 0.0001_dp 
      temp_pfon  = start_temp
      ! these part needs to be changed since the temp can not be negative
@@ -529,7 +529,15 @@ contains
             end if
 
             write(iw,'(" pFON: Temp=",F9.2,", Beta=",ES11.4,", sumOcc(a)=",F8.3,", sumOcc(b)=",F8.3)') &
-                temp_pfon, beta_pfon, sum_occ_alpha, sum_occ_beta
+                 temp_pfon, beta_pfon, sum_occ_alpha, sum_occ_beta
+
+            write(iw,'(" Start: Temp=",F9.2,", END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
+                 start_temp, end_temp, electron_sum_a, electron_sum_b
+
+            do i = 1, nbf
+                write(iw,'(" Occ a(",I3,")=",F9.2,", Occ b(",I3,")=",F9.2)') &
+                     i, occ_a(i), i, occ_b(i)
+            end do
         end if
 
 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -96,6 +96,24 @@ contains
      vshift = infos%control%vshift
      vshift_last_iter=.false.
      H_U_gap_crit=0.02_dp
+  ! pFON settings
+     logical :: do_pfon
+     real(kind=dp) :: beta_pfon, start_temp, end_temp, temp_pfon
+     real(kind=dp) :: electron_sum_a, electron_sum_b 
+     real(kind=dp), allocatable :: occ_a(:), occ_b(:)
+
+     do_pfon = .false. 
+
+     do_pfon = infos%control%pfon 
+
+  !  pFON parameters (can be input by user in future)
+     start_temp = 0.005_dp 
+     end_temp   = 0.0001_dp 
+     temp_pfon  = start_temp
+     if (temp_pfon <= 1.0e-10_dp) temp_pfon = 1.0e-5_dp
+
+  !  for beta in this case we use atomic unit( change later)
+     beta_pfon = 3.166811563e-6_dp / temp_pfon 
 
   !  DIIS options
   !  none IS NOT recommended!
@@ -466,6 +484,47 @@ contains
         call int2_driver%pe%bcast(mo_a, size(mo_a))
         call int2_driver%pe%bcast(mo_energy_a, size(mo_energy_a))
 
+        ! pFON section
+        if (do_pfon) then
+            if (.not. allocated(occ_a)) allocate(occ_a(nbf))
+            if (.not. allocated(occ_b)) allocate(occ_b(nbf))
+
+            select case (scf_type)
+            case (scf_rhf)
+                call pfon_occupations(mo_energy_a, nbf, nelec, occ_a, beta_pfon)
+
+            case (scf_uhf)
+                call pfon_occupations(mo_energy_a, nbf, nelec_a, occ_a, beta_pfon)
+                if (nelec_b > 0) then
+                    call pfon_occupations(mo_energy_b, nbf, nelec_b, occ_b, beta_pfon)
+                end if
+
+            case (scf_rohf)
+                call pfon_occupations(mo_energy_a, nbf, nelec_a, occ_a, beta_pfon)
+                if (nelec_b > 0) then
+                    call pfon_occupations(mo_energy_a, nbf, nelec_b, occ_b, beta_pfon)
+                end if
+            end select
+
+            ! (Alpha)
+            sum_occ_alpha = 0.0_dp
+            do i = 1, nbf
+                sum_occ_alpha = sum_occ_alpha + occ_a(i)
+            end do
+
+            ! (Beta)
+            sum_occ_beta = 0.0_dp
+            if (scf_type == scf_uhf .or. scf_type == scf_rohf) then
+                do i = 1, nbf
+                    sum_occ_beta = sum_occ_beta + occ_b(i)
+                end do
+            end if
+
+            write(iw,'(" pFON: Temp=",F7.4,", Beta=",ES11.4,", sumOcc(a)=",F8.3,", sumOcc(b)=",F8.3)') &
+                temp_pfon, beta_pfon, sum_occ_alpha, sum_occ_beta
+        end if
+
+
   !     MOM option works for RHF and ROHF
         if (do_mom .and. diis_error.lt.infos%control%mom_switch) do_mom_flag=.true.
         if (do_mom .and. do_mom_flag .and. .not. step_0_mom) then
@@ -480,10 +539,19 @@ contains
 
   !     New density matrix in AO basis using MO.
         if (int2_driver%pe%rank == 0) then
-           call get_ab_initio_density(pdmat(:,1),mo_a,pdmat(:,2),mo_b,infos,basis)
-        end if
+            if (.not. do_pfon) then 
+                call get_ab_initio_density(pdmat(:,1),mo_a,pdmat(:,2),mo_b,infos,basis)
+            else 
+                call build_pfon_density(pdmat, mo_a, mo_b, occ_a, occ_b, scf_type, nbf, nelec_a, nelec_b)
+            end if
+        end if 
         call int2_driver%pe%bcast(pdmat, size(pdmat))
-
+        
+        ! adjusting temperature 
+        if (do_pfon) then 
+            temp_pfon = max(temp_pfon * 0.95_dp, end_temp)
+            beta_pfon = 1.0_dp / temp_pfon
+        end if 
   !
 
   !     Checking the HOMO-LUMO gaps for predicting SCF convergency
@@ -917,6 +985,97 @@ contains
    call reorderMOs(Vb, Eb, Smo, nbf, nbf, 1, na+1)
 
  end subroutine mo_reorder
+!> @brief      Assign pFON occupation 
+ subroutine pfon_occupations(mo_energy, nbf, nelec, occ, beta_pfon)
+     use precision, only: dp 
+     implicit none 
+
+     integer, intent(in) :: nbf 
+     integer, intent(in) :: nelec
+     real(kind=dp), intent(in) :: beta_pfon
+     real(kind=dp), intent(in) :: mo_energy(nbf)
+     real(kind=dp), intent(inout) :: occ(nbf)
+
+     real(kind=dp) :: eF, sum_occ
+     integer :: i, i_homo, i_lumo
+     real(kind=dp) :: tmp
+
+   ! Identifying the homo for rhf, homo ~ nelect/2 
+     i_homo = max(1, nelec/2)
+     i_lumo = i_homo + 1 
+     if (i_lumo > nbf) i_lumo = nbf 
+
+     ! Fermi level!
+     eF = 0.5_dp * (mo_energy(i_homo) + mo_energy(i_lumo))
+
+     ! pre-normalizrion occupation 
+
+     do i = 1, nbf
+        tmp = beta_pfon * (mo_energy(i) - eF)
+        occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
+     end do 
+     
+     ! Re-normalization to total number of electrons for rhf (alpha) 
+
+     sum_occ = 0.0_dp 
+     do i = 1, nbf 
+        sum_occ = sum_occ + occ(i) 
+     end do 
+     if (sum_occ < 1.0e-14_dp) then
+        sum_occ = 1.0_dp 
+        ! avoid dividing by zero 
+     end if 
+     do i = 1, nbf 
+        occ(i) = occ(i) * (real(nelec,dp) / sum_occ)
+     end do 
+ end subroutine pfon_occupations
+ 
+ ! pfon density
+ subroutine build_pfon_density(pdmat, mo_a, mo_b, occ_a, occ_b, scf_type, nbf, nelec_a, nelec_b)
+    use precision, only: dp 
+    use mathlib, only: pack_matrix
+    implicit none 
+
+    real(kind=dp), intent(inout) :: pdmat(:,:)
+    real(kind=dp), intent(in) :: mo_a(:,:), mo_b(:,:)
+    real(kind=dp), intent(in) :: occ_a(:), occ_b(:)
+    integer, intent(in) :: nbf, scf_type, nelec_a, nelec_b
+
+    real(kind=dp), allocatable :: dtmp(:,:), cmo(:,:)
+    integer :: i, mu, nu 
+
+    allocate(dtmp(nbf, nbf), source=0.0_dp)
+    pdmat(:,1) = 0.0_dp 
+    if (size(pdmat,2) > 1) pdmat(:,2) = 0.0_dp 
+
+    ! build alpha density 
+    do i = 1, nbf 
+        if (occ_a(i) > 1.0e-14_dp) then 
+            do mu = 1, nbf
+                do nu = 1, nbf 
+                    dtmp(mu,nu) = dtmp(mu,nu) + occ_a(i) * mo_a(mu,i)*mo_a(nu,i)
+                end do 
+            end do 
+        end if 
+    end do 
+
+    call pack_matrix(dtmp, pdmat(:,1))
+
+    ! needs to be rechecked 
+    if (scf_type == 2 .or. scf_type == 3)
+        dtmp(:,:) = 0.0_dp 
+        do i = 1, nbf 
+            if (occ_b(i) > 1.0e-14_dp) then 
+                do mu = 1, nbf 
+                    do nu = 1, nbf 
+                        dtmp(mu,nu) = dtmp(mu,nu) + occ_b(i)*mo_b(mu,i)*mo_b(nu,i)
+                    end do 
+                end do 
+            end if 
+        end do
+        call pack_matrix(dtmp, pdmat(:,2))
+    end if 
+ end subroutine build_pfon_density 
 
 !> @brief      This routine reorders orbitals to maximum overlap.
  subroutine reordermos(v,e,smo,l0,nbf,lr1,lr2)
@@ -981,3 +1140,4 @@ contains
  end subroutine
 
 end module scf
+

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -343,8 +343,6 @@ contains
   !     The main SCF iteration loop
 !>------------------------------------------------------------------------- 
         if (do_pfon) then
-!            if (iter == maxit - 2) then 
-!                temp_pfon = 0.0_dp 
             if ( (iter == maxit ) .or. (abs(diis_error) < 10.0_dp * infos%control%conv) ) then 
                 temp_pfon = 0.0_dp 
             else 
@@ -356,7 +354,6 @@ contains
             else 
                 beta_pfon = 1.0e20_dp 
             end if
-            ! Force integer occupation: fill up the lowest mo_i with 2 electrons until we run out
         end if 
 !>-------------------------------------------------------------------------
  
@@ -545,16 +542,11 @@ contains
                 end do
             end if
 
-            write(iw,'(" pFON: Temp=",F9.2,", Beta=",ES11.4,", sumOcc(a)=",F8.3,", sumOcc(b)=",F8.3)') &
-                 temp_pfon, beta_pfon, sum_occ_alpha, sum_occ_beta
+            write(iw,'(" pFON: Temp=",F9.2,", Beta=",ES11.4,", Start Temp=",F8.3)') &
+                 temp_pfon, beta_pfon, start_temp
 
-            write(iw,'(" Start: ",F9.2,", END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
-                  start_temp ,end_temp, electron_sum_a, electron_sum_b
-
-!            do i = 1, nbf
-!                write(iw,'(" Occ a(",I3,")=",F9.2,", Occ b(",I3,")=",F9.2)') &
-!                     i, occ_a(i), i, occ_b(i)
-!            end do
+!            write(iw,'(" Start: ",F9.2,", END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
+!                  start_temp ,end_temp, electron_sum_a, electron_sum_b
         end if
 !>-------------------------------------------------------------------------
 
@@ -1055,7 +1047,7 @@ contains
         occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
      end do 
 
-     ! Re-normalization to total number of electrons for rhf (alpha) 
+     ! Re-normalization  
      sum_occ = 0.0_dp 
      do i = 1, nbf 
         sum_occ = sum_occ + occ(i) 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -343,9 +343,9 @@ contains
   !     The main SCF iteration loop
 !>------------------------------------------------------------------------- 
         if (do_pfon) then
-            if (iter == maxit - 2) then 
-                temp_pfon = 0.0_dp 
-            elseif ( (iter == maxit - 1) .or. (abs(diis_error) < 10.0_dp * infos%control%conv) ) then 
+!            if (iter == maxit - 2) then 
+!                temp_pfon = 0.0_dp 
+            if ( (iter == maxit ) .or. (abs(diis_error) < 10.0_dp * infos%control%conv) ) then 
                 temp_pfon = 0.0_dp 
             else 
                 temp_pfon = temp_pfon - 50.0_dp 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -538,26 +538,24 @@ contains
 !>-------------------------------------------------------------------------
         ! pFON section
         if (do_pfon) then
+            if (.not. allocated(occ_a)) allocate(occ_a(nbf))
+            if (.not. allocated(occ_b)) allocate(occ_b(nbf))
+
             select case (scf_type)
             case (scf_rhf)
-                ! RHF: total electrons
                 call pfon_occupations(mo_energy_a, nbf, nelec, occ_a, beta_pfon)
-                occ_a = 0.5_dp * occ_a  ! Scale for RHF (each orbital holds 2 electrons)
-
+! uhf/rohf are wrong and needs to be corrected. 
             case (scf_uhf)
-                ! UHF: separate alpha and beta
                 call pfon_occupations(mo_energy_a, nbf, nelec_a, occ_a, beta_pfon)
                 if (nelec_b > 0) then
                     call pfon_occupations(mo_energy_b, nbf, nelec_b, occ_b, beta_pfon)
                 end if
 
             case (scf_rohf)
-                ! ROHF: use same orbitals but different occupations
                 call pfon_occupations(mo_energy_a, nbf, nelec_a, occ_a, beta_pfon)
                 if (nelec_b > 0) then
                     call pfon_occupations(mo_energy_a, nbf, nelec_b, occ_b, beta_pfon)
                 end if
-
             end select
 
             ! (Alpha)
@@ -1049,36 +1047,61 @@ contains
 !> method into SCF calculations, ensuring smooth occupation numbers using 
 !> Fermi-Dirac distribution. It dynamically adjusts temperature and beta 
 !> factors to enhance SCF convergence, particularly for near-degenerate states.
-! Replace the current pfon_occupations with this:
  subroutine pfon_occupations(mo_energy, nbf, nelec, occ, beta_pfon)
-    use precision, only: dp 
-    implicit none 
+     use precision, only: dp 
+     implicit none 
 
-    integer, intent(in) :: nbf, nelec
-    real(kind=dp), intent(in) :: beta_pfon, mo_energy(nbf)
-    real(kind=dp), intent(inout) :: occ(nbf)
-    
-    real(kind=dp) :: eF, sum_occ
-    integer :: i, i_homo, i_lumo
-    
-    ! Set HOMO and LUMO indices
-    i_homo = nelec  ! Use full electron count 
-    i_lumo = i_homo + 1
-    if (i_lumo > nbf) i_lumo = nbf
-    
-    ! Calculate Fermi energy
-    eF = 0.5_dp * (mo_energy(i_homo) + mo_energy(i_lumo))
-    
-    ! Calculate occupations
-    do i = 1, nbf
-        occ(i) = 1.0_dp / (1.0_dp + exp(beta_pfon * (mo_energy(i) - eF)))
-    end do
-    
-    ! Normalize
-    sum_occ = sum(occ)
-    if (sum_occ < 1.0e-14_dp) sum_occ = 1.0_dp
-    occ = occ * (real(nelec,dp) / sum_occ)
+     integer, intent(in) :: nbf 
+     integer, intent(in) :: nelec
+     real(kind=dp), intent(in) :: beta_pfon
+     real(kind=dp), intent(in) :: mo_energy(nbf)
+!     logical, intent(in) :: is_alpha ! if its alpha or not, this is for uhf and rohf 
+     real(kind=dp), intent(inout) :: occ(nbf)
+     real(kind=dp) :: eF, sum_occ
+     integer :: i, i_homo, i_lumo
+     real(kind=dp) :: tmp
+! For UHF and ROHF, the HOMO can be like this (check with Prof.)
+!     if (is_alpha) then
+!         i_homo = nelec
+!     else 
+!         i_homo = nelec
+!     end if 
+!     i_lumo = i_homo + 1
+! HOMO-LUMO and can be different for rhf,uhf, rohf
+   ! Identifying the homo for rhf, homo ~ nelect/2 
+     i_homo = max(1, nelec/2)
+     i_lumo = i_homo + 1 
+     if (i_lumo > nbf) i_lumo = nbf 
+
+     ! Fermi level!
+     eF = 0.5_dp * (mo_energy(i_homo) + mo_energy(i_lumo))
+
+     ! pre-normalizrion occupation 
+    print *, "Occ(i) Before ", occ(i)
+    print *, "tmp Before ", tmp
+     do i = 1, nbf
+        tmp = beta_pfon * (mo_energy(i) - eF)
+    print *, "tmp in loop ", tmp
+        occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
+    print *, "Occ(i) in loop ", occ(i)
+     end do 
+    print *, "tmp After ", tmp
+    print *, "Occ(i) After ", occ(i)  
+     ! Re-normalization to total number of electrons for rhf (alpha) 
+
+     sum_occ = 0.0_dp 
+     do i = 1, nbf 
+        sum_occ = sum_occ + occ(i) 
+     end do 
+     if (sum_occ < 1.0e-14_dp) then
+        sum_occ = 1.0_dp 
+        ! avoid dividing by zero 
+     end if 
+     do i = 1, nbf 
+        occ(i) = occ(i) * (real(nelec,dp) / sum_occ)
+     end do 
  end subroutine pfon_occupations
+ 
  ! pfon density
  subroutine build_pfon_density(pdmat, mo_a, mo_b, occ_a, occ_b, scf_type, nbf, nelec_a, nelec_b)
     use precision, only: dp 
@@ -1090,38 +1113,34 @@ contains
     real(kind=dp), intent(in) :: occ_a(:), occ_b(:)
     integer, intent(in) :: nbf, scf_type, nelec_a, nelec_b
 
-    real(kind=dp), allocatable :: dtmp(:,:)
+    real(kind=dp), allocatable :: dtmp(:,:), cmo(:,:)
     integer :: i, mu, nu 
 
     allocate(dtmp(nbf, nbf), source=0.0_dp)
-    
-    ! Build alpha density
-    dtmp = 0.0_dp
+    pdmat(:,1) = 0.0_dp 
+    if (size(pdmat,2) > 1) pdmat(:,2) = 0.0_dp 
+
+    ! build alpha density 
     do i = 1, nbf 
         if (occ_a(i) > 1.0e-14_dp) then 
             do mu = 1, nbf
-                do nu = 1, mu  ! Use symmetry
+                do nu = 1, nbf 
                     dtmp(mu,nu) = dtmp(mu,nu) + occ_a(i) * mo_a(mu,i)*mo_a(nu,i)
-                    if (mu /= nu) dtmp(nu,mu) = dtmp(mu,nu)
                 end do 
             end do 
         end if 
     end do 
+
     call pack_matrix(dtmp, pdmat(:,1))
 
-    ! Build beta density for UHF/ROHF
-    if (scf_type >= 2) then  ! UHF or ROHF
-        dtmp = 0.0_dp 
+    ! needs to be rechecked 
+    if (scf_type == 2 .or. scf_type == 3) then 
+        dtmp(:,:) = 0.0_dp 
         do i = 1, nbf 
             if (occ_b(i) > 1.0e-14_dp) then 
                 do mu = 1, nbf 
-                    do nu = 1, mu  ! Use symmetry
-                        if (scf_type == 2) then  ! UHF
-                            dtmp(mu,nu) = dtmp(mu,nu) + occ_b(i)*mo_b(mu,i)*mo_b(nu,i)
-                        else  ! ROHF
-                            dtmp(mu,nu) = dtmp(mu,nu) + occ_b(i)*mo_a(mu,i)*mo_a(nu,i)
-                        end if
-                        if (mu /= nu) dtmp(nu,mu) = dtmp(mu,nu)
+                    do nu = 1, nbf 
+                        dtmp(mu,nu) = dtmp(mu,nu) + occ_b(i)*mo_b(mu,i)*mo_b(nu,i)
                     end do 
                 end do 
             end if 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -342,8 +342,10 @@ contains
 
   !     The main SCF iteration loop
 !>------------------------------------------------------------------------- 
-        if (do_pfon) then 
-            if ( (iter == maxit - 1) .or. (abs(diis_error) < 10.0_dp * infos%control%conv) ) then 
+        if (do_pfon) then
+            if (iter == maxit - 2) then 
+                temp_pfon = 0.0_dp 
+            elseif ( (iter == maxit - 1) .or. (abs(diis_error) < 10.0_dp * infos%control%conv) ) then 
                 temp_pfon = 0.0_dp 
             else 
                 temp_pfon = temp_pfon - 50.0_dp 
@@ -546,8 +548,8 @@ contains
             write(iw,'(" pFON: Temp=",F9.2,", Beta=",ES11.4,", sumOcc(a)=",F8.3,", sumOcc(b)=",F8.3)') &
                  temp_pfon, beta_pfon, sum_occ_alpha, sum_occ_beta
 
-            write(iw,'(" END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
-                  end_temp, electron_sum_a, electron_sum_b
+            write(iw,'(" Start: ",F9.2,", END: Temp=",F9.2,", Elect Sum(a)=",F8.3,", Elect Sum(b)=",F8.3)') &
+                  start_temp ,end_temp, electron_sum_a, electron_sum_b
 
 !            do i = 1, nbf
 !                write(iw,'(" Occ a(",I3,")=",F9.2,", Occ b(",I3,")=",F9.2)') &
@@ -1048,14 +1050,10 @@ contains
      eF = 0.5_dp * (mo_energy(i_homo) + mo_energy(i_lumo))
 
      ! pre-normalizrion occupation 
-    print *, "Occ(i) Before ", occ(i)
-    print *, "tmp Before ", tmp
      do i = 1, nbf
         tmp = beta_pfon * (mo_energy(i) - eF)
         occ(i) = 1.0_dp / (1.0_dp + exp(tmp))
      end do 
-    print *, "tmp After ", tmp
-    print *, "Occ(i) After ", occ(i)  
      ! Re-normalization to total number of electrons for rhf (alpha) 
 
      sum_occ = 0.0_dp 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -131,6 +131,7 @@ contains
      ! => if T in K,   beta = 1 / ( kB_HaK * T ) in 1/Hartree
      beta_pfon = 1.0_dp / (kB_HaK * temp_pfon)
 !>-------------------------------------------------------------------------
+
   !  DIIS options
   !  none IS NOT recommended!
   !  c-DIIS: Default commutator DIIS
@@ -340,7 +341,7 @@ contains
                 & infos%control%vshift, infos%control%vshift_cdiis_switch
      write(iw,'(5X,"MOM = ",L5,21X,"MOM_Switch = ",F8.5)') &
                 & infos%control%mom, infos%control%mom_switch 
-     write(iw,'(5X,"pFON = ",L5,21X,"pFON Start Temp. = ",F9.2/)') &
+     write(iw,'(5X,"pFON = ",L5,21X,"pFON Start Temp. = ",F9.2)') &
                 & infos%control%pfon, infos%control%pfon_start_temp
   !  Initial message
      write(IW,fmt="&
@@ -502,6 +503,7 @@ contains
         call int2_driver%pe%bcast(mo_a, size(mo_a))
         call int2_driver%pe%bcast(mo_energy_a, size(mo_energy_a))
         do_pfon = infos%control%pfon
+!>-------------------------------------------------------------------------
         ! pFON section
         if (do_pfon) then
             if (.not. allocated(occ_a)) allocate(occ_a(nbf))
@@ -549,6 +551,7 @@ contains
 !                     i, occ_a(i), i, occ_b(i)
 !            end do
         end if
+!>-------------------------------------------------------------------------
 
 
   !     MOM option works for RHF and ROHF
@@ -572,7 +575,7 @@ contains
             end if
         end if 
         call int2_driver%pe%bcast(pdmat, size(pdmat))
-        
+!>------------------------------------------------------------------------- 
         ! adjusting temperature 
 !        if (do_pfon) then 
 !           temp_pfon = max(temp_pfon * 0.95_dp, end_temp)
@@ -603,6 +606,7 @@ contains
             end if
             ! Force integer occupation: fill up the lowest mo_i with 2 electrons until we run out
         end if 
+!>-------------------------------------------------------------------------
   !     Checking the HOMO-LUMO gaps for predicting SCF convergency
         if ((iter > 10).and.(vshift==0.0_dp)) then
            select case (scf_type)
@@ -1034,10 +1038,11 @@ contains
    call reorderMOs(Vb, Eb, Smo, nbf, nbf, 1, na+1)
 
  end subroutine mo_reorder
+!>-------------------------------------------------------------------------
 !> @brief      pFON Implementation in SCF Module
 !> Author: Alireza Lashkaripour
 !> Date: January 2025
-
+!> Reference paper: https://doi.org/10.1063/1.478177
 !> This module incorporates the Partial Fractional Occupation Number (pFON) 
 !> method into SCF calculations, ensuring smooth occupation numbers using 
 !> Fermi-Dirac distribution. It dynamically adjusts temperature and beta 
@@ -1132,6 +1137,7 @@ contains
         call pack_matrix(dtmp, pdmat(:,2))
     end if 
  end subroutine build_pfon_density 
+!>-------------------------------------------------------------------------
 
 !> @brief      This routine reorders orbitals to maximum overlap.
  subroutine reordermos(v,e,smo,l0,nbf,lr1,lr2)

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -483,7 +483,7 @@ contains
         end if
         call int2_driver%pe%bcast(mo_a, size(mo_a))
         call int2_driver%pe%bcast(mo_energy_a, size(mo_energy_a))
-
+        do_pfon = infos%control%pfon
         ! pFON section
         if (do_pfon) then
             if (.not. allocated(occ_a)) allocate(occ_a(nbf))

--- a/source/types.F90
+++ b/source/types.F90
@@ -116,7 +116,7 @@ module types
     real(c_double) :: mom_switch = 0.003_dp          !< Turn on criteria of DIIS error
     real(c_double) :: pfon_start_temp = 2000.0_dp    !< Starting tempreature for pFON
     real(c_double) :: pfon_cooling_rate = 50.0_dp    !< Tempreature cooling rate for pFON
-    real(c_double) :: pfon_nsmear = 0.0_dp          !< Num. of smearing orbitals for pFON if = 0, all 
+    real(c_double) :: pfon_nsmear = 5.0_dp           !< Num. of smearing orbitals for pFON if = 0, all 
     real(c_double) :: conv         = 1e-6_dp         !< Convergency criteria of SCF
     integer(c_int64_t) :: scf_incremental = 1        !< Enable/disable incremental Fock build
     real(c_double) :: int2e_cutoff = 5e-11_dp        !< 2e-integrals cutoff

--- a/source/types.F90
+++ b/source/types.F90
@@ -116,6 +116,7 @@ module types
     real(c_double) :: mom_switch = 0.003_dp          !< Turn on criteria of DIIS error
     real(c_double) :: pfon_start_temp = 2000.0_dp    !< Starting tempreature for pFON
     real(c_double) :: pfon_cooling_rate = 50.0_dp    !< Tempreature cooling rate for pFON
+    real(c_double) :: pfon_nsmear = 0.0_dp          !< Num. of smearing orbitals for pFON if = 0, all 
     real(c_double) :: conv         = 1e-6_dp         !< Convergency criteria of SCF
     integer(c_int64_t) :: scf_incremental = 1        !< Enable/disable incremental Fock build
     real(c_double) :: int2e_cutoff = 5e-11_dp        !< 2e-integrals cutoff

--- a/source/types.F90
+++ b/source/types.F90
@@ -115,6 +115,7 @@ module types
     logical(c_bool) :: pfon = .false.                !< Pseudo-Fractional Occupation Number Method (pFON) for scf
     real(c_double) :: mom_switch = 0.003_dp          !< Turn on criteria of DIIS error
     real(c_double) :: pfon_start_temp = 2000.0_dp    !< Starting tempreature for pFON
+    real(c_double) :: pfon_cooling_rate = 50.0_dp    !< Tempreature cooling rate for pFON
     real(c_double) :: conv         = 1e-6_dp         !< Convergency criteria of SCF
     integer(c_int64_t) :: scf_incremental = 1        !< Enable/disable incremental Fock build
     real(c_double) :: int2e_cutoff = 5e-11_dp        !< 2e-integrals cutoff

--- a/source/types.F90
+++ b/source/types.F90
@@ -111,9 +111,10 @@ module types
     real(c_double) :: vdiis_vshift_switch = 0.003_dp !< The threshold for setting vshift = 0
     real(c_double) :: vshift_cdiis_switch = 0.3_dp   !< The threshold for selecting cdiis for vshift
     real(c_double) :: vshift = 0.0_dp                !< Virtual orbital shift for ROHF
-    logical(c_bool) :: mom = .false.                 ! Maximum Overlap Method for SCF Convergency
-    logical(c_bool) :: pfon = .false.                ! Pseudo-Fractional Occupation Number Method (pFON) for scf
-    real(c_double) :: mom_switch = 0.003_dp          ! Turn on criteria of DIIS error
+    logical(c_bool) :: mom = .false.                 !< Maximum Overlap Method for SCF Convergency
+    logical(c_bool) :: pfon = .false.                !< Pseudo-Fractional Occupation Number Method (pFON) for scf
+    real(c_double) :: mom_switch = 0.003_dp          !< Turn on criteria of DIIS error
+    real(c_double) :: pfon_start_temp = 2000.0_dp    !< Starting tempreature for pFON
     real(c_double) :: conv         = 1e-6_dp         !< Convergency criteria of SCF
     integer(c_int64_t) :: scf_incremental = 1        !< Enable/disable incremental Fock build
     real(c_double) :: int2e_cutoff = 5e-11_dp        !< 2e-integrals cutoff

--- a/source/types.F90
+++ b/source/types.F90
@@ -112,6 +112,7 @@ module types
     real(c_double) :: vshift_cdiis_switch = 0.3_dp   !< The threshold for selecting cdiis for vshift
     real(c_double) :: vshift = 0.0_dp                !< Virtual orbital shift for ROHF
     logical(c_bool) :: mom = .false.                 ! Maximum Overlap Method for SCF Convergency
+    logical(c_bool) :: pfon = .false.                ! Pseudo-Fractional Occupation Number Method (pFON) for scf
     real(c_double) :: mom_switch = 0.003_dp          ! Turn on criteria of DIIS error
     real(c_double) :: conv         = 1e-6_dp         !< Convergency criteria of SCF
     integer(c_int64_t) :: scf_incremental = 1        !< Enable/disable incremental Fock build
@@ -205,3 +206,4 @@ contains
   end function
 
 end module types
+


### PR DESCRIPTION
Pseudo-FON (pFON) method implemented based on "J. Chem. Phys. 110, 695–700 (1999)".


in [scf] section:
pfon=true ! Initiate pfon
pfon_start_temp=    ! default 2000K , pfon starting temperature  
pfon_cooling_rate= ! default 50k, cooling rate for each iterations 
pfon_nsmear=  ! default 0 (apply fractional occupation for all orbitals) e.g. = 5 means fractionally occupy  5 orbitals below HOMO and on top of LUMO. 
