### PR TITLE
add guess=pyscf

### DIFF
--- a/pyoqp/oqp/library/external.py
+++ b/pyoqp/oqp/library/external.py
@@ -1,0 +1,116 @@
+"""OQP external quantum chemical program"""
+import re
+import os
+import sys
+import oqp
+from oqp.utils.constants import ANGSTROM_TO_BOHR
+from oqp.periodic_table import SYMBOL_MAP, ELEMENTS_NAME
+
+try:
+    from pyscf import gto, dft, lib
+
+except ModuleNotFoundError:
+    gto = None
+    dft = None
+    lib = None
+
+try:
+    from mokit.lib import py2openqp
+
+except ModuleNotFoundError:
+    py2openqp = None
+
+pyscf_functional = {
+    "pbe0": "pbe0",
+    "b3lyp": "b3lyp",
+    "bhhlyp": "bhandhlyp",
+    "cam-b3lyp": "camb3lyp",
+    "camb3lyp": "camb3lyp",
+}
+
+
+def guess_from_pyscf(mol):
+    """Set up pySCF calculation"""
+
+    if gto is None:
+        print(f'\n   PyOQP cannot find PySCF\n')
+        ## pyscf run mpi with a different lib, which might cause conflict with mpi4py, disabling mpi now for future dev
+        sys.exit(1)
+
+    if py2openqp is None:
+        print(f'\n   PyOQP cannot find Mokit\n')
+        ## pyscf run mpi with a different lib, which might cause conflict with mpi4py, disabling mpi now for future dev
+        sys.exit(1)
+
+    if mol.usempi:
+        print(f'\n   PyOQP cannot run pySCF with MPI\n')
+        ## pyscf run mpi with a different lib, which might cause conflict with mpi4py, disabling mpi now for future dev
+        sys.exit(1)
+
+    atoms = []
+    coord = mol.get_system().reshape((-1, 3)) * ANGSTROM_TO_BOHR
+    for n, at in enumerate(mol.get_atoms()):
+        atoms.append([ELEMENTS_NAME[SYMBOL_MAP[int(at)]], coord[n]])
+
+    mole = gto.Mole()
+    mole.atom = atoms
+    mole.basis = mol.config["input"]["basis"]
+    mole.charge = mol.config["input"]["charge"]
+    mole.spin = mol.config["scf"]["multiplicity"] - 1
+    mole.output = '%s.pyscf' % mol.project_name
+    mole.verbose = 4
+    mole.build(cart=False)
+    functional = mol.config["input"]["functional"]
+
+    if mol.config["scf"]["type"] == 'rohf':
+        mf = dft.ROKS(mole)
+    elif mol.config["scf"]["type"] == 'uhf':
+        mf = dft.UKS(mole)
+    elif mol.config["scf"]["type"] == 'rhf':
+        mf = dft.RKS(mole)
+    else:
+        print(f'\n   PyOQP only support pySCF with rhf, uhf, and rohf\n')
+        sys.exit(1)
+
+    try:
+        xcfun = pyscf_functional[functional]
+    except KeyError:
+        xcfun = 'pbe0'
+
+    mf.xc = xcfun
+    mf.max_cycle = mol.config["scf"]["maxit"]
+    mf.level_shift = mol.config["scf"]["vshift"]
+
+    try:
+        os.environ["PYSCF_MAX_MEMORY"]
+    except KeyError:
+        mf.max_memory = 1000  # MB
+    try:
+        os.environ["OMP_NUM_THREADS"]
+    except KeyError:
+        lib.num_threads(1)
+
+    mf.kernel()
+
+    if mf.converged is False:
+        mf = mf.newton()
+        mf.kernel()
+
+    py2openqp(mf, 'mokit.inp', mrsf=True)
+
+    target_basis = mol.config['input']['basis']
+    target_library = mol.config['input']['library']
+    mol.config['guess']['file'] = 'mokit_wfn.json'
+    mol.load_data()
+
+    mol.data.set_scf_active_basis(1)
+    mol.config['input']['basis'] = mol.config['json']['basis']
+    mol.config['input']['library'] = mol.config['json']['library']
+    oqp.library.set_basis(mol)
+
+    mol.data.set_scf_active_basis(0)
+    mol.config['input']['basis'] = target_basis
+    mol.config['input']['library'] = target_library
+    oqp.library.project_basis(mol)
+
+    return

--- a/pyoqp/oqp/library/guess.py
+++ b/pyoqp/oqp/library/guess.py
@@ -5,7 +5,7 @@ import copy
 import oqp
 from oqp.utils.file_utils import try_basis
 from oqp.utils.file_utils import dump_log
-
+from oqp.library.external import guess_from_pyscf
 
 def update_guess(mol):
     if mol.config['json']['scf_type'] == 'rhf':
@@ -52,6 +52,10 @@ def guess(mol):
             alpha = 'computed'
             beta = 'computed'
 
+    elif guess_type == 'pyscf':
+        guess_from_pyscf(mol)
+        alpha = 'computed'
+        beta = 'computed'
 #    # molden does not have sufficient numerical accuracy
 #    elif guess_type == "molden":
 #        # Check if the molden file from the input exists

--- a/pyoqp/upload.sh
+++ b/pyoqp/upload.sh
@@ -1,3 +1,0 @@
-scp -r oqp rt:/root/pyoqp
-scp setup.py rt:/root/pyoqp
-scp README.md rt:/root/pyoqp


### PR DESCRIPTION
guess=pyscf will call pyscf to compute MOs, then use mokit to convert the MOs to the openqp format for subsequent calculations.

pyscf installation

    pip install pyscf

mokit installation

    gitclone https://gitlab.com/jxzou/mokit.git
    cd ./mokit/src
    make all -f Makefile.gnu_mkl # assume you use gfortran and mkl
    cd ./mokit/mokit
    pip install .

add the following environment variables

    export MOKIT_ROOT=$path_to_mokit/mokit
    export PATH=$MOKIT_ROOT/bin:$PATH
    export PYTHONPATH=$MOKIT_ROOT:$PYTHONPATH

due to the conflict between Numpy<2.0 and Python>3.9, you might encounter an error

    No module named 'distutils.msvccompiler'

you can modify the Numpy codes following [this](https://github.com/numpy/numpy/issues/27405)
add the following code in numpy/distutils/command/config.py

    try:
        from distutils.msvccompiler import get_build_version as get_build_msvc_version
    except ImportError:
        def get_build_msvc_version():
            return None