### PR TITLE
fix: synchronize int2 OpenMP workshares

### DIFF
--- a/source/integrals/int2.F90
+++ b/source/integrals/int2.F90
@@ -504,7 +504,12 @@ contains
 
           end do
         end do
-!$omp end do nowait
+! Do not use NOWAIT here. This workshare is encountered once per (i,j)
+! shell pair inside the surrounding parallel region. All threads must leave
+! the current workshare before any thread can enter the next shell-pair
+! workshare, otherwise the OpenMP runtime can see overlapping dynamic
+! workshares with different loop bounds and hand out invalid shell indices.
+!$omp end do
       end do
     end do
 

--- a/tests/test_int2_openmp_workshare.py
+++ b/tests/test_int2_openmp_workshare.py
@@ -1,0 +1,26 @@
+import re
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "source" / "integrals" / "int2.F90"
+
+
+class Int2OpenMPWorkshareTest(unittest.TestCase):
+    def test_shell_pair_workshare_has_barrier_between_dynamic_do_instances(self):
+        text = SOURCE.read_text()
+        match = re.search(
+            r"subroutine int2_twoei\(this, int2_consumer\)(.*?)end subroutine int2_twoei",
+            text,
+            re.IGNORECASE | re.DOTALL,
+        )
+        if match is None:
+            self.fail("Could not find int2_twoei")
+        body = match.group(1)
+        self.assertIn("!$omp do schedule(dynamic,2)", body)
+        self.assertNotIn("!$omp end do nowait", body)
+        self.assertIn("!$omp end do", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes a high-thread macOS/Homebrew GCC libgomp crash in the Rys/int2 ERI path by synchronizing repeated dynamic OpenMP workshares in `int2_twoei`.
- Removes `nowait` from the inner `!$omp do schedule(dynamic,2)` so all threads finish the current `(i,j)` shell-pair workshare before any thread enters the next workshare with different loop bounds.
- Adds a lightweight source-guard unittest to prevent reintroducing `!$omp end do nowait` in this loop.

## Root cause
The dynamic workshare is encountered once per outer shell-pair block. With `nowait`, a fast thread can enter the next dynamic workshare while other threads are still completing the previous one. On macOS Homebrew GCC/libgomp at 32 threads, this exposed corrupted shell/workshare state and SIGSEGV in `int2_rys_compute`. The barrier makes the worksharing construct sequence explicit and runtime-independent.

## Test plan
- `/opt/homebrew/bin/python3.11 -m unittest tests.test_int2_openmp_workshare -v`
- macOS/Homebrew GCC 15 rebuild with OpenMP enabled and `USE_LIBINT=OFF`
- 32-thread uracil CI21 reproducer:
  - `OMP_NUM_THREADS=32`
  - BLAS thread counts forced to 1
  - `OMP_STACKSIZE=512M`, `GOMP_STACKSIZE=512M`
  - run dir: `/Volumes/External_Storage/Hermes-Agent/quantum_calculation_data/openqp/uracil/rootfix_nowait_only_32c_finalcheck_20260525_193748`
  - result: exit 0, 30 geometry steps, 0 TRAH, 0 crash markers, normal max-iteration termination, elapsed 1090 s
