### PR TITLE
fix: dangling ECP CFFI buffers corrupt nuclear repulsion for large systems

### DIFF
--- a/pyoqp/oqp/library/set_basis.py
+++ b/pyoqp/oqp/library/set_basis.py
@@ -194,8 +194,14 @@ class BasisData:
         self.mol.data["ecp_rex"] = ffi.cast("int*", ffi.from_buffer(r_expo_array))
 
         coord_array = np.array(self.ecp["coord"], dtype=np.float64)
-        self.mol.data["ecp_am"] = ffi.cast("int*", ffi.from_buffer(np.array(self.ecp["ang"], dtype=np.float64)))
-        self.mol.data["ecp_zn"] = ffi.cast("int*", ffi.from_buffer(np.array(self.ecp["ecp_electron"], dtype=np.int32)))
+        # Keep the numpy arrays alive in named variables until append_ecp has
+        # consumed them: ffi.from_buffer does not hold a reference, so passing
+        # a temporary leaves mol.data with a dangling pointer (garbage
+        # ecp_zn_num -> garbage nuclear repulsion for large systems).
+        ecp_am_array = np.array(self.ecp["ang"], dtype=np.float64)
+        ecp_zn_array = np.array(self.ecp["ecp_electron"], dtype=np.int32)
+        self.mol.data["ecp_am"] = ffi.cast("int*", ffi.from_buffer(ecp_am_array))
+        self.mol.data["ecp_zn"] = ffi.cast("int*", ffi.from_buffer(ecp_zn_array))
         self.mol.data["ecp_coord"] = ffi.cast("double*", ffi.from_buffer(coord_array))
 
         oqp.append_ecp(self.mol)

--- a/tests/test_set_basis_ecp_buffer_lifetime.py
+++ b/tests/test_set_basis_ecp_buffer_lifetime.py
@@ -1,0 +1,71 @@
+"""Regression tests for the dangling ecp_zn/ecp_am CFFI buffers (1BNA bug).
+
+set_ecp_data() used to build the ecp_zn/ecp_am pointers from temporary numpy
+arrays: ``ffi.cast("int*", ffi.from_buffer(np.array(...)))``.  ffi.from_buffer
+does not keep the array alive, so the buffer was freed before
+``oqp.append_ecp`` copied it in Fortran.  For large systems (758 atoms in the
+1BNA benchmark) the freed block was reused, ecp_zn_num filled with garbage,
+and the nuclear repulsion energy ``e_charge_repulsion(xyz, zn - ecp_zn_num)``
+became a huge constant — SCF energies printed as ``*****`` from iteration 1
+while DIIS still converged.  Introduced by commit d1398dfe (ECP, 2025-02-18).
+"""
+
+import gc
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SET_BASIS = ROOT / "pyoqp" / "oqp" / "library" / "set_basis.py"
+
+
+def test_no_inline_temporary_buffers_in_set_basis():
+    """ffi.from_buffer(np.array(...)) hands CFFI a temporary — forbidden."""
+    source = SET_BASIS.read_text()
+    assert "ffi.from_buffer(np.array(" not in source
+
+
+def test_append_ecp_sees_live_ecp_zn_buffer(monkeypatch):
+    """ecp_zn data must still be intact when append_ecp reads it."""
+    oqp = pytest.importorskip("oqp")
+    from oqp import ffi
+    from oqp.library.set_basis import BasisData
+
+    natom = 758
+    captured = {}
+
+    def fake_append_ecp(mol):
+        # Emulate allocator reuse of any freed temporary before the Fortran
+        # side would copy the buffer.
+        gc.collect()
+        churn = [np.full(natom, 7, dtype=np.int32) for _ in range(64)]
+        buf = ffi.buffer(mol.data["ecp_zn"], natom * 4)
+        captured["ecp_zn"] = np.frombuffer(bytes(buf), dtype=np.int32).copy()
+        del churn
+
+    monkeypatch.setattr(oqp, "append_ecp", fake_append_ecp)
+
+    class FakeMol:
+        data = {}
+
+    basis_data = object.__new__(BasisData)
+    basis_data.mol = FakeMol()
+    basis_data.use_ecp = False
+    basis_data.ecp = {
+        "ang": [],
+        "r_expo": [],
+        "g_expo": [],
+        "coef": [],
+        "coord": [],
+        "element_id": 0,
+        "ecp_electron": [0] * natom,
+        "num_expo": [],
+    }
+
+    basis_data.set_ecp_data()
+
+    assert captured["ecp_zn"].shape == (natom,)
+    # No ECP: every entry must be exactly zero, not recycled-heap garbage.
+    assert np.all(captured["ecp_zn"] == 0)


### PR DESCRIPTION
## Summary

Fixes a use-after-free in the Python→Fortran ECP interface that has silently corrupted the nuclear repulsion energy for large systems since the ECP commit (d1398dfe, Feb 2025).

`set_ecp_data()` built the `ecp_zn`/`ecp_am` C pointers from **temporary** numpy arrays:

```python
self.mol.data["ecp_zn"] = ffi.cast("int*", ffi.from_buffer(np.array(self.ecp["ecp_electron"], dtype=np.int32)))
```

`ffi.from_buffer` does not hold a reference to its argument, so the temporary is freed as soon as the statement ends and `mol.data` is left with a dangling pointer. `oqp_append_ecp` (basis_api.F90) is called unconditionally — even with no ECP — and copies `natom` integers from that pointer *before* the `element_id == 0` early return. The garbage propagates to `basis%ecp_zn_num`, and the SCF driver computes the nuclear repulsion from `zn - ecp_zn_num`, turning the total energy into a huge garbage constant while the Fock/density/DIIS path stays correct.

Small systems survived by luck (the tiny freed block was rarely reused). Large systems failed deterministically — e.g. the 1BNA benchmark (758 atoms, RHF/STO-3G, 2790 AOs, charge −22):

```
 Iter         Energy            Delta E         Int Skip     DIIS Error
    1  ***************** ***************** 1237063183430 **************
    2  ***************** ***************** 1237024131088     0.41034169
```

The neighbouring arrays (`n_expo_array`, `expo_array`, `coef_array`, `r_expo_array`, `coord_array`) were already bound to named locals; `ecp_am`/`ecp_zn` now follow the same pattern.

## Verification

- 1BNA RHF/STO-3G iteration 1 restored to `-31414.4194501916` (DIIS `0.71894225`), matching the pre-ECP reference log (`-31414.4194501924` / `0.71894225`) to 12 significant figures.
- H2O RHF/STO-3G smoke unchanged: `-74.9631468000`.
- New regression test monkeypatches `oqp.append_ecp`, churns the heap, and reads the buffer back: on the unfixed code it reads recycled heap (the churn fill value) instead of the ECP electron counts; with the fix it reads the correct values. A source-level check also bans the `ffi.from_buffer(np.array(` pattern in set_basis.py.

```
tests/test_set_basis_ecp_buffer_lifetime.py  2 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
