### PR TITLE
feat: add geomeTRIC NEB workflow scaffold

### DIFF
--- a/pyoqp/oqp/library/libgeometric.py
+++ b/pyoqp/oqp/library/libgeometric.py
@@ -178,3 +178,27 @@ class GeometricIRCOpt(_GeometricRunner, StateSpecificOpt):
 
     def _optimizer_keywords(self):
         return {"irc": True, "irc_direction": self.irc_direction}
+
+
+class GeometricNEBOpt:
+    """Dependency-light scaffold for geomeTRIC NEB path calculations."""
+
+    def __init__(self, mol):
+        self.mol = mol
+        self.neb_config = mol.config.get("neb", {})
+        self.nimage = int(self.neb_config.get("nimage", 5))
+
+    def plan_image_directories(self):
+        """Return isolated per-image working directories for a NEB path."""
+        log_path = getattr(self.mol, "log_path", os.getcwd())
+        neb_root = os.path.join(log_path, "neb")
+        return [
+            os.path.join(neb_root, f"image_{image_index:03d}")
+            for image_index in range(self.nimage)
+        ]
+
+    def optimize(self):
+        raise NotImplementedError(
+            "geomeTRIC NEB runner wiring is not implemented yet; "
+            "the current scaffold only validates input and plans isolated image directories."
+        )

--- a/pyoqp/oqp/library/neb_utils.py
+++ b/pyoqp/oqp/library/neb_utils.py
@@ -1,0 +1,89 @@
+"""Dependency-light helpers for geomeTRIC NEB endpoint paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class NEBImage:
+    """One NEB path image in user-facing Angstrom coordinates."""
+
+    symbols: list[str]
+    coordinates_angstrom: list[list[float]]
+
+
+def _read_xyz(path: str | Path) -> NEBImage:
+    xyz_path = Path(path)
+    lines = xyz_path.read_text().splitlines()
+    if not lines:
+        raise ValueError(f"XYZ endpoint is empty: {xyz_path}")
+    try:
+        natom = int(lines[0].strip())
+    except ValueError as exc:
+        raise ValueError(f"XYZ endpoint first line must be an atom count: {xyz_path}") from exc
+    atom_lines = lines[2:]
+    if len(atom_lines) < natom:
+        raise ValueError(f"XYZ endpoint has fewer atom lines than declared: {xyz_path}")
+
+    symbols: list[str] = []
+    coordinates: list[list[float]] = []
+    for index, line in enumerate(atom_lines[:natom], start=1):
+        fields = line.split()
+        if len(fields) < 4:
+            raise ValueError(f"XYZ atom line {index} must contain symbol and x/y/z: {xyz_path}")
+        symbols.append(fields[0])
+        try:
+            coordinates.append([float(fields[1]), float(fields[2]), float(fields[3])])
+        except ValueError as exc:
+            raise ValueError(f"XYZ atom line {index} contains non-numeric coordinates: {xyz_path}") from exc
+    return NEBImage(symbols=symbols, coordinates_angstrom=coordinates)
+
+
+def _interpolate_coordinates(
+    reactant: Iterable[Iterable[float]],
+    product: Iterable[Iterable[float]],
+    fraction: float,
+) -> list[list[float]]:
+    return [
+        [r_value + fraction * (p_value - r_value) for r_value, p_value in zip(r_atom, p_atom)]
+        for r_atom, p_atom in zip(reactant, product)
+    ]
+
+
+def interpolate_xyz_endpoints(
+    reactant_xyz: str | Path,
+    product_xyz: str | Path,
+    nimage: int,
+) -> list[NEBImage]:
+    """Return linearly interpolated NEB images including both endpoints.
+
+    Input and output coordinates are Angstrom, matching OpenQP XYZ/system input
+    conventions. Atom symbols/count/order must match exactly so each image can
+    be evaluated on the same state-specific surface.
+    """
+
+    if nimage < 3:
+        raise ValueError("NEB interpolation requires nimage >= 3")
+    reactant = _read_xyz(reactant_xyz)
+    product = _read_xyz(product_xyz)
+    if reactant.symbols != product.symbols:
+        raise ValueError("NEB endpoints must have identical atom symbols and order")
+
+    denominator = nimage - 1
+    images: list[NEBImage] = []
+    for image_index in range(nimage):
+        fraction = image_index / denominator
+        images.append(
+            NEBImage(
+                symbols=list(reactant.symbols),
+                coordinates_angstrom=_interpolate_coordinates(
+                    reactant.coordinates_angstrom,
+                    product.coordinates_angstrom,
+                    fraction,
+                ),
+            )
+        )
+    return images

--- a/pyoqp/oqp/library/runfunc.py
+++ b/pyoqp/oqp/library/runfunc.py
@@ -14,6 +14,7 @@ from oqp.library.libgeometric import (
     GeometricIRCOpt,
     GeometricMECIOpt,
     GeometricMECPOpt,
+    GeometricNEBOpt,
     GeometricOpt,
     GeometricTSOpt,
 )
@@ -217,7 +218,7 @@ def get_optimizer(mol):
             'mep': None,
             'ts': GeometricTSOpt,
             'irc': GeometricIRCOpt,
-            'neb': None,
+            'neb': GeometricNEBOpt,
         },
     }
 

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -209,6 +209,10 @@ OQP_CONFIG_SCHEMA = {
         'enforce': {'type': float, 'default': '0.0'},
         'conmethod': {'type': int, 'default': '0'},
     },
+    'neb': {
+        'product': {'type': str, 'default': ''},
+        'nimage': {'type': int, 'default': '5'},
+    },
     'hess': {
         'type': {'type': string, 'default': 'numerical'},
         'state': {'type': int, 'default': '0'},

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -63,6 +63,7 @@ class Runner:
             'mep': compute_geom,
             'ts': compute_geom,
             'irc': compute_geom,
+            'neb': compute_geom,
             'hess': compute_hess,
             'thermo': compute_thermo,
             'prop': compute_properties,

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -12,9 +12,9 @@ from oqp.utils.mpi_utils import MPIManager
 
 SUPPORTED_RUNTYPES = {
     "energy", "grad", "hess", "nac", "nacme", "bp", "optimize",
-    "meci", "mecp", "mep", "ts", "irc", "prop", "data",
+    "meci", "mecp", "mep", "ts", "irc", "neb", "prop", "data",
 }
-NOT_AVAILABLE_RUNTYPES = {"soc", "neb", "md"}
+NOT_AVAILABLE_RUNTYPES = {"soc", "md"}
 ALL_RUNTYPES = SUPPORTED_RUNTYPES | NOT_AVAILABLE_RUNTYPES
 DFTB_SUPPORTED_RUNTYPES = {"energy", "grad", "optimize"}
 DFTB_UNSUPPORTED_REASONS = {
@@ -52,7 +52,7 @@ DLFIND_MECI_IMS = {1, 2, 3}
 INIT_SCF_TYPES = {"no", "rhf", "uhf", "rohf", "rks", "uks", "roks"}
 
 WIKI_HELP = {
-    "input.runtype": "Use energy, grad, hess, nac, nacme, optimize, meci, mecp, mep, ts, prop, or data. soc and neb are recognized but not implemented yet.",
+    "input.runtype": "Use energy, grad, hess, nac, nacme, optimize, meci, mecp, mep, ts, irc, neb, prop, or data. soc and md are recognized but not implemented yet.",
     "input.method": "Use method=hf for HF/DFT, method=tdhf for TDHF/TDDFT/SF/MRSF, or method=dftb for the optional external DFTB+ backend.",
     "input.system": "Set system to an XYZ file path or inline coordinates with one atom per indented line.",
     "input.basis": "Set basis to a basis name, a comma-separated per-atom list, or library with tagged atoms and [input] library mappings.",
@@ -751,8 +751,11 @@ def _check_runtype(config: dict[str, Any], report: CheckReport) -> None:
                 action="Use grad=1,2,... for excited-state gradients.",
             )
 
-    if runtype in {"optimize", "meci", "mecp", "mep", "ts", "irc"}:
+    if runtype in {"optimize", "meci", "mecp", "mep", "ts", "irc", "neb"}:
         _check_optimize(config, report)
+
+    if runtype == "neb":
+        _check_neb(config, report)
 
     if runtype in {"nac", "bp"}:
         _check_nac(config, report)
@@ -910,14 +913,78 @@ def _check_optimize(config: dict[str, Any], report: CheckReport) -> None:
             action="Switch to lib=scipy or choose a DL-FIND-supported runtype.",
         )
 
-    if lib == "geometric" and runtype not in {"optimize", "meci", "mecp", "ts", "irc"}:
+    if runtype == "neb" and lib != "geometric":
         report.add(
             "ERROR",
             "optimize.lib",
-            "geomeTRIC is currently connected only to state-specific geometry optimization, MECI, MECP, TS, and IRC.",
+            "NEB is currently wired only through geomeTRIC.",
+            value=lib,
+            expected="geometric",
+            action="Set [optimize] lib=geometric for runtype=neb.",
+        )
+
+    if lib == "geometric" and runtype not in {"optimize", "meci", "mecp", "ts", "irc", "neb"}:
+        report.add(
+            "ERROR",
+            "optimize.lib",
+            "geomeTRIC is currently connected only to state-specific geometry optimization, MECI, MECP, TS, IRC, and NEB.",
             value=f"{lib}/{runtype}",
-            expected="optimize, meci, mecp, ts, or irc",
-            action="Use [input] runtype=optimize/meci/mecp/ts/irc or choose scipy/dlfind for this runtype.",
+            expected="optimize, meci, mecp, ts, irc, or neb",
+            action="Use [input] runtype=optimize/meci/mecp/ts/irc/neb or choose scipy/dlfind for this runtype.",
+        )
+
+
+def _check_neb(config: dict[str, Any], report: CheckReport) -> None:
+    method = _as_lower(_get(config, "input", "method", "hf"))
+    istate = _get(config, "optimize", "istate", 0)
+    product = _get(config, "neb", "product", "")
+    nimage = _get(config, "neb", "nimage", 5)
+
+    if method == "hf" and istate != 0:
+        report.add(
+            "ERROR",
+            "optimize.istate",
+            "HF/DFT NEB currently supports only the ground state.",
+            value=istate,
+            expected="0",
+            action="Set [optimize] istate=0 or wait for TDHF/MRSF NEB support.",
+        )
+
+    if method == "tdhf":
+        report.add(
+            "ERROR",
+            "input.method",
+            "TDHF/MRSF NEB is not wired in the first NEB scope.",
+            value=method,
+            expected="hf for the first NEB implementation scope",
+            action="Use method=hf with optimize.istate=0 for the initial geomeTRIC NEB scaffold.",
+        )
+
+    if not product:
+        report.add(
+            "ERROR",
+            "neb.product",
+            "NEB product endpoint is missing.",
+            expected="XYZ filename",
+            action="Set [neb] product to a product-endpoint XYZ file.",
+        )
+    elif not os.path.exists(os.path.abspath(str(product))):
+        report.add(
+            "ERROR",
+            "neb.product",
+            "NEB product endpoint file does not exist.",
+            value=product,
+            action="Fix the product path or place the XYZ file in the working directory.",
+        )
+
+    if nimage < 3:
+        report.add(
+            "ERROR",
+            "neb.nimage",
+            "NEB requires at least reactant, one intermediate, and product images.",
+            value=nimage,
+            expected=">= 3",
+            action="Set [neb] nimage=3 or larger.",
         )
 
 

--- a/tests/test_neb_dispatch.py
+++ b/tests/test_neb_dispatch.py
@@ -1,0 +1,72 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, relative_path):
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def install_geometric_stubs():
+    sys.modules.setdefault("oqp", types.ModuleType("oqp"))
+    sys.modules.setdefault("oqp.library", types.ModuleType("oqp.library"))
+    libscipy = types.ModuleType("oqp.library.libscipy")
+    libscipy.MECIOpt = object
+    libscipy.MECPOpt = object
+    libscipy.StateSpecificOpt = object
+    sys.modules["oqp.library.libscipy"] = libscipy
+    sys.modules.setdefault("oqp.utils", types.ModuleType("oqp.utils"))
+    file_utils = types.ModuleType("oqp.utils.file_utils")
+    file_utils.dump_log = lambda *args, **kwargs: None
+    sys.modules["oqp.utils.file_utils"] = file_utils
+
+
+class FakeMol:
+    def __init__(self, log_path):
+        self.log_path = str(log_path)
+        self.config = {
+            "neb": {"product": "product.xyz", "nimage": 4},
+            "geometric": {"prefix": "neb-test"},
+        }
+
+
+class TestNEBDispatchScaffold(unittest.TestCase):
+    def setUp(self):
+        install_geometric_stubs()
+
+    def test_geometric_neb_scaffold_plans_isolated_image_directories(self):
+        libgeometric = load_module(
+            "libgeometric_neb_scaffold_under_test",
+            "pyoqp/oqp/library/libgeometric.py",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            optimizer = libgeometric.GeometricNEBOpt(FakeMol(tmpdir))
+            image_dirs = optimizer.plan_image_directories()
+
+        self.assertEqual(
+            [Path(path).name for path in image_dirs],
+            ["image_000", "image_001", "image_002", "image_003"],
+        )
+        self.assertTrue(all(str(Path(tmpdir) / "neb") in path for path in image_dirs))
+
+    def test_dispatch_maps_geometric_neb_to_scaffold(self):
+        runfunc_text = (ROOT / "pyoqp/oqp/library/runfunc.py").read_text()
+        pyoqp_text = (ROOT / "pyoqp/oqp/pyoqp.py").read_text()
+
+        self.assertIn("GeometricNEBOpt", runfunc_text)
+        self.assertIn("'neb': GeometricNEBOpt", runfunc_text)
+        self.assertIn("'neb': compute_geom", pyoqp_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_neb_input.py
+++ b/tests/test_neb_input.py
@@ -1,0 +1,101 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, relative_path):
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def install_minimal_oqp_stubs():
+    sys.modules.setdefault("oqp", types.ModuleType("oqp"))
+    sys.modules.setdefault("oqp.utils", types.ModuleType("oqp.utils"))
+    mpi_utils = types.ModuleType("oqp.utils.mpi_utils")
+
+    class MPIManager:
+        size = 1
+        use_mpi = False
+
+    mpi_utils.MPIManager = MPIManager
+    sys.modules["oqp.utils.mpi_utils"] = mpi_utils
+
+
+class TestNEBInputSchema(unittest.TestCase):
+    def setUp(self):
+        install_minimal_oqp_stubs()
+
+    def test_neb_config_schema_defines_product_and_image_count(self):
+        text = (ROOT / "pyoqp/oqp/molecule/oqpdata.py").read_text()
+
+        self.assertIn("'neb': {", text)
+        self.assertIn("'product': {'type': str, 'default': ''}", text)
+        self.assertIn("'nimage': {'type': int, 'default': '5'}", text)
+
+    def test_full_input_checker_accepts_hf_s0_geometric_neb(self):
+        input_checker = load_module(
+            "input_checker_neb_valid_under_test",
+            "pyoqp/oqp/utils/input_checker.py",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            product = Path(tmpdir) / "product.xyz"
+            product.write_text("2\nproduct\nH 0.0 0.0 0.0\nH 0.0 0.0 1.0\n")
+            config = {
+                "input": {
+                    "runtype": "neb",
+                    "method": "hf",
+                    "basis": "3-21g",
+                    "system": "\nH 0.0 0.0 0.0\nH 0.0 0.0 0.7",
+                },
+                "guess": {},
+                "scf": {"type": "rhf", "multiplicity": 1},
+                "tdhf": {},
+                "properties": {},
+                "optimize": {"lib": "geometric", "istate": 0},
+                "neb": {"product": str(product), "nimage": 3},
+            }
+
+            report = input_checker.check_input_values(config, raise_error=False, emit=False)
+
+        self.assertTrue(report.ok, report.to_text())
+
+    def test_neb_requires_geometric_optimizer_product_and_three_images(self):
+        input_checker = load_module(
+            "input_checker_neb_invalid_under_test",
+            "pyoqp/oqp/utils/input_checker.py",
+        )
+        config = {
+            "input": {
+                "runtype": "neb",
+                "method": "hf",
+                "basis": "3-21g",
+                "system": "\nH 0.0 0.0 0.0\nH 0.0 0.0 0.7",
+            },
+            "guess": {},
+            "scf": {"type": "rhf", "multiplicity": 1},
+            "tdhf": {},
+            "properties": {},
+            "optimize": {"lib": "scipy", "istate": 0},
+            "neb": {"product": "", "nimage": 2},
+        }
+
+        report = input_checker.check_input_values(config, raise_error=False, emit=False)
+        text = report.to_text()
+
+        self.assertFalse(report.ok)
+        self.assertIn("optimize.lib", text)
+        self.assertIn("neb.product", text)
+        self.assertIn("neb.nimage", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_neb_utils.py
+++ b/tests/test_neb_utils.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, relative_path):
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestNEBEndpointInterpolation(unittest.TestCase):
+    def setUp(self):
+        self.neb_utils = load_module(
+            "neb_utils_under_test",
+            "pyoqp/oqp/library/neb_utils.py",
+        )
+
+    def test_interpolate_preserves_endpoints_and_linearly_spaces_images(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reactant = Path(tmpdir) / "reactant.xyz"
+            product = Path(tmpdir) / "product.xyz"
+            reactant.write_text(
+                "2\nreactant\nH 0.0 0.0 0.0\nH 0.0 0.0 1.0\n"
+            )
+            product.write_text(
+                "2\nproduct\nH 0.0 0.0 0.2\nH 0.0 0.0 1.4\n"
+            )
+
+            images = self.neb_utils.interpolate_xyz_endpoints(
+                reactant,
+                product,
+                nimage=3,
+            )
+
+        self.assertEqual([image.symbols for image in images], [["H", "H"]] * 3)
+        self.assertEqual(images[0].coordinates_angstrom, [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        self.assertEqual(images[1].coordinates_angstrom, [[0.0, 0.0, 0.1], [0.0, 0.0, 1.2]])
+        self.assertEqual(images[2].coordinates_angstrom, [[0.0, 0.0, 0.2], [0.0, 0.0, 1.4]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds narrow geomeTRIC-backed `runtype=neb` schema/input validation for HF/DFT S0 first scope.
- Adds dependency-light NEB endpoint interpolation helpers.
- Adds dispatch scaffold and isolated per-image directory planning for future geomeTRIC NEB runner wiring.

## Validation
- `python3 -m unittest tests.test_neb_input tests.test_neb_utils tests.test_neb_dispatch -v`

## Current scope / blockers
- geomeTRIC is not installed in the current autopilot environment, so runtime NEB API wiring and OpenQP smoke validation are pending.
- `GeometricNEBOpt.optimize()` currently raises a clear `NotImplementedError` until Phase 4 runner wiring is implemented.
- Out of scope: DFTB+ NEB, MPI image farming, MECI/MECP-as-NEB, and broad MRSF production claims.
