### PR TITLE
feat: add excited-state electric moments

### DIFF
--- a/include/oqp.h
+++ b/include/oqp.h
@@ -218,6 +218,7 @@ void tdhf_mrsf_z_vector(struct oqp_handle_t *inf);
 void tdhf_mrsf_gradient(struct oqp_handle_t *inf);
 
 void electric_moments(struct oqp_handle_t *inf);
+void electric_moments_excited(struct oqp_handle_t *inf);
 void get_structures_ao_overlap(struct oqp_handle_t *inf);
 void get_states_overlap(struct oqp_handle_t *inf);
 void resp_charges(struct oqp_handle_t *inf);

--- a/include/oqp.h
+++ b/include/oqp.h
@@ -223,5 +223,6 @@ void get_structures_ao_overlap(struct oqp_handle_t *inf);
 void get_states_overlap(struct oqp_handle_t *inf);
 void resp_charges(struct oqp_handle_t *inf);
 void mulliken(struct oqp_handle_t *inf);
+void mulliken_excited(struct oqp_handle_t *inf);
 void lowdin(struct oqp_handle_t *inf);
 

--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -459,6 +459,7 @@ class Gradient(Calculator):
         self.grads = mol.config["properties"]["grad"]
         self.natom = mol.data["natom"]
         self.nstate = mol.config['tdhf']['nstate']
+        self.td_prop = mol.config['properties']['td_prop']
 
         self.zvec_func = {
             'rpa': oqp.tdhf_z_vector,
@@ -528,7 +529,9 @@ class Gradient(Calculator):
                     raise ZVnotConverged()
                 else:
                     exit()
-            oqp.electric_moments_excited(self.mol)
+            if self.td_prop == True:
+                oqp.electric_moments_excited(self.mol)
+                oqp.mulliken_excited(self.mol)
 
             self.grad_func[self.td](self.mol)
             grad = self.mol.get_grad().reshape((self.natom, 3))

--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -528,6 +528,7 @@ class Gradient(Calculator):
                     raise ZVnotConverged()
                 else:
                     exit()
+            oqp.electric_moments_excited(self.mol)
 
             self.grad_func[self.td](self.mol)
             grad = self.mol.get_grad().reshape((self.natom, 3))

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -23,8 +23,9 @@ def iarray(strng):
 
 
 def barray(strng):
-    """Convert array of parameters to list of booleans"""
-    return list(bool(s) for s in strng.split(',')) if strng else ()
+    """Convert comma-separated boolean parameters to a list of booleans."""
+    return [s.strip().lower() in ("true", "t", "1", "yes", ".true.")
+            for s in strng.split(",")] if strng else ()
 
 
 def parray(strng):

--- a/source/modules/electric_moments.F90
+++ b/source/modules/electric_moments.F90
@@ -6,6 +6,7 @@ module electric_moments_mod
 
   private
   public electric_moments
+  public electric_moments_excited
 
 contains
 
@@ -17,6 +18,17 @@ contains
     inf => oqp_handle_get_info(c_handle)
     call electric_moments(inf)
   end subroutine electric_moments_c
+
+  subroutine electric_moments_excited_C(c_handle) bind(C, name="electric_moments_excited")
+    use c_interop, only: oqp_handle_t, oqp_handle_get_info
+    use types, only: information
+    type(oqp_handle_t) :: c_handle
+    type(information), pointer :: inf
+    inf => oqp_handle_get_info(c_handle)
+    call electric_moments_excited(inf)
+
+  end subroutine electric_moments_excited_C
+
 
   subroutine electric_moments(infos)
     use io_constants, only: iw
@@ -199,5 +211,192 @@ contains
     close(iw)
 
   end subroutine electric_moments
+
+  subroutine electric_moments_excited(infos)
+    use io_constants, only: iw
+    use oqp_tagarray_driver
+    use basis_tools, only: basis_set
+    use messages, only: show_message, with_abort
+    use types, only: information
+    use strings, only: Cstring, fstring
+    use mathlib, only: traceprod_sym_packed, triangular_to_full
+    use int1, only: multipole_integrals
+    use physical_constants, only: AU_TO_DEBYE, AU_TO_BUCK, AU_TO_OCT
+    use xyz_order
+
+    implicit none
+
+    character(len=*), parameter :: subroutine_name = "electric_moments_excited"
+
+    type(information), target, intent(inout) :: infos
+
+    integer :: nbf, nbf2, ok
+    logical :: urohf
+    type(basis_set), pointer :: basis
+    real(kind=8), allocatable :: mints(:,:)
+    real(kind=8), allocatable :: dens_ex(:)
+    real(kind=8) :: com(3), dip(3), qxyz(6), quad(3,3), dr(3), z
+    real(kind=8) :: oxyz(10), oct(10)
+    integer :: nat, i, istate
+
+    real(kind=8), contiguous, pointer :: dmat_a(:), dmat_b(:)
+    real(kind=8), contiguous, pointer :: td_p(:,:)
+    integer(4) :: status
+
+    urohf = infos%control%scftype == 2 .or. infos%control%scftype == 3
+
+    open (unit=IW, file=infos%log_filename, position="append")
+
+    basis => infos%basis
+    basis%atoms => infos%atoms
+
+    nbf  = basis%nbf
+    nbf2 = nbf*(nbf+1)/2
+
+    istate = infos%tddft%target_state
+
+    write(iw,'(2/)')
+    write(iw,'(4x,a)')      '================================================='
+    write(iw,'(4x,a,i4)')   'Electric moment analysis for excited state ', istate
+    write(iw,'(4x,a)')      '     (using relaxed one-particle density)       '
+    write(iw,'(4x,a)')      '================================================='
+    call flush(iw)
+
+    nat = ubound(basis%atoms%zn,1)
+
+    allocate(mints(nbf2,19), source=0.0d0, stat=ok)
+    if (ok /= 0) call show_message('Cannot allocate mints', WITH_ABORT)
+
+    allocate(dens_ex(nbf2), source=0.0d0, stat=ok)
+    if (ok /= 0) call show_message('Cannot allocate dens_ex', WITH_ABORT)
+
+
+!   Ground-state density
+    call tagarray_get_data(infos%dat, OQP_DM_A, dmat_a, status)
+    call check_status(status, module_name, subroutine_name, OQP_DM_A)
+    dens_ex = dmat_a
+
+    if (urohf) then
+      call tagarray_get_data(infos%dat, OQP_DM_B, dmat_b, status)
+      call check_status(status, module_name, subroutine_name, OQP_DM_B)
+      dens_ex = dens_ex + dmat_b
+    end if
+
+    call tagarray_get_data(infos%dat, OQP_TD_P, td_p, status)
+    call check_status(status, module_name, subroutine_name, OQP_TD_P)
+    dens_ex = dens_ex + td_p(:,1) + td_p(:,2)
+
+    com = 0
+    do i = 1, nat
+      com = com + basis%atoms%xyz(:,i)*basis%atoms%mass(i)
+    end do
+    com = com / sum(basis%atoms%mass)
+
+    call multipole_integrals(basis, mints, com, 3)
+
+    dip  = 0
+    qxyz = 0
+    oxyz = 0
+
+    do i = 1, nat
+      dr = infos%atoms%xyz(:,i) - com
+      z  = infos%atoms%zn(i) - infos%basis%ecp_zn_num(i)
+
+      dip = dip + z * dr
+
+      qxyz(XX_) = qxyz(XX_) + z * dr(X__)*dr(X__)
+      qxyz(YY_) = qxyz(YY_) + z * dr(Y__)*dr(Y__)
+      qxyz(ZZ_) = qxyz(ZZ_) + z * dr(Z__)*dr(Z__)
+      qxyz(XY_) = qxyz(XY_) + z * dr(X__)*dr(Y__)
+      qxyz(XZ_) = qxyz(XZ_) + z * dr(X__)*dr(Z__)
+      qxyz(YZ_) = qxyz(YZ_) + z * dr(Y__)*dr(Z__)
+
+      oxyz(XXX) = oxyz(XXX) + z * dr(X__)*dr(X__)*dr(X__)
+      oxyz(YYY) = oxyz(YYY) + z * dr(Y__)*dr(Y__)*dr(Y__)
+      oxyz(ZZZ) = oxyz(ZZZ) + z * dr(Z__)*dr(Z__)*dr(Z__)
+      oxyz(XXY) = oxyz(XXY) + z * dr(X__)*dr(X__)*dr(Y__)
+      oxyz(XXZ) = oxyz(XXZ) + z * dr(X__)*dr(X__)*dr(Z__)
+      oxyz(YYX) = oxyz(YYX) + z * dr(Y__)*dr(Y__)*dr(X__)
+      oxyz(YYZ) = oxyz(YYZ) + z * dr(Y__)*dr(Y__)*dr(Z__)
+      oxyz(ZZX) = oxyz(ZZX) + z * dr(Z__)*dr(Z__)*dr(X__)
+      oxyz(ZZY) = oxyz(ZZY) + z * dr(Z__)*dr(Z__)*dr(Y__)
+      oxyz(XYZ) = oxyz(XYZ) + z * dr(X__)*dr(Y__)*dr(Z__)
+    end do
+
+    do i = 1, 3
+      dip(i) = dip(i) - traceprod_sym_packed(mints(:,i), dens_ex, nbf)
+    end do
+
+    do i = 1, 6
+      qxyz(i) = qxyz(i) - traceprod_sym_packed(mints(:,3+i), dens_ex, nbf)
+    end do
+
+    do i = 1, 10
+      oxyz(i) = oxyz(i) - traceprod_sym_packed(mints(:,9+i), dens_ex, nbf)
+    end do
+
+
+    dip = dip*AU_TO_DEBYE
+
+    quad(X__,X__) = 0.5*(2*qxyz(XX_) - (qxyz(YY_)+qxyz(ZZ_)))
+    quad(X__,Y__) = 0.5*(3*qxyz(XY_)                        )
+    quad(X__,Z__) = 0.5*(3*qxyz(XZ_)                        )
+    quad(Y__,Y__) = 0.5*(2*qxyz(YY_) - (qxyz(XX_)+qxyz(ZZ_)))
+    quad(Y__,Z__) = 0.5*(3*qxyz(YZ_)                        )
+    quad(Z__,Z__) = 0.5*(2*qxyz(ZZ_) - (qxyz(XX_)+qxyz(YY_)))
+    call triangular_to_full(quad,3,'u')
+    quad = quad*AU_TO_BUCK
+
+    oct(XXX) = 0.5*(2*oxyz(XXX) - 3*(oxyz(YYX)+oxyz(ZZX)))
+    oct(YYY) = 0.5*(2*oxyz(YYY) - 3*(oxyz(XXY)+oxyz(ZZY)))
+    oct(ZZZ) = 0.5*(2*oxyz(ZZZ) - 3*(oxyz(YYZ)+oxyz(XXZ)))
+    oct(XXY) = 0.5*(4*oxyz(XXY) -   (oxyz(YYY)+oxyz(ZZY)))
+    oct(XXZ) = 0.5*(4*oxyz(XXZ) -   (oxyz(YYZ)+oxyz(ZZZ)))
+    oct(YYX) = 0.5*(4*oxyz(YYX) -   (oxyz(XXX)+oxyz(ZZX)))
+    oct(YYZ) = 0.5*(4*oxyz(YYZ) -   (oxyz(XXZ)+oxyz(ZZZ)))
+    oct(ZZX) = 0.5*(4*oxyz(ZZX) -   (oxyz(XXX)+oxyz(YYX)))
+    oct(ZZY) = 0.5*(4*oxyz(ZZY) -   (oxyz(XXY)+oxyz(YYY)))
+    oct(XYZ) = 0.5*(5*oxyz(XYZ)                          )
+
+    oct = oct*AU_TO_OCT
+
+
+    write(iw,'(/1x,a,i4)') 'Excited state index: ', istate
+    write(iw,'( 1x,a)')    'Density used: relaxed (P_ground + dP_relaxed)'
+
+    write(iw,'(/1x,a)') 'At point (Bohr):'
+    write(iw,'(4x,40x,3(a8,7x))') 'X', 'Y', 'Z'
+    write(iw,'(4x,40x,3f15.8,sp,f12.5)') com
+
+    write(iw,'(/4x,a)') 'electric charge (a.u.):'
+    write(iw,'(4x,34x,a6,sp,f12.5)') 'C_o', real(infos%mol_prop%charge)
+
+    write(iw,'(/4x,a)') 'electric dipole (Debye) - excited state:'
+    write(iw,'(4x,40x,3(a8,7x),a10)') 'X', 'Y', 'Z', 'Norm'
+    write(iw,'(4x,34x,a6,4f15.8)') 'D_ex', dip, norm2(dip)
+
+    write(iw,'(/4x,a)') 'electric quadrupole (Buckingham) - excited state:'
+    write(iw,'(4x,40x,3(a8,7x))') 'X', 'Y', 'Z'
+    write(iw,'(4x,34x,a6,3F15.8)') 'Q_X', quad(:,1)
+    write(iw,'(4x,34x,a6,3f15.8)') 'Q_Y', quad(:,2)
+    write(iw,'(4x,34x,a6,3f15.8)') 'Q_Z', quad(:,3)
+
+    write(iw,'(/4x,a)') 'electric octoupole (Buckingham*Angstrom) - excited state:'
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_xxx', oct(XXX)
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_xxy', oct(XXY)
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_xxz', oct(XXZ)
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_xyy', oct(YYX)
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_xyz', oct(XYZ)
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_xzz', oct(ZZX)
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_yyy', oct(YYY)
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_yyz', oct(YYZ)
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_zzy', oct(ZZY)
+    write(iw,'(4x,34x,a6,*(F15.8))') 'O_zzz', oct(ZZZ)
+
+    close(iw)
+
+    deallocate(mints, dens_ex)
+
+  end subroutine electric_moments_excited
 
 end module electric_moments_mod

--- a/source/modules/population_analysis.F90
+++ b/source/modules/population_analysis.F90
@@ -32,6 +32,18 @@ contains
 
 !--------------------------------------------------------------------------------
 
+  subroutine mulliken_excited_C(c_handle) bind(C, name="mulliken_excited")
+    use c_interop, only: oqp_handle_t, oqp_handle_get_info, oqp_handle_refresh_ptr
+    use strings, only: Cstring
+    use types, only: information
+    type(oqp_handle_t) :: c_handle
+    type(information), pointer :: inf
+    inf => oqp_handle_get_info(c_handle)
+    call mulliken_excited(inf)
+  end subroutine mulliken_excited_C
+
+!--------------------------------------------------------------------------------
+
   subroutine lowdin_C(c_handle) bind(C, name="lowdin")
     use c_interop, only: oqp_handle_t, oqp_handle_get_info, oqp_handle_refresh_ptr
     use strings, only: Cstring
@@ -43,6 +55,125 @@ contains
   end subroutine lowdin_C
 
 !--------------------------------------------------------------------------------
+
+!--------------------------------------------------------------------------------
+!--------------------------------------------------------------------------------
+!> @brief Mulliken population analysis for MRSF-TDDFT excited states
+!>
+!> Computes Mulliken charges for a target excited state using:
+!>   P_excited = P_ground + Delta_P
+!> where Delta_P is the excited-state difference density (relaxed or unrelaxed).
+!>
+!> @param[in]  infos   OQP handle
+!>
+!> @author   Mohsen Mazaherifar
+!>
+!> REVISION HISTORY:
+!> @date _Apr, 2026_ Initial release
+!--------------------------------------------------------------------------------
+
+  subroutine mulliken_excited(infos)
+    use precision, only: dp
+    use io_constants, only: iw
+    use basis_tools, only: basis_set
+    use messages, only: show_message, with_abort
+    use types, only: information
+    use oqp_tagarray_driver
+    use mathlib, only: unpack_matrix
+    implicit none
+
+    type(information), target, intent(inout) :: infos
+    type(basis_set), pointer :: basis
+
+    real(kind=dp), allocatable :: orbital_pop(:)
+    real(kind=dp), allocatable :: chg(:)
+    real(kind=dp), allocatable :: dens(:,:), tmp(:)
+
+    integer :: nat, nbf, nbf2, ok, istate
+    logical :: urohf, use_relaxed
+
+    ! tagarray pointers
+    real(kind=dp), contiguous, pointer :: dmat_a(:), dmat_b(:), smat(:)
+    real(kind=dp), contiguous, pointer :: td_p(:,:), td_abxc(:)
+    character(len=*), parameter :: tags_required(5) = (/ character(len=80) :: &
+      OQP_DM_A, OQP_DM_B, OQP_TD_P, OQP_TD_ABXC, OQP_SM /)
+
+    character(len=*), parameter :: subroutine_name = "mulliken_excited"
+
+    open (unit=IW, file=infos%log_filename, position="append")
+
+    basis => infos%basis
+    basis%atoms => infos%atoms
+    nat = ubound(infos%atoms%zn, 1)
+    nbf = basis%nbf
+    nbf2 = nbf * (nbf + 1) / 2
+
+    urohf = infos%control%scftype == 2 .or. infos%control%scftype == 3
+
+    istate = infos%tddft%target_state
+
+    use_relaxed = .true.
+
+    allocate(orbital_pop(nbf), &
+             chg(nat),         &
+             tmp(nbf2),        &
+             dens(nbf, nbf),   &
+             source=0.0d0, stat=ok)
+    if (ok /= 0) call show_message('Cannot allocate memory', WITH_ABORT)
+
+    call data_has_tags(infos%dat, tags_required, module_name, subroutine_name, WITH_ABORT)
+
+    call tagarray_get_data(infos%dat, OQP_DM_A, dmat_a)
+    tmp = dmat_a
+    if (urohf) then
+      call tagarray_get_data(infos%dat, OQP_DM_B, dmat_b)
+      tmp = tmp + dmat_b
+    end if
+
+
+    if (use_relaxed) then
+      ! Try to get the relaxed density first
+      call tagarray_get_data(infos%dat, OQP_TD_P, td_p)
+      tmp = tmp + td_p(:,1) + td_p(:,2)
+      write(iw,'(4x,a)') 'Using RELAXED difference density (Z-vector)'
+    else
+      ! Fall back to unrelaxed density
+      call tagarray_get_data(infos%dat, OQP_TD_ABXC, td_abxc)
+      tmp = tmp + td_abxc
+      write(iw,'(4x,a)') 'Using UNRELAXED difference density'
+    end if
+
+    call tagarray_get_data(infos%dat, OQP_SM, smat)
+
+    call unpack_matrix(tmp, dens)
+
+
+    call get_orb_pop_mulliken(smat, dens, orbital_pop)
+
+    call get_atomic_pop(basis, orbital_pop, chg)
+
+    chg = infos%atoms%zn - infos%basis%ecp_zn_num - chg
+
+!   -----------------------------------------------------------------------
+!   Print results
+!   -----------------------------------------------------------------------
+    write(iw,'(2/)')
+    write(iw,'(4x,a)')    '============================================='
+    write(iw,'(4x,a,i4)') 'Mulliken population analysis for state ', istate
+    write(iw,'(4x,a)')    '============================================='
+    call flush(iw)
+
+    write(iw,'(/,2X,A,I4)') 'Gross AO population (Mulliken) - State ', istate
+    call print_ao_pop(infos, orbital_pop)
+
+    write(iw,'(/,2X,A,I4)') 'Atomic partial charges (Mulliken) - State ', istate
+    call print_charges(infos, chg)
+
+    close(iw)
+
+    deallocate(orbital_pop, chg, tmp, dens)
+
+  end subroutine mulliken_excited
 
   subroutine mulliken(infos)
     use precision, only: dp

--- a/source/modules/resp.F90
+++ b/source/modules/resp.F90
@@ -99,6 +99,8 @@ contains
 
     open (unit=IW, file=infos%log_filename, position="append")
 
+
+    nat = ubound(infos%atoms%zn, 1)
     select case(infos%control%esp)
     case(0,1)
       restr = .false.
@@ -135,7 +137,6 @@ contains
 !   Allocate memory
     nbf = basis%nbf
     nbf2 = nbf*(nbf+1)/2
-    nat = ubound(infos%atoms%zn, 1)
     npt = nat * sum(npt_layer)
     urohf = infos%control%scftype == 2 .or. infos%control%scftype == 3
 

--- a/source/modules/tdhf_mrsf_energy.F90
+++ b/source/modules/tdhf_mrsf_energy.F90
@@ -314,7 +314,7 @@ contains
     if (infos%tddft%spc_coov==-1.0_dp) &
           infos%tddft%spc_coov = infos%tddft%HFscale
 
-    if(debug_mode.or..true.)then
+    if(debug_mode)then
       write(*,'(/,5x,"Input parameters:")')
       write(*,'(5x,"Number of states:                 ",1x,I0)') nstates
       write(*,'(5x,"Number of single excitations:     ",1x,I0)') xvec_dim
@@ -488,14 +488,7 @@ contains
           if (infos%tddft%spc_ovov /= infos%tddft%hfscale) &
              fmrst2(:,9,:,:) = fmrst2(:,9,:,:) * infos%tddft%spc_ovov / infos%tddft%hfscale
           if (infos%tddft%spc_coov /= infos%tddft%hfscale) &
-             fmrst2(:,1,:,:) = fmrst2(:,1,:,:) * infos%tddft%spc_coov / infos%tddft%hfscale
-             fmrst2(:,2,:,:) = fmrst2(:,2,:,:) * infos%tddft%spc_coov / infos%tddft%hfscale
-             fmrst2(:,3,:,:) = fmrst2(:,3,:,:) * infos%tddft%spc_coov / infos%tddft%hfscale
-             fmrst2(:,4,:,:) = fmrst2(:,4,:,:) * infos%tddft%spc_coov / infos%tddft%hfscale
-             fmrst2(:,5,:,:) = fmrst2(:,5,:,:) * infos%tddft%spc_coov / infos%tddft%hfscale
-             fmrst2(:,6,:,:) = fmrst2(:,6,:,:) * infos%tddft%spc_coov / infos%tddft%hfscale
-             fmrst2(:,7,:,:) = fmrst2(:,7,:,:) * infos%tddft%spc_coov / infos%tddft%hfscale
-             fmrst2(:,8,:,:) = fmrst2(:,8,:,:) * infos%tddft%spc_coov / infos%tddft%hfscale
+             fmrst2(:,1:8,:,:) = fmrst2(:,1:8,:,:) * infos%tddft%spc_coov / infos%tddft%hfscale
         else
           if (infos%tddft%spc_coco /= infos%tddft%hfscale) &
              fmrst2(:,6,:,:) = fmrst2(:,6,:,:) * infos%tddft%spc_coco / infos%tddft%hfscale


### PR DESCRIPTION
Add electric_moments_excited and electric_moments_excited_C for computing dipole, quadrupole, and octopole moments of an MRSF-TDDFT excited state using the Z-vector relaxed difference density (OQP_TD_P).

Total excited-state density is assembled as P^(0) + dP_relaxed and contracted against the existing multipole integrals. Target state is read from infos%tddft%target_state.