### PR TITLE
fix: flatten int2 OpenMP shell-pair workshare

### DIFF
--- a/source/integrals/int2.F90
+++ b/source/integrals/int2.F90
@@ -357,7 +357,7 @@ contains
     class(int2_compute_t), target, intent(inout) :: this
     class(int2_compute_data_t), intent(inout) :: int2_consumer
 
-    integer :: i, j, k, l, ij
+    integer :: i, j, k, l, ij_pair, npairs
     integer :: lmax
     integer :: nint
     real(kind=dp) :: test
@@ -381,6 +381,7 @@ contains
     integer :: ok
 
     nshell = this%basis%nshell
+    npairs = nshell*(nshell+1)/2
 
 
     ! preparations for screening
@@ -408,7 +409,7 @@ contains
 
 !$omp parallel &
 !$omp   private( &
-!$omp   i, j, k, l, ij, jork, &
+!$omp   i, j, k, l, ij_pair, jork, &
 !$omp   tim0, tim1, tim2, tim3, tim4, ithread,   &
 !$omp   test, &
 !$omp   int2_storage, &
@@ -455,14 +456,18 @@ contains
     int2_storage%thread_id = ithread + 1
 
 !$omp barrier
-    if (this%pe%size>1) then
-      ij= 0
-    end if
-    do i = this%basis%nshell, 1, -1
-      do j = 1, i
+
+! Distribute shell pairs through one flat dynamic workshare per int2_twoei
+! parallel region.  The previous structure opened a fresh dynamic workshare
+! for every (i,j) shell pair and needed a barrier after every shell pair to
+! keep OpenMP runtimes from overlapping workshares with different k-loop
+! bounds.  A flat shell-pair workshare keeps scheduling granular without any
+! synchronization point inside the shell-pair loop.
+!$omp do schedule(dynamic,1)
+    do ij_pair = 1, npairs
+        call int2_decode_shell_pair(ij_pair, nshell, i, j)
         if (this%pe%size>1) then
-          ij = ij +1
-          if (mod(ij, this%pe%size) /= this%pe%rank) cycle
+          if (mod(ij_pair, this%pe%size) /= this%pe%rank) cycle
         end if
 
         if (this%schwarz) then
@@ -473,7 +478,6 @@ contains
           end if
         end if
 
-!$omp do schedule(dynamic,2)
         do k = 1, i
 
           jork = k
@@ -504,9 +508,8 @@ contains
 
           end do
         end do
-!$omp end do nowait
-      end do
     end do
+!$omp end do
 
     call int2_consumer%update(int2_storage)
 
@@ -536,6 +539,27 @@ contains
     call int2_consumer%parallel_stop()
 
     this%skipped = nschwz
+
+  contains
+
+    subroutine int2_decode_shell_pair(ij_pair, nshell, i, j)
+      implicit none
+      integer, intent(in) :: ij_pair, nshell
+      integer, intent(out) :: i, j
+      integer :: remaining
+
+      remaining = ij_pair
+      do i = nshell, 1, -1
+        if (remaining <= i) then
+          j = remaining
+          return
+        end if
+        remaining = remaining - i
+      end do
+
+      i = 0
+      j = 0
+    end subroutine int2_decode_shell_pair
 
   end subroutine int2_twoei
 

--- a/tests/test_int2_openmp_workshare.py
+++ b/tests/test_int2_openmp_workshare.py
@@ -1,0 +1,56 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INT2 = ROOT / "source" / "integrals" / "int2.F90"
+
+
+class Int2OpenMPWorkshareTests(unittest.TestCase):
+    def _int2_twoei_source(self):
+        text = INT2.read_text()
+        match = re.search(
+            r"subroutine\s+int2_twoei\b(?P<body>.*?)end\s+subroutine\s+int2_twoei",
+            text,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        if match is None:
+            self.fail("int2_twoei subroutine not found")
+        return match.group("body").lower()
+
+    def test_shell_pair_parallelism_uses_single_flat_pair_workshare(self):
+        body = self._int2_twoei_source()
+
+        self.assertIn("npairs = nshell*(nshell+1)/2", body)
+        self.assertRegex(
+            body,
+            r"!\$omp\s+do\s+schedule\(dynamic,1\)\s*\n\s*do\s+ij_pair\s*=\s*1\s*,\s*npairs",
+        )
+        self.assertIn("call int2_decode_shell_pair(ij_pair, nshell, i, j)", body)
+        self.assertNotIn("!$omp end do nowait", body)
+        self.assertNotIn("!$omp do schedule(dynamic,2)", body)
+
+        flat_workshare = re.search(
+            r"do\s+ij_pair\s*=\s*1\s*,\s*npairs(?P<body>.*?)!\$omp\s+end\s+do",
+            body,
+            flags=re.DOTALL,
+        )
+        if flat_workshare is None:
+            self.fail("flat shell-pair workshare not found")
+        self.assertNotRegex(flat_workshare.group("body"), r"do\s+j\s*=\s*1\s*,\s*i")
+        self.assertNotIn("!$omp do", flat_workshare.group("body"))
+        self.assertNotIn("!$omp barrier", flat_workshare.group("body"))
+
+    def test_shell_pair_decoder_preserves_descending_i_then_ascending_j_order(self):
+        body = self._int2_twoei_source()
+
+        self.assertIn("subroutine int2_decode_shell_pair(ij_pair, nshell, i, j)", body)
+        self.assertIn("remaining = ij_pair", body)
+        self.assertIn("do i = nshell, 1, -1", body)
+        self.assertIn("if (remaining <= i) then", body)
+        self.assertIn("j = remaining", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace repeated nested dynamic OpenMP workshares in int2_twoei with one flat shell-pair workshare.
- Preserve the original shell-pair traversal order with an internal ij-pair decoder.
- Add a source-level regression guard for the OpenMP loop shape.

## Motivation
This avoids the macOS/Homebrew libgomp high-thread crash/segfault path while avoiding the severe slowdown of a barrier-after-every-shell-pair workaround.

## Validation
- python3 -m unittest tests.test_int2_openmp_workshare -v
- macOS 32-thread uracil CI21 reproducer: completed normally, 0 TRAH, 0 crash markers.
- macOS medium-10 RHF/HF/6-31g* 32-thread benchmark: completed normally, 0 TRAH, 0 crash markers.
- Lima 32-thread medium-10 flat vs original: energies unchanged; flat/original total ratio 1.0342.
- CHC2 32-thread medium-10 flat vs original: energies unchanged; flat/original total ratio 1.0291.

## Performance note
The safe flat shell-pair workshare is about 3-4% slower than the original on the Linux medium-10 benchmark, but it eliminates the macOS high-thread OpenMP crash. Further decode/granularity optimization will be explored separately.