### PR TITLE
change pyscf to 6d10f

### DIFF
--- a/pyoqp/oqp/library/external.py
+++ b/pyoqp/oqp/library/external.py
@@ -59,7 +59,7 @@ def guess_from_pyscf(mol):
     mole.spin = mol.config["scf"]["multiplicity"] - 1
     mole.output = '%s.pyscf' % mol.project_name
     mole.verbose = 4
-    mole.build(cart=False)
+    mole.build(cart=True)
     functional = mol.config["input"]["functional"]
 
     if mol.config["scf"]["type"] == 'rohf':


### PR DESCRIPTION
The pyscf uses 5d7f by default. Although mokit can convert it to 6d10f for openqp, the numerical difference can lead to divergence in the openqp SCF calculation, even though the first SCF iteration seems ok. Change pyscf to 6d10f to minimize the numerical issue in openqp.