### PR TITLE
Fixed Problem with mult=4 for Spin-Flip

### DIFF
--- a/source/modules/tdhf_sf_energy.F90
+++ b/source/modules/tdhf_sf_energy.F90
@@ -98,8 +98,12 @@ contains
       OQP_FOCK_A, OQP_DM_A, OQP_E_MO_A, OQP_VEC_MO_A, OQP_FOCK_B, OQP_DM_B, OQP_E_MO_B, OQP_VEC_MO_B, OQP_SM /)
 
     mol_mult = infos%mol_prop%mult
-    if (mol_mult/=3) call show_message('SF-TDDFT are available for ROHF/UHF ref. with ONLY triplet multiplicity(mult=3)',with_abort)
-
+    if (.not. (mol_mult == 3 .or. mol_mult == 4)) then
+      call show_message( &
+        'SF-TDDFT only supports mult=3 (triplet) or mult=4 (quartet) references', &
+        with_abort)
+    end if 
+    
     scf_type = infos%control%scftype
     if (scf_type==3) roref = .true.
 
@@ -378,7 +382,7 @@ contains
 
     do ist = 1, nstates
       call sfdmat(bvec_mo(:,ist),abxc,mo_a,ta,tb,nocca,noccb)
-      spin_square(ist) = get_spin_square(dmat_a,dmat_b,ta,tb,abxc,Smat,noccb)
+      spin_square(ist) = get_spin_square(dmat_a,dmat_b,ta,tb,abxc,Smat,noccb,nocca)
     end do
 
     call get_transitions(trans, nocca, noccb, nbf)

--- a/source/modules/tdhf_sf_energy.F90
+++ b/source/modules/tdhf_sf_energy.F90
@@ -98,11 +98,11 @@ contains
       OQP_FOCK_A, OQP_DM_A, OQP_E_MO_A, OQP_VEC_MO_A, OQP_FOCK_B, OQP_DM_B, OQP_E_MO_B, OQP_VEC_MO_B, OQP_SM /)
 
     mol_mult = infos%mol_prop%mult
-    if (.not. (mol_mult == 3 .or. mol_mult == 4)) then
-      call show_message( &
-        'SF-TDDFT only supports mult=3 (triplet) or mult=4 (quartet) references', &
-        with_abort)
-    end if 
+!    if (.not. (mol_mult == 3 .or. mol_mult == 4)) then
+!      call show_message( &
+!        'SF-TDDFT only supports mult=3 (triplet) or mult=4 (quartet) references', &
+!        with_abort)
+!    end if 
     
     scf_type = infos%control%scftype
     if (scf_type==3) roref = .true.

--- a/source/modules/tdhf_sf_gradient.F90
+++ b/source/modules/tdhf_sf_gradient.F90
@@ -84,11 +84,11 @@ contains
       OQP_DM_A, OQP_DM_B, OQP_td_abxc, OQP_td_p /)
 
     mol_mult = infos%mol_prop%mult
-    if (.not. (mol_mult == 3 .or. mol_mult == 4)) then
-      call show_message( &
-        'SF-TDDFT only supports mult=3 (triplet) or mult=4 (quartet) references', &
-        with_abort)
-    end if 
+!    if (.not. (mol_mult == 3 .or. mol_mult == 4)) then
+!      call show_message( &
+!        'SF-TDDFT only supports mult=3 (triplet) or mult=4 (quartet) references', &
+!        with_abort)
+!    end if 
 
     scf_type = infos%control%scftype
     if (scf_type==3) roref = .true.

--- a/source/modules/tdhf_sf_gradient.F90
+++ b/source/modules/tdhf_sf_gradient.F90
@@ -84,9 +84,11 @@ contains
       OQP_DM_A, OQP_DM_B, OQP_td_abxc, OQP_td_p /)
 
     mol_mult = infos%mol_prop%mult
-    if (mol_mult/=3) call show_message(&
-            'SF-TDDFT are available for ROHF/UHF ref.&
-            &with ONLY triplet multiplicity(mult=3)', with_abort)
+    if (.not. (mol_mult == 3 .or. mol_mult == 4)) then
+      call show_message( &
+        'SF-TDDFT only supports mult=3 (triplet) or mult=4 (quartet) references', &
+        with_abort)
+    end if 
 
     scf_type = infos%control%scftype
     if (scf_type==3) roref = .true.

--- a/source/modules/tdhf_sf_z_vector.F90
+++ b/source/modules/tdhf_sf_z_vector.F90
@@ -101,9 +101,11 @@ contains
       OQP_td_energies /)
 
     mol_mult = infos%mol_prop%mult
-    if (mol_mult/=3) call show_message(&
-            'SF-TDDFT are available for ROHF/UHF ref.&
-            &with ONLY triplet multiplicity(mult=3)', with_abort)
+    if (.not. (mol_mult == 3 .or. mol_mult == 4)) then
+      call show_message( &
+        'SF-TDDFT only supports mult=3 (triplet) or mult=4 (quartet) references', &
+        with_abort)
+    end if 
 
     scf_type = infos%control%scftype
     if (scf_type==3) roref = .true.

--- a/source/modules/tdhf_sf_z_vector.F90
+++ b/source/modules/tdhf_sf_z_vector.F90
@@ -101,11 +101,11 @@ contains
       OQP_td_energies /)
 
     mol_mult = infos%mol_prop%mult
-    if (.not. (mol_mult == 3 .or. mol_mult == 4)) then
-      call show_message( &
-        'SF-TDDFT only supports mult=3 (triplet) or mult=4 (quartet) references', &
-        with_abort)
-    end if 
+ !   if (.not. (mol_mult == 3 .or. mol_mult == 4)) then
+ !     call show_message( &
+ !       'SF-TDDFT only supports mult=3 (triplet) or mult=4 (quartet) references', &
+ !       with_abort)
+ !   end if 
 
     scf_type = infos%control%scftype
     if (scf_type==3) roref = .true.

--- a/source/tdhf_sf_lib.F90
+++ b/source/tdhf_sf_lib.F90
@@ -933,7 +933,7 @@ contains
 
   end subroutine sfrowcal
 
-  function get_spin_square(dmat_a,dmat_b,ta,tb,abxc,Smat,nocb) result(s2)
+  function get_spin_square(dmat_a,dmat_b,ta,tb,abxc,Smat,nocb,noca) result(s2)
   ! dmat_a / dmat_b -- alpha/beta density of the excited state
   ! ta / tb -- alpha/beta difference density matrix
     use precision, only : dp
@@ -947,13 +947,13 @@ contains
       dmat_a, dmat_b, ta, tb
     real(kind=dp), intent(in), dimension(:,:) :: abxc
     real(kind=dp), intent(in), dimension(:) :: smat
-    integer, intent(in) :: nocb
-    real(kind=dp) :: s2
+    integer, intent(in) :: nocb, noca
+    real(kind=dp) :: s2, nsocc
 
     real(kind=dp), allocatable :: scr1(:), dmat_t(:), &
       dmat_t_sq(:,:), smat_sq(:,:), tmp1(:,:), tmp2(:,:)
     integer :: nbf, nbf_tri, ok
-    real(kind=dp) :: dum1, dum2, dum3, dum4
+    real(kind=dp) :: dum0, dum1, dum2, dum3, dum4
 
     nbf = ubound(abxc, 1)
     nbf_tri = ubound(dmat_a, 1)
@@ -968,6 +968,8 @@ contains
     if (ok/=0) call show_message('Cannot allocate memory in qet_spin_square',with_abort)
 
    ! Calculate spin expectation values
+     nsocc = noca - nocb
+     dum0 = 0.25_dp*nsocc*(nsocc-2)
      dum1 = nocb+1
 
    ! Symmetric matrix scr1 = Smat*Dmat_a*Smat
@@ -1007,7 +1009,7 @@ contains
      call pack_matrix(tmp1, scr1)
      dum4 = traceprod_sym_packed(scr1, smat, nbf)/2.0_dp
 
-     s2 = dum1 + dum2 - dum3 + dum4**2
+     s2 = dum0 + dum1 + dum2 - dum3 + dum4**2
 
  end function get_spin_square
 


### PR DESCRIPTION
The current version of OpenQP blocks mult=4 for Spin-Flip TDDFT. After comparing with the GAMESS(US) implementation, the issue was identified and fixed. Energy and gradient results from this branch are identical to those from the main OpenQP code for mult=3. Both sets of results are in good agreement with  those obtained using GAMESS(US).

<img width="1548" alt="image" src="https://github.com/user-attachments/assets/a14cb5ab-5830-43e2-ae6a-772b046b2a5f" />
