### PR TITLE
fix: disable SD in 2nd SCF attempt

### DIFF
--- a/include/oqp.h
+++ b/include/oqp.h
@@ -150,6 +150,7 @@ struct control_parameters {
     int64_t   trh_nmic;
     double    trh_gred;
     double    trh_lred;
+    bool      sd_scf;
 };
 
 struct mpi_communicator {

--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -393,6 +393,7 @@ class SinglePoint(Calculator):
             else:
                 dump_log(self.mol, title='PyOQP: SCF energy is not converged after %s attempts' % (itr + 1), section='')
                 self.mol.data.set_scf_converger_type(self.alternative_scf)
+                self.mol.data.set_sd_scf(False)
                 dump_log(self.mol, title=f'PyOQP: Enable the {self.alternative_scf} in SCF to improve convergence.', section='input')
 
         if not scf_flag:

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -283,6 +283,7 @@ class OQPData:
             "trh_nmic": "set_trah_n_micro",
             "trh_gred": "set_trah_global_red_factor",
             "trh_lred": "set_trah_local_red_factor",
+            "sd_scf": "set_sd_scf"
         },
         "dftgrid": {
             "rad_type": "set_dftgrid_rad_type",
@@ -656,6 +657,9 @@ class OQPData:
         if not (0.0 < f < 1.0):
             raise ValueError("local_red_factor must be in (0,1)")
         self._data.control.trh_lred = float(f)
+    def set_sd_scf(self, sd_scf):
+        """prevent running the first SD-SCF calculation"""
+        self._data.control.sd_scf = sd_scf
 
     def set_tdhf_type(self, td_type):
         """Handle td-dft calculation type"""

--- a/source/printing.F90
+++ b/source/printing.F90
@@ -75,6 +75,9 @@ contains
     integer, intent(in) :: mostart, moend
     integer :: mo0, mo1
 
+    if (.not. infos%mol_energy%SCF_converged &
+        .and. infos%control%verbose < 2) return
+
     write (iw,fmt="(/&
             &10x, 31('=')/&
             &10x, 'Molecular Orbitals and Energies'/&

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -548,7 +548,8 @@ contains
                        overlap_sqrt=qmat, &
                        num_focks=soscf_nfocks, &
                        scf_type=infos%control%scftype, &
-                       verbose=infos%control%verbose)
+                       verbose=infos%control%verbose, &
+                       sd_scf=infos%control%sd_scf)
 
       ! Configure the TRAH converger with input parameters
       call set_trah_parametres(infos, molgrid, conv)
@@ -973,7 +974,7 @@ contains
     !----------------------------------------------------------------------------
     if (use_trah) iter = conv_res%get_iter()
     if (iter > maxit) then
-      write(IW,"(3x,64('-')/10x,'SCF is not converged ....')")
+      write(IW,"(3x,64('-')/10x,'SCF did not converge. Restarting SCF with the TRAH method.')")
       infos%mol_energy%SCF_converged = .false.
     else
       write(IW,"(3x,64('-')/10x,'SCF convergence achieved ....')")

--- a/source/scf_converger.F90
+++ b/source/scf_converger.F90
@@ -410,6 +410,7 @@ module scf_converger
   use mathlib, only: antisymmetrize_matrix, unpack_matrix, pack_matrix
   use scf_addons, only: pfon_t
   use, intrinsic :: iso_fortran_env, only: int32
+  use, intrinsic :: iso_c_binding, only: c_bool
   use types, only: information
   use mod_dft_molgrid, only: dft_grid_t
 
@@ -1451,7 +1452,7 @@ contains
   !> @param[in] num_focks 1 if R/ROHF, 2 if UHF
   !> @param[in] verbose Verbosity level
   subroutine scf_conv_init(self, ldim, nelec_a, nelec_b, maxvec, subconvergers, thresholds, &
-                          overlap, overlap_sqrt, num_focks, scf_type ,verbose)
+                          overlap, overlap_sqrt, num_focks, scf_type ,verbose, sd_scf)
     class(scf_conv), intent(inout) :: self
     integer, intent(in) :: ldim
     integer, optional, intent(in) :: nelec_a
@@ -1464,6 +1465,7 @@ contains
     integer, optional, intent(in) :: verbose
     integer :: nfocks, istat, i
     integer, optional, intent(in) :: scf_type
+    logical(c_bool), optional, intent(in) :: sd_scf
 
     if (self%state /= conv_state_not_initialized) call self%clean()
 
@@ -1502,6 +1504,9 @@ contains
     if (istat /= 0) then
       self%state = conv_state_not_initialized
       return
+    end if
+    if (present(sd_scf)) then
+        if(.not. sd_scf) self%step = self%step + 1
     end if
 
     if (present(subconvergers)) then

--- a/source/types.F90
+++ b/source/types.F90
@@ -143,6 +143,8 @@ module types
     integer(c_int64_t)     :: trh_nmic = 50         !< Max micro-iterations per macro step
     real(c_double)         :: trh_gred = 1.0d-3     !< Global trust-radius reduction factor (0<gred<1)
     real(c_double)         :: trh_lred = 1.0d-4     !< Local trust-radius reduction factor (0<lred<1)
+    ! SD parameters
+    logical(c_bool) :: sd_scf = .true.           !< prevent running the first SD-SCF calculation
   end type control_parameters
 
   type, public, bind(c) :: tddft_parameters


### PR DESCRIPTION
This fixes the initial MO in the second SCF attempt, which uses the TRAH method.