### PR TITLE
docs: reduce DFTB backend README detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,9 @@ Open Quantum Platform ([OpenQP](https://pubs.acs.org/doi/10.1021/acs.jctc.4c0111
 - Native PySCF-backed initial guesses: `guess.type=pyscf`, `guess.type=sad`, and `guess.type=sap`
 - [OpenqpView](https://open-quantum-platform.github.io/OpenqpView/) browser-based visualization for OpenQP outputs, supporting local log, JSON, Molden, cube, and XYZ inspection
   
-### DFTB+ External Backend
+### Backend Integrations
 
-This branch includes an optional external DFTB+ backend for ground-state workflows. It shells out to a user-provided `dftb+` executable and Slater-Koster parameter directory configured in the `[dftb]` input section.
-
-| Capability | Status | Scope |
-| --- | --- | --- |
-| Energy | Supported | Parses DFTB+ `results.tag` or `detailed.out`. |
-| Gradient | Supported | Parses DFTB+ forces and returns OpenQP gradients. |
-| Geometry optimization | Supported | Ground-state `runtype=optimize`, `lib=scipy`, `istate=0`, using DFTB+ energy/gradient callbacks. |
-| TD-DFTB excited states | Unsupported | DFTB+ excited-state outputs are not parsed or mapped into OpenQP TD data. |
-| Nonadiabatic couplings | Unsupported | OpenQP NAC workflows require TDHF/MRSF state data unavailable from this bridge. |
-| Spin-flip DFTB | Unsupported | OpenQP spin-flip response is native TDHF/MRSF only. |
-| Hessian/frequencies | Unsupported | No DFTB+ Hessian parser or numerical-Hessian callback is wired. |
-| Molecular dynamics | Unsupported | No OpenQP DFTB+ MD workflow is wired in this branch. |
-| Native OpenQP DFTB Hamiltonian | Unsupported | This backend is external DFTB+ only. |
+Optional external-backend integrations let OpenQP call user-provided engines for targeted workflows; the current DFTB+ bridge covers ground-state energy, gradient, and geometry optimization when configured in the `[dftb]` input section.
 
 ### Upcoming Features
 - **Efficient electrostatic embedding QM/MM** by [ESPF QM/MM](https://doi.org/10.1063/5.0133646)


### PR DESCRIPTION
## Summary
- replaces the detailed DFTB+ capability table with a short backend-integration note
- keeps README focused while still mentioning the optional external DFTB+ backend scope

## Test Plan
- documentation-only change; inspected README diff and remaining DFTB mentions