### PR TITLE
perf: precompute int2 shell-pair decode map

### DIFF
--- a/source/integrals/int2.F90
+++ b/source/integrals/int2.F90
@@ -357,7 +357,7 @@ contains
     class(int2_compute_t), target, intent(inout) :: this
     class(int2_compute_data_t), intent(inout) :: int2_consumer
 
-    integer :: i, j, k, l, ij
+    integer :: i, j, k, l, ij_pair, npairs
     integer :: lmax
     integer :: nint
     real(kind=dp) :: test
@@ -381,6 +381,7 @@ contains
     integer :: ok
 
     nshell = this%basis%nshell
+    npairs = nshell*(nshell+1)/2
 
 
     ! preparations for screening
@@ -408,7 +409,7 @@ contains
 
 !$omp parallel &
 !$omp   private( &
-!$omp   i, j, k, l, ij, jork, &
+!$omp   i, j, k, l, ij_pair, jork, &
 !$omp   tim0, tim1, tim2, tim3, tim4, ithread,   &
 !$omp   test, &
 !$omp   int2_storage, &
@@ -455,14 +456,18 @@ contains
     int2_storage%thread_id = ithread + 1
 
 !$omp barrier
-    if (this%pe%size>1) then
-      ij= 0
-    end if
-    do i = this%basis%nshell, 1, -1
-      do j = 1, i
+
+! Distribute shell pairs through one flat dynamic workshare per int2_twoei
+! parallel region.  The previous structure opened a fresh dynamic workshare
+! for every (i,j) shell pair and needed a barrier after every shell pair to
+! keep OpenMP runtimes from overlapping workshares with different k-loop
+! bounds.  A flat shell-pair workshare keeps scheduling granular without any
+! synchronization point inside the shell-pair loop.
+!$omp do schedule(dynamic,1)
+    do ij_pair = 1, npairs
+        call int2_decode_shell_pair(ij_pair, nshell, i, j)
         if (this%pe%size>1) then
-          ij = ij +1
-          if (mod(ij, this%pe%size) /= this%pe%rank) cycle
+          if (mod(ij_pair, this%pe%size) /= this%pe%rank) cycle
         end if
 
         if (this%schwarz) then
@@ -473,7 +478,6 @@ contains
           end if
         end if
 
-!$omp do schedule(dynamic,2)
         do k = 1, i
 
           jork = k
@@ -504,9 +508,8 @@ contains
 
           end do
         end do
-!$omp end do nowait
-      end do
     end do
+!$omp end do
 
     call int2_consumer%update(int2_storage)
 
@@ -536,6 +539,27 @@ contains
     call int2_consumer%parallel_stop()
 
     this%skipped = nschwz
+
+  contains
+
+    subroutine int2_decode_shell_pair(ij_pair, nshell, i, j)
+      implicit none
+      integer, intent(in) :: ij_pair, nshell
+      integer, intent(out) :: i, j
+      integer :: remaining
+
+      remaining = ij_pair
+      do i = nshell, 1, -1
+        if (remaining <= i) then
+          j = remaining
+          return
+        end if
+        remaining = remaining - i
+      end do
+
+      i = 0
+      j = 0
+    end subroutine int2_decode_shell_pair
 
   end subroutine int2_twoei
 

--- a/source/integrals/int2.F90
+++ b/source/integrals/int2.F90
@@ -358,6 +358,7 @@ contains
     class(int2_compute_data_t), intent(inout) :: int2_consumer
 
     integer :: i, j, k, l, ij_pair, npairs
+    integer, allocatable :: pair_i(:), pair_j(:)
     integer :: lmax
     integer :: nint
     real(kind=dp) :: test
@@ -382,6 +383,8 @@ contains
 
     nshell = this%basis%nshell
     npairs = nshell*(nshell+1)/2
+    allocate(pair_i(npairs), pair_j(npairs))
+    call int2_build_shell_pair_map(nshell, pair_i, pair_j)
 
 
     ! preparations for screening
@@ -465,7 +468,8 @@ contains
 ! synchronization point inside the shell-pair loop.
 !$omp do schedule(dynamic,1)
     do ij_pair = 1, npairs
-        call int2_decode_shell_pair(ij_pair, nshell, i, j)
+        i = pair_i(ij_pair)
+        j = pair_j(ij_pair)
         if (this%pe%size>1) then
           if (mod(ij_pair, this%pe%size) /= this%pe%rank) cycle
         end if
@@ -535,6 +539,7 @@ contains
 
     deallocate(eri_data)
 !$omp end parallel
+    deallocate(pair_i, pair_j)
     call int2_consumer%pe%init(this%pe%comm, this%pe%use_mpi)
     call int2_consumer%parallel_stop()
 
@@ -542,24 +547,21 @@ contains
 
   contains
 
-    subroutine int2_decode_shell_pair(ij_pair, nshell, i, j)
+    subroutine int2_build_shell_pair_map(nshell, shell_pair_i, shell_pair_j)
       implicit none
-      integer, intent(in) :: ij_pair, nshell
-      integer, intent(out) :: i, j
-      integer :: remaining
+      integer, intent(in) :: nshell
+      integer, intent(out) :: shell_pair_i(:), shell_pair_j(:)
+      integer :: i, j, ij_pair
 
-      remaining = ij_pair
+      ij_pair = 0
       do i = nshell, 1, -1
-        if (remaining <= i) then
-          j = remaining
-          return
-        end if
-        remaining = remaining - i
+        do j = 1, i
+          ij_pair = ij_pair + 1
+          shell_pair_i(ij_pair) = i
+          shell_pair_j(ij_pair) = j
+        end do
       end do
-
-      i = 0
-      j = 0
-    end subroutine int2_decode_shell_pair
+    end subroutine int2_build_shell_pair_map
 
   end subroutine int2_twoei
 

--- a/tests/test_int2_openmp_workshare.py
+++ b/tests/test_int2_openmp_workshare.py
@@ -27,7 +27,9 @@ class Int2OpenMPWorkshareTests(unittest.TestCase):
             body,
             r"!\$omp\s+do\s+schedule\(dynamic,1\)\s*\n\s*do\s+ij_pair\s*=\s*1\s*,\s*npairs",
         )
-        self.assertIn("call int2_decode_shell_pair(ij_pair, nshell, i, j)", body)
+        self.assertIn("call int2_build_shell_pair_map(nshell, pair_i, pair_j)", body)
+        self.assertIn("i = pair_i(ij_pair)", body)
+        self.assertIn("j = pair_j(ij_pair)", body)
         self.assertNotIn("!$omp end do nowait", body)
         self.assertNotIn("!$omp do schedule(dynamic,2)", body)
 
@@ -38,18 +40,33 @@ class Int2OpenMPWorkshareTests(unittest.TestCase):
         )
         if flat_workshare is None:
             self.fail("flat shell-pair workshare not found")
-        self.assertNotRegex(flat_workshare.group("body"), r"do\s+j\s*=\s*1\s*,\s*i")
-        self.assertNotIn("!$omp do", flat_workshare.group("body"))
-        self.assertNotIn("!$omp barrier", flat_workshare.group("body"))
+        flat_body = flat_workshare.group("body")
+        self.assertNotRegex(flat_body, r"do\s+j\s*=\s*1\s*,\s*i")
+        self.assertNotIn("!$omp do", flat_body)
+        self.assertNotIn("!$omp barrier", flat_body)
+        self.assertNotIn("call int2_decode_shell_pair", flat_body)
 
-    def test_shell_pair_decoder_preserves_descending_i_then_ascending_j_order(self):
+    def test_precomputed_shell_pair_map_preserves_descending_i_then_ascending_j_order(self):
         body = self._int2_twoei_source()
 
-        self.assertIn("subroutine int2_decode_shell_pair(ij_pair, nshell, i, j)", body)
-        self.assertIn("remaining = ij_pair", body)
-        self.assertIn("do i = nshell, 1, -1", body)
-        self.assertIn("if (remaining <= i) then", body)
-        self.assertIn("j = remaining", body)
+        build_map = re.search(
+            r"subroutine\s+int2_build_shell_pair_map\b(?P<body>.*?)end\s+subroutine\s+int2_build_shell_pair_map",
+            body,
+            flags=re.DOTALL,
+        )
+        if build_map is None:
+            self.fail("int2_build_shell_pair_map subroutine not found")
+        map_body = build_map.group("body")
+
+        self.assertIn("ij_pair = 0", map_body)
+        self.assertRegex(
+            map_body,
+            r"do\s+i\s*=\s*nshell\s*,\s*1\s*,\s*-1\s*\n\s*do\s+j\s*=\s*1\s*,\s*i",
+        )
+        self.assertRegex(
+            map_body,
+            r"ij_pair\s*=\s*ij_pair\s*\+\s*1\s*\n\s*shell_pair_i\(ij_pair\)\s*=\s*i\s*\n\s*shell_pair_j\(ij_pair\)\s*=\s*j",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_int2_openmp_workshare.py
+++ b/tests/test_int2_openmp_workshare.py
@@ -1,0 +1,56 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INT2 = ROOT / "source" / "integrals" / "int2.F90"
+
+
+class Int2OpenMPWorkshareTests(unittest.TestCase):
+    def _int2_twoei_source(self):
+        text = INT2.read_text()
+        match = re.search(
+            r"subroutine\s+int2_twoei\b(?P<body>.*?)end\s+subroutine\s+int2_twoei",
+            text,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        if match is None:
+            self.fail("int2_twoei subroutine not found")
+        return match.group("body").lower()
+
+    def test_shell_pair_parallelism_uses_single_flat_pair_workshare(self):
+        body = self._int2_twoei_source()
+
+        self.assertIn("npairs = nshell*(nshell+1)/2", body)
+        self.assertRegex(
+            body,
+            r"!\$omp\s+do\s+schedule\(dynamic,1\)\s*\n\s*do\s+ij_pair\s*=\s*1\s*,\s*npairs",
+        )
+        self.assertIn("call int2_decode_shell_pair(ij_pair, nshell, i, j)", body)
+        self.assertNotIn("!$omp end do nowait", body)
+        self.assertNotIn("!$omp do schedule(dynamic,2)", body)
+
+        flat_workshare = re.search(
+            r"do\s+ij_pair\s*=\s*1\s*,\s*npairs(?P<body>.*?)!\$omp\s+end\s+do",
+            body,
+            flags=re.DOTALL,
+        )
+        if flat_workshare is None:
+            self.fail("flat shell-pair workshare not found")
+        self.assertNotRegex(flat_workshare.group("body"), r"do\s+j\s*=\s*1\s*,\s*i")
+        self.assertNotIn("!$omp do", flat_workshare.group("body"))
+        self.assertNotIn("!$omp barrier", flat_workshare.group("body"))
+
+    def test_shell_pair_decoder_preserves_descending_i_then_ascending_j_order(self):
+        body = self._int2_twoei_source()
+
+        self.assertIn("subroutine int2_decode_shell_pair(ij_pair, nshell, i, j)", body)
+        self.assertIn("remaining = ij_pair", body)
+        self.assertIn("do i = nshell, 1, -1", body)
+        self.assertIn("if (remaining <= i) then", body)
+        self.assertIn("j = remaining", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Precompute the `ij_pair -> (i,j)` shell-pair map once before the `int2_twoei` OpenMP parallel region.
- Keep PR #144's safe single flat `!$omp do schedule(dynamic,1)` workshare over `ij_pair = 1, npairs`.
- Replace per-work-item O(nshell) decode calls with indexed loads from the precomputed maps while preserving descending-i / ascending-j traversal order.
- Update source-level tests to verify the precomputed map order and guard against nested OpenMP workshare/nowait/barrier inside the flat shell-pair loop.

## Validation
- `python3 -m unittest tests.test_int2_openmp_workshare -v`

## Notes
- This is stacked on PR #144 / `fix/macos-int2-flat-workshare` and is intended as an exploratory follow-up performance/decode optimization.
- No benchmark speedup is claimed here; only source-level validation was run.
- Opened against `main` as requested; it depends on the flat-workshare fix from PR #144.