### PR TITLE
docs: update README and PyOQP manuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Open Quantum Platform ([OpenQP](https://pubs.acs.org/doi/10.1021/acs.jctc.4c0111
 - **Flexible prototyping through a Python wrapper, PyOQP**
 - **Ground and Excited State Properties** by [MRSF-TDDFT](https://doi.org/10.1021/acs.jpclett.3c02296)
 - **Nonadiabatic Coupling** based on [TLF Technology](https://doi.org/10.1021/acs.jpclett.1c00932) using **MRSF-TDDFT**
+- **Spin-Orbit Coupling** by [**Relativistic** MRSF-TDDFT](https://doi.org/10.1021/acs.jctc.2c01036), including one-electron and mean-field two-electron SOC terms through `runtype=soc`
 - **New Exchange-Correlation Functionals** of [**DTCAM** series](https://doi.org/10.1021/acs.jctc.4c00640) for MRSF-TDDFT
 - **Ground State Properties** by HF and DFT theories
 - **Geometry Optimization, Transition State Search, and Conical Intersection Search** by SciPy and [DL-Find](https://github.com/digital-chemistry-laboratory/libdlfind)
+- [geomeTRIC](https://github.com/leeping/geomeTRIC) optimizer backend for state-specific optimization, MECI, MECP, transition-state searches, constrained optimizations, and IRC paths
 - [PyRAI2MD](https://github.com/mlcclab/PyRAI2MD-hiam) Integration to support Artificial Intelligence Ab Initio Molecular Dynamics
 - [LibXC](https://gitlab.com/libxc/libxc) Integration to support a variety of exchange-correlation functionals
 - [basis_set_exchange](https://github.com/MolSSI-BSE/basis_set_exchange) Integration to support a variety of basis sets
@@ -20,10 +22,11 @@ Open Quantum Platform ([OpenQP](https://pubs.acs.org/doi/10.1021/acs.jctc.4c0111
 - **OpenMP and MPI Parallelization** and **BLAS/LAPACK Optimization** for high performance
 - [OpenTrustRegion library](https://github.com/eriksen-lab/opentrustregion) for stable SCF convergence
 - Native PySCF-based advanced initial guesses, plus optional [MOKIT](https://github.com/1234zou/MOKIT) support for broader external wavefunction conversion workflows
+- Native PySCF-backed initial guesses: `guess.type=pyscf`, `guess.type=sad`, and `guess.type=sap`
+- [OpenqpView](https://open-quantum-platform.github.io/OpenqpView/) browser-based visualization for OpenQP outputs, supporting local log, JSON, Molden, cube, and XYZ inspection
   
 ### Upcoming Features
 - **Efficient electrostatic embedding QM/MM** by [ESPF QM/MM](https://doi.org/10.1063/5.0133646)
-- **Spin-Orbit Coupling** by [**Relativistic** MRSF-TDDFT](https://doi.org/10.1021/acs.jctc.2c01036)
 - **Ionization Potential/Electron Affinity** by [**EKT**-MRSF-TDDFT](https://doi.org/10.1021/acs.jpclett.1c02494)
 
 ### Quickstart
@@ -131,6 +134,9 @@ For more in-depth information, visit:
 
 ### Input Generator
 Easily create input files for OpenQP using our [Web-based Input Generator](https://open-quantum-platform.github.io/OpenQP_Input_Generator/).
+
+### OpenqpView
+Inspect OpenQP calculation outputs directly in the browser with [OpenqpView](https://open-quantum-platform.github.io/OpenqpView/). Recent OpenqpView development added a GitHub Pages deployment, full-periodic-table molecule rendering, local file/drop/paste loading, WebGL auto-spin controls, and support for OpenQP log, JSON, Molden, cube, and XYZ data. Files and pasted text are processed locally in the browser and are not uploaded to a server.
 
 ### Citing OpenQP
 If you use OpenQP in your research, please cite the following papers:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Open Quantum Platform ([OpenQP](https://pubs.acs.org/doi/10.1021/acs.jctc.4c0111
 - **Flexible prototyping through a Python wrapper, PyOQP**
 - **Ground and Excited State Properties** by [MRSF-TDDFT](https://doi.org/10.1021/acs.jpclett.3c02296)
 - **Nonadiabatic Coupling** based on [TLF Technology](https://doi.org/10.1021/acs.jpclett.1c00932) using **MRSF-TDDFT**
-- **Spin-Orbit Coupling** by [**Relativistic** MRSF-TDDFT](https://doi.org/10.1021/acs.jctc.2c01036), including one-electron and mean-field two-electron SOC terms through `runtype=soc`
 - **New Exchange-Correlation Functionals** of [**DTCAM** series](https://doi.org/10.1021/acs.jctc.4c00640) for MRSF-TDDFT
 - **Ground State Properties** by HF and DFT theories
 - **Geometry Optimization, Transition State Search, and Conical Intersection Search** by SciPy and [DL-Find](https://github.com/digital-chemistry-laboratory/libdlfind)
@@ -27,6 +26,7 @@ Open Quantum Platform ([OpenQP](https://pubs.acs.org/doi/10.1021/acs.jctc.4c0111
   
 ### Upcoming Features
 - **Efficient electrostatic embedding QM/MM** by [ESPF QM/MM](https://doi.org/10.1063/5.0133646)
+- **Spin-Orbit Coupling** by [**Relativistic** MRSF-TDDFT](https://doi.org/10.1021/acs.jctc.2c01036)
 - **Ionization Potential/Electron Affinity** by [**EKT**-MRSF-TDDFT](https://doi.org/10.1021/acs.jpclett.1c02494)
 
 ### Quickstart

--- a/pyoqp/README.md
+++ b/pyoqp/README.md
@@ -76,7 +76,6 @@ Results, including log files and `test_report.txt`, will be stored in the curren
     runtype=energy
     system=''
     d4=False
-    soc_2e=1
 
 [guess]
     type=huckel
@@ -127,6 +126,7 @@ Results, including log files and `test_report.txt`, will be stored in the curren
     td_prop=False
     grad=0
     nac=''
+    soc=''
     export=False
 
 [optimize]
@@ -197,7 +197,7 @@ input section handle the basic information of molecular system
       grad       single-point energy and gradients
       hess       frequency calculation (numerical only)
       nac        non-adiabatic coupling (not available yet)
-      soc        spin-orbit coupling for MRSF-TDDFT
+      soc        spin-orbit coupling (not available yet)
       optimize   local minimum geometry optimization
       meci       minimum energy conical intersection optimization
       mep        minimum energy path calculation
@@ -221,14 +221,6 @@ input section handle the basic information of molecular system
 
       False      do not compute DFTD4 corrections according to functional (default)
       True       compute DFTD4 corrections for energy and gradients. some functional might not be supported
-
-- soc_2e // choose SOC terms for runtype=soc
-
-      0          one-electron SOC only
-      1          one-electron plus mean-field two-electron SOC (default)
-
-      runtype=soc requires method=tdhf, tdhf.type=mrsf, scf.type=rohf,
-      and scf.multiplicity=3.
 
 ### [guess]
 

--- a/pyoqp/README.md
+++ b/pyoqp/README.md
@@ -6,6 +6,8 @@
 
 - Geometry optimization for arbitrary state local minimum, MECI, MEP with Scipy library
 - Geometry optimization for arbitrary state local minimum, MECI, TS with DL-FIND library
+- Geometry optimization with geomeTRIC for state-specific optimization, MECI, MECP, TS, constrained optimizations, and IRC paths
+- Native PySCF-backed initial guesses: `pyscf`, `sad`, and `sap`
 - Energy gradient calculations interface for nonadiabatic molecular dynamics
 
 ## Prerequisite
@@ -74,12 +76,25 @@ Results, including log files and `test_report.txt`, will be stored in the curren
     runtype=energy
     system=''
     d4=False
+    soc_2e=1
 
 [guess]
     type=huckel
     file=''
     save_mol=False
     continue_geom=False
+
+[geometric]
+    coordsys=tric
+    trust=0.1
+    tmax=0.3
+    convergence_set=GAU
+    prefix=geometric
+    hessian=never
+    irc_direction=forward
+    constraints_file=''
+    enforce=0.0
+    conmethod=0
 
 [scf]
     type=rhf
@@ -112,7 +127,6 @@ Results, including log files and `test_report.txt`, will be stored in the curren
     td_prop=False
     grad=0
     nac=''
-    soc=''
     export=False
 
 [optimize]
@@ -183,11 +197,12 @@ input section handle the basic information of molecular system
       grad       single-point energy and gradients
       hess       frequency calculation (numerical only)
       nac        non-adiabatic coupling (not available yet)
-      soc        spin-orbit coupling (not available yet)
+      soc        spin-orbit coupling for MRSF-TDDFT
       optimize   local minimum geometry optimization
       meci       minimum energy conical intersection optimization
       mep        minimum energy path calculation
       ts         transition state optimization
+      irc        intrinsic reaction coordinate with [optimize]lib=geometric
       neb        nudge elasted band calculation (not avaialble yet)
  
 - system // specify molecular structure or xyz file
@@ -207,6 +222,14 @@ input section handle the basic information of molecular system
       False      do not compute DFTD4 corrections according to functional (default)
       True       compute DFTD4 corrections for energy and gradients. some functional might not be supported
 
+- soc_2e // choose SOC terms for runtype=soc
+
+      0          one-electron SOC only
+      1          one-electron plus mean-field two-electron SOC (default)
+
+      runtype=soc requires method=tdhf, tdhf.type=mrsf, scf.type=rohf,
+      and scf.multiplicity=3.
+
 ### [guess]
 
 guess section handle the guess orbitals 
@@ -217,6 +240,14 @@ guess section handle the guess orbitals
       hcore      hcore guess
       model      read orbital from molden
       json       load data from json
+      auto       load json if the requested file exists; otherwise use huckel
+      pyscf      run a PySCF SCF calculation and import the converged orbitals
+      sad        build a PySCF superposition-of-atomic-density initial guess
+      sap        build a PySCF superposition-of-atomic-potential initial guess
+
+      pyscf, sad, and sap use the native OpenQP JSON restart exporter.
+      PySCF is installed with OpenQP's Python dependencies. MOKIT is not
+      required for these initial guesses.
 
 - file // set the guess orbital or data file
 
@@ -384,6 +415,7 @@ optimize section handle the geometry optimization
 
       scipy       use scipy.optimize library (default)
       dlfind      use DL-FIND library
+      geometric   use geomeTRIC. Supports runtype=optimize, meci, mecp, ts, and irc
 
 - optimizer // choose the scipy optimizer
 
@@ -462,6 +494,52 @@ optimize section handle the geometry optimization
 
       True       do initial SCF iterations in every optimization step
       False      do not do initial SCF iterations after the first optimization step
+
+### [geometric]
+
+geometric section controls the geomeTRIC optimizer backend when [optimize]lib=geometric
+
+- coordsys // coordinate system passed to geomeTRIC
+
+      tric       translation-rotation internal coordinates (default)
+
+- trust // initial trust radius in Angstrom
+
+      0.1 (default)
+
+- tmax // maximum trust radius in Angstrom
+
+      0.3 (default)
+
+- convergence_set // geomeTRIC convergence preset
+
+      GAU (default)
+
+- prefix // prefix for geomeTRIC output files
+
+      geometric (default)
+
+- hessian // initial Hessian option passed to geomeTRIC
+
+      never (default for minima and constrained optimization)
+      first (recommended/automatically used for ts and irc if hessian=never)
+
+- irc_direction // IRC branch direction for runtype=irc
+
+      forward (default)
+      backward
+
+- constraints_file // geomeTRIC constraints file for constrained optimization
+
+      relative paths are resolved relative to the OpenQP input file
+
+- enforce // geomeTRIC constraint enforcement value
+
+      0.0 (default)
+
+- conmethod // geomeTRIC constraint method
+
+      0 (default)
 
 ### [dlfind]
 


### PR DESCRIPTION
## Summary
- Add geomeTRIC optimizer backend documentation to README and PyOQP README
- Add OpenqpView link and recent OpenqpView development summary to README
- Document PySCF-backed `pyscf`, `sad`, and `sap` initial guesses in PyOQP README

## Scope
- Non-SOC README/manual updates only. SOC documentation is kept with PR #128.
- Wiki documentation was updated separately in the OpenQP wiki repository.

## Test Plan
- `git diff --check`