### PR TITLE
Enable automatic Claude PR reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 name: Claude
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -11,6 +13,31 @@ on:
     types: [submitted]
 
 jobs:
+  claude-pr-review:
+    name: Claude automatic PR review
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude PR Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request. Be concise and actionable. Do not modify files.
+            Leave a non-blocking review comment with blocking issues, important suggestions,
+            and tests that should be run. If no blocking issues are found, say so clearly.
+
   claude-mention:
     name: Claude mention handler
     if: |


### PR DESCRIPTION
## Summary
- restore the `pull_request` trigger for the Claude workflow
- add a `Claude automatic PR review` job for opened/synchronized/reopened/ready-for-review PRs
- grant job-level `id-token: write` so the Claude GitHub App token exchange can work

## Verification
- inspected upstream `claude.yml` on `main`: mention handler existed, automatic PR review path was missing
- confirmed `CLAUDE_CODE_OAUTH_TOKEN` repository secret exists
- reviewed the last failed automatic review run; it failed during OIDC token fetch
