### PR TITLE
ci: enable automatic Claude PR reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 name: Claude
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -11,6 +13,30 @@ on:
     types: [submitted]
 
 jobs:
+  claude-pr-review:
+    name: Claude automatic PR review
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code Action Official
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request. Be concise and actionable. Do not modify files;
+            leave a review comment with blocking issues, important suggestions, and tests to run.
+
   claude-mention:
     name: Claude mention handler
     if: |


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger to the existing Claude workflow.
- Adds a non-mutating automatic Claude PR review job for opened, synchronized, reopened, and ready-for-review PRs.
- Keeps the existing `@claude` mention handler unchanged.

## Verification
- Confirmed upstream repo admin permission and `workflow` token scope.
- Confirmed `CLAUDE_CODE_OAUTH_TOKEN` secret exists (name only; value not read).
- Parsed `.github/workflows/claude.yml` locally with PyYAML.
