### PR TITLE
Hessian follow-ups from #177: ECP buffer leak, 64-bit sizes, open-shell Raman dispatch

### DIFF
--- a/source/ecp.F90
+++ b/source/ecp.F90
@@ -5,7 +5,7 @@
 !> @author Mohsen Mazaherifar
 !> @date January 2025
 module ecp_tool
-    use iso_c_binding, only: c_double, c_ptr, c_int,&
+    use iso_c_binding, only: c_double, c_ptr, c_int, c_int64_t,&
             c_f_pointer, C_LOC, c_null_ptr
     use, intrinsic :: iso_fortran_env, only: real64
     use libecpint_wrapper
@@ -63,12 +63,14 @@ contains
             end do
         end do
 
+        ! free the C-side buffer BEFORE nulling the local handle: free_result
+        ! takes the struct by value, so nulling first would leak the buffer
+        call free_result(result_ptr)
         result_ptr%data = c_null_ptr
         result_ptr%size = 0
         nullify(libecp_res)
 
         call free_integrator(integrator)
-        call free_result(result_ptr)
 
     end subroutine add_ecpint
 
@@ -97,7 +99,9 @@ contains
         real(real64), allocatable :: res_x(:), res_y(:), res_z(:)
         real(real64), allocatable :: deloc(:,:)
         integer :: i, j, c, n, natm, prim
-        integer :: tri_size, full_size
+        integer :: tri_size
+        ! 64-bit: slice offsets reach 3*natm*nbf^2 and overflow default integers
+        integer(c_int64_t) :: full_size
         integer(c_int) :: driv_order
 
         if (.not.(basis%ecp_params%is_ecp)) then
@@ -107,7 +111,7 @@ contains
         driv_order = 1
 
         tri_size = basis%nbf * (basis%nbf + 1) / 2
-        full_size = basis%nbf * basis%nbf
+        full_size = int(basis%nbf, c_int64_t) * basis%nbf
 
         allocate(res_x(full_size))
         allocate(res_y(full_size))
@@ -153,12 +157,13 @@ contains
 
         de(:, 1:natm) = de(:, 1:natm) + deloc(:, 1:natm)
 
+        ! free the C-side buffer BEFORE nulling the local handle (see add_ecpint)
+        call free_result(result_ptr)
         result_ptr%data = c_null_ptr
         result_ptr%size = 0
         nullify(libecp_res)
 
         call free_integrator(integrator)
-        call free_result(result_ptr)
 
     end subroutine add_ecpder
 
@@ -188,7 +193,9 @@ contains
         type(c_ptr) :: integrator
         real(c_double), pointer :: libecp_res(:)
         real(real64), allocatable :: res_c(:)
-        integer :: nbf, full_size, natm, n, cc, i, j
+        integer :: nbf, natm, n, cc, i, j
+        ! 64-bit: slice offsets reach 3*natm*nbf^2 and overflow default integers
+        integer(c_int64_t) :: full_size
         integer(c_int) :: driv_order
 
         dVecp = 0.0_dp
@@ -198,7 +205,7 @@ contains
 
         driv_order = 1
         nbf = basis%nbf
-        full_size = nbf * nbf
+        full_size = int(nbf, c_int64_t) * nbf
         natm = size(coord, dim=2)
         allocate(res_c(full_size))
 
@@ -220,12 +227,13 @@ contains
             end do
         end do
 
+        ! free the C-side buffer BEFORE nulling the local handle (see add_ecpint)
+        call free_result(result_ptr)
         result_ptr%data = c_null_ptr
         result_ptr%size = 0
         nullify(libecp_res)
 
         call free_integrator(integrator)
-        call free_result(result_ptr)
         deallocate(res_c)
 
     end subroutine ecp_deriv_ints
@@ -262,9 +270,11 @@ contains
         type(c_ptr) :: integrator
         real(c_double), pointer :: libecp_res(:)
         real(real64), allocatable :: blk(:)
-        integer :: nbf, mat_sz, natm
+        integer :: nbf, natm
         integer :: iat, jat, ia0, ja0, hstart, base, ncomp, n
         integer :: a, b, i, j, c, prim
+        ! 64-bit: block offsets reach 3N(3N+1)/2 * nbf^2 and overflow default integers
+        integer(c_int64_t) :: mat_sz
         integer(c_int) :: driv_order
         integer :: amap(9), bmap(9)
         real(real64) :: val
@@ -275,7 +285,7 @@ contains
 
         driv_order = 2
         nbf = basis%nbf
-        mat_sz = nbf * nbf
+        mat_sz = int(nbf, c_int64_t) * nbf
         natm = size(coord, dim=2)
         allocate(blk(mat_sz))
 
@@ -332,12 +342,13 @@ contains
             end do
         end do
 
+        ! free the C-side buffer BEFORE nulling the local handle (see add_ecpint)
+        call free_result(result_ptr)
         result_ptr%data = c_null_ptr
         result_ptr%size = 0
         nullify(libecp_res)
 
         call free_integrator(integrator)
-        call free_result(result_ptr)
         deallocate(blk)
 
     end subroutine add_ecphess

--- a/source/ecpint.F90
+++ b/source/ecpint.F90
@@ -4,7 +4,10 @@ module libecp_result
 
     type, bind(c) :: ecp_result
         type(c_ptr) :: data
-        integer(c_int) :: size
+        ! 64-bit: the second-derivative payload is 3N(3N+1)/2 * nbf^2 doubles,
+        ! which overflows a 32-bit count already around ~50 atoms / 500 basis
+        ! functions. (Mirrors int64_t in source/wrapper/libecpint_wrapper.cpp.)
+        integer(c_int64_t) :: size
     end type ecp_result
 end module libecp_result
 

--- a/source/modules/cphf.F90
+++ b/source/modules/cphf.F90
@@ -104,6 +104,8 @@ module cphf_mod
   public :: rohf_pack_trial, rohf_unpack_trial
   public :: cphf_static_polarizability
   public :: cphf_static_polarizability_C
+  public :: cphf_uhf_static_polarizability
+  public :: cphf_rohf_static_polarizability
   public :: cphf_polarizability_selftest
   public :: cphf_polarizability_selftest_C
   public :: cphf_uhf_polarizability_selftest
@@ -175,7 +177,9 @@ contains
         pxm(j,i) = mo_energy_a(nocc+i) - mo_energy_a(j)
       end do
     end do
-    xminv = 1.0_dp/xm
+    ! clamp near-degenerate occ-vir gaps so the diagonal preconditioner
+    ! stays finite (same guard as the ROHF solver)
+    xminv = 1.0_dp/sign(max(abs(xm), 1.0d-8), xm)
 
     scale_exch = 1.0_dp
     if (dft) scale_exch = infos%dft%HFscale
@@ -316,7 +320,17 @@ contains
     real(c_double), intent(out) :: alpha(3,3)
     type(information), pointer :: inf
     inf => oqp_handle_get_info(c_handle)
-    call cphf_static_polarizability(inf, alpha)
+    ! Dispatch on the SCF reference so every caller (in particular the
+    ! vibrational Raman-activity path) gets the correct response kernel:
+    ! 1 = RHF/RKS, 2 = UHF/UKS, 3 = ROHF/ROKS.
+    select case (inf%control%scftype)
+    case (2)
+      call cphf_uhf_static_polarizability(inf, alpha)
+    case (3)
+      call cphf_rohf_static_polarizability(inf, alpha)
+    case default
+      call cphf_static_polarizability(inf, alpha)
+    end select
   end subroutine cphf_static_polarizability_C
 
 !> @brief Compute native closed-shell static dipole polarizability.
@@ -491,7 +505,9 @@ contains
         end do
       end do
     end if
-    xminv = 1.0_dp/xm
+    ! clamp near-degenerate occ-vir gaps so the diagonal preconditioner
+    ! stays finite (same guard as the ROHF solver)
+    xminv = 1.0_dp/sign(max(abs(xm), 1.0d-8), xm)
 
     scale_exch = 1.0_dp
     if (dft) scale_exch = infos%dft%HFscale
@@ -620,26 +636,26 @@ contains
     call cphf_uhf_polarizability_selftest(inf)
   end subroutine cphf_uhf_polarizability_selftest_C
 
-!> @brief Validate the open-shell CPHF solver via the static dipole
-!>   polarizability.  Built per spin: B^sigma_ia = -<i|q|a>^sigma, solve
+!> @brief Compute the native open-shell (UHF) static dipole polarizability.
+!>   Built per spin: B^sigma_ia = -<i|q|a>^sigma, solve
 !>   M U^q = B^q, and alpha_pq = -2 sum_sigma sum_ia mu^p,sigma_ia U^q,sigma_ia.
 !>   For a closed-shell system run as UHF (multiplicity 1) the tensor must equal
 !>   the closed-shell (RHF) cphf_static_polarizability, which is the unambiguous
-!>   correctness check for the spin coupling and normalization.  Written to
-!>   /tmp/cphf_uhf_polar.out.
-  subroutine cphf_uhf_polarizability_selftest(infos)
+!>   correctness check for the spin coupling and normalization.
+  subroutine cphf_uhf_static_polarizability(infos, alpha)
     use oqp_tagarray_driver, only: tagarray_get_data, OQP_VEC_MO_A, OQP_VEC_MO_B
     use int1, only: multipole_integrals
     use mathlib, only: unpack_matrix
     type(information), target, intent(inout) :: infos
+    real(kind=dp), intent(out) :: alpha(3,3)
 
     type(basis_set), pointer :: basis
     real(kind=dp), contiguous, pointer :: moa(:,:), mob(:,:)
     real(kind=dp), allocatable :: mints(:,:), dipfull(:,:), dmo(:,:), scr(:,:)
     real(kind=dp), allocatable :: bvec(:,:), uvec(:,:), mua(:,:), mub(:,:)
-    real(kind=dp) :: origin(3), alpha(3,3)
+    real(kind=dp) :: origin(3)
     integer :: nbf, nbf2, nocca, noccb, nvira, nvirb, la, lb, ltot
-    integer :: q, i, a, ia, pq, uu
+    integer :: q, i, a, ia, pq
 
     basis => infos%basis
     basis%atoms => infos%atoms
@@ -700,6 +716,19 @@ contains
       end do
     end do
 
+    deallocate(mints, dipfull, dmo, scr, bvec, uvec, mua, mub)
+  end subroutine cphf_uhf_static_polarizability
+
+!> @brief Validate the open-shell (UHF) CPHF solver via the static dipole
+!>   polarizability.  Written to /tmp/cphf_uhf_polar.out.
+  subroutine cphf_uhf_polarizability_selftest(infos)
+    type(information), target, intent(inout) :: infos
+
+    real(kind=dp) :: alpha(3,3)
+    integer :: i, uu
+
+    call cphf_uhf_static_polarizability(infos, alpha)
+
     open(newunit=uu, file='/tmp/cphf_uhf_polar.out', status='replace', action='write')
     write(uu,'(a)') 'open-shell (UHF) CPHF static dipole polarizability (a.u.):'
     do i = 1, 3
@@ -707,8 +736,6 @@ contains
     end do
     write(uu,'(a,f16.8)') 'isotropic = ', (alpha(1,1)+alpha(2,2)+alpha(3,3))/3.0_dp
     close(uu)
-
-    deallocate(mints, dipfull, dmo, scr, bvec, uvec, mua, mub)
   end subroutine cphf_uhf_polarizability_selftest
 
 !###############################################################################
@@ -1029,26 +1056,26 @@ contains
     call cphf_rohf_polarizability_selftest(inf)
   end subroutine cphf_rohf_polarizability_selftest_C
 
-!> @brief Validate the ROHF CPHF solver via the static dipole polarizability.
+!> @brief Compute the native ROHF static dipole polarizability.
 !>   For a closed-shell molecule run as ROHF (multiplicity 1, offset=0) the
 !>   rotation space reduces to the virt-docc block and the ROHF orbital Hessian
 !>   reduces to (twice) the RHF one; the resulting static polarizability must
 !>   equal the validated closed-shell cphf_static_polarizability.  This is the
 !>   unambiguous check for the solver plumbing, the operator and the packing.
-!>   Written to /tmp/cphf_rohf_polar.out.
-  subroutine cphf_rohf_polarizability_selftest(infos)
+  subroutine cphf_rohf_static_polarizability(infos, alpha)
     use oqp_tagarray_driver, only: tagarray_get_data, OQP_VEC_MO_A
     use int1, only: multipole_integrals
     use mathlib, only: unpack_matrix
     type(information), target, intent(inout) :: infos
+    real(kind=dp), intent(out) :: alpha(3,3)
 
     type(basis_set), pointer :: basis
     real(kind=dp), contiguous, pointer :: mo(:,:)
     real(kind=dp), allocatable :: mints(:,:), dipfull(:,:), dmo(:,:), scr(:,:)
     real(kind=dp), allocatable :: xa(:,:), xb(:,:), bvec(:,:), uvec(:,:)
-    real(kind=dp) :: origin(3), alpha(3,3)
+    real(kind=dp) :: origin(3)
     integer :: nbf, nbf2, nocca, noccb, nvira, nvirb, offset, ltot
-    integer :: q, pq, i, a, uu
+    integer :: q, pq, i, a
 
     basis => infos%basis
     basis%atoms => infos%atoms
@@ -1099,6 +1126,19 @@ contains
       end do
     end do
 
+    deallocate(mints, dipfull, dmo, scr, xa, xb, bvec, uvec)
+  end subroutine cphf_rohf_static_polarizability
+
+!> @brief Validate the ROHF CPHF solver via the static dipole polarizability.
+!>   Written to /tmp/cphf_rohf_polar.out.
+  subroutine cphf_rohf_polarizability_selftest(infos)
+    type(information), target, intent(inout) :: infos
+
+    real(kind=dp) :: alpha(3,3)
+    integer :: i, uu
+
+    call cphf_rohf_static_polarizability(infos, alpha)
+
     open(newunit=uu, file='/tmp/cphf_rohf_polar.out', status='replace', action='write')
     write(uu,'(a)') 'open-shell (ROHF) CPHF static dipole polarizability (a.u.):'
     do i = 1, 3
@@ -1106,8 +1146,6 @@ contains
     end do
     write(uu,'(a,f16.8)') 'isotropic = ', (alpha(1,1)+alpha(2,2)+alpha(3,3))/3.0_dp
     close(uu)
-
-    deallocate(mints, dipfull, dmo, scr, xa, xb, bvec, uvec)
   end subroutine cphf_rohf_polarizability_selftest
 
 end module cphf_mod

--- a/source/modules/hf_hessian.F90
+++ b/source/modules/hf_hessian.F90
@@ -1203,6 +1203,14 @@ contains
           end if
         end do
       end do
+      ! Every ECP centre must have been matched to an atom: an unmapped centre
+      ! would stay fixed while its atom is displaced, silently corrupting the
+      ! semi-numerical response. Abort loudly instead.
+      if (count(iecp_atom > 0) /= nec) then
+        call show_message('hf_hessian (ROHF): could not map every ECP centre '// &
+          'to an atom (coordinate mismatch > 1e-6 bohr); analytic Hessian '// &
+          'would be wrong - use [hess] type=numerical for this system.', WITH_ABORT)
+      end if
     end if
 
     ! derivative integrals (normalized into the bfnrm/MO convention)

--- a/source/modules/hf_hessian.F90
+++ b/source/modules/hf_hessian.F90
@@ -1126,6 +1126,7 @@ contains
     use scf_addons, only: fock_jk
     use cphf_mod, only: cphf_solve_rohf, rohf_pack_trial, rohf_unpack_trial
     use io_constants, only: iw
+    use messages, only: show_message, WITH_ABORT
 
     implicit none
 

--- a/source/wrapper/libecpint_wrapper.cpp
+++ b/source/wrapper/libecpint_wrapper.cpp
@@ -9,12 +9,16 @@
 #include <iostream>
 #include <memory>
 #include <iomanip>
+#include <cstdint>
 
 extern "C" {
 
     typedef struct {
         double *data;
-        int size;
+        // 64-bit: the second-derivative payload is 3N(3N+1)/2 * nbf^2 doubles,
+        // which overflows a 32-bit count already around ~50 atoms / 500 basis
+        // functions. (Mirrored by integer(c_int64_t) in source/ecpint.F90.)
+        int64_t size;
     } ResultArray;
 
     // Initialize integrator and set Gaussian basis
@@ -60,18 +64,18 @@ extern "C" {
         factory->compute_first_derivs();
         std::vector<std::shared_ptr<std::vector<double>>> first_derivs = factory->get_first_derivs();
 
-        int total_size = 0;
+        int64_t total_size = 0;
         for (const auto& vec : first_derivs) {
-            total_size += vec->size();
+            total_size += static_cast<int64_t>(vec->size());
         }
 
         ResultArray result;
         result.size = total_size;
         result.data = new double[total_size];
-        int index = 0;
+        int64_t index = 0;
         for (const auto& vec : first_derivs) {
             std::copy(vec->begin(), vec->end(), result.data + index);
-            index += vec->size();
+            index += static_cast<int64_t>(vec->size());
         }
 
         return result;
@@ -83,18 +87,23 @@ extern "C" {
         factory->compute_second_derivs();
         std::vector<std::shared_ptr<std::vector<double>>> second_derivs = factory->get_second_derivs();
 
-        int total_size = 0;
+        // NOTE: libecpint already holds the full second-derivative set
+        // internally, and this wrapper copies it into one more concatenated
+        // buffer, so the peak footprint is ~2x the payload
+        // (3N(3N+1)/2 * nbf^2 doubles). A chunked per-component hand-off
+        // would halve that, but is constrained by the libecpint API.
+        int64_t total_size = 0;
         for (const auto& vec : second_derivs) {
-            total_size += vec->size();
+            total_size += static_cast<int64_t>(vec->size());
         }
 
         ResultArray result;
         result.size = total_size;
         result.data = new double[total_size];
-        int index = 0;
+        int64_t index = 0;
         for (const auto& vec : second_derivs) {
             std::copy(vec->begin(), vec->end(), result.data + index);
-            index += vec->size();
+            index += static_cast<int64_t>(vec->size());
         }
 
         return result;

--- a/tests/test_polarizability_dispatch.py
+++ b/tests/test_polarizability_dispatch.py
@@ -1,0 +1,85 @@
+"""Validate the SCF-type dispatch of the cphf_static_polarizability entry point.
+
+The C entry point cphf_static_polarizability (used by the vibrational
+Raman-activity path in single_point._compute_vibrational_intensities) must
+route to the matching CPHF response kernel for the converged reference:
+RHF/RKS -> closed-shell, UHF/UKS -> per-spin UHF, ROHF/ROKS -> single-MO ROHF.
+Previously it always ran the closed-shell kernel, silently producing wrong
+Raman activities for open-shell Hessian runs.
+
+Correctness check (no external reference needed): for a closed-shell molecule
+run as RHF, UHF (multiplicity 1) and ROHF (multiplicity 1), all three dispatched
+tensors must agree, and the open-shell routes must reproduce the validated
+closed-shell result.
+
+Skipped unless the compiled OpenQP runtime is importable.
+"""
+
+import os
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+
+INPUT_TMPL = """[input]
+system=
+   8   0.000000000   0.000000000  -0.041061554
+   1  -0.533194329   0.533194329  -0.614469223
+   1   0.533194329  -0.533194329  -0.614469223
+charge=0
+runtype=energy
+basis=6-31g
+method=hf
+[guess]
+type=huckel
+[scf]
+multiplicity=1
+type={scftype}
+"""
+
+
+def _runtime_available():
+    try:
+        os.environ.setdefault("OPENQP_ROOT", str(ROOT))
+        os.environ.setdefault("OMP_NUM_THREADS", "1")
+        import oqp  # noqa: F401
+        from oqp.pyoqp import Runner  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@unittest.skipUnless(_runtime_available(), "compiled OpenQP runtime not available")
+class PolarizabilityDispatch(unittest.TestCase):
+    def _alpha(self, scftype):
+        import oqp
+        from oqp.pyoqp import Runner
+
+        workdir = Path(f"/tmp/oqp_polar_dispatch_{scftype}")
+        workdir.mkdir(exist_ok=True)
+        inp = workdir / "h2o.inp"
+        inp.write_text(INPUT_TMPL.format(scftype=scftype))
+        runner = Runner(project=f"h2o_disp_{scftype}", input_file=str(inp),
+                        log=str(workdir / "h2o.log"))
+        runner.run()
+        alpha = np.zeros((3, 3), dtype=np.float64)
+        oqp.cphf_static_polarizability(
+            runner.mol, oqp.ffi.cast("double *", oqp.ffi.from_buffer(alpha)))
+        return alpha
+
+    def test_dispatch_matches_closed_shell(self):
+        a_rhf = self._alpha("rhf")
+        a_uhf = self._alpha("uhf")
+        a_rohf = self._alpha("rohf")
+        # sanity: a real, nonzero tensor
+        self.assertGreater(np.trace(a_rhf) / 3.0, 0.1)
+        np.testing.assert_allclose(a_uhf, a_rhf, atol=2.0e-4,
+                                   err_msg="UHF-dispatched polarizability != RHF")
+        np.testing.assert_allclose(a_rohf, a_rhf, atol=2.0e-4,
+                                   err_msg="ROHF-dispatched polarizability != RHF")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Five robustness/correctness follow-ups identified while validating the merged analytic-Hessian PR (#177). None change results for the cases #177 validated; they fix silent-failure and at-scale hazards.

| # | issue | fix |
|---|---|---|
| 1 | **ECP result-buffer leak** — all four libecpint call sites nulled `result_ptr%data` *before* `free_result` (struct passed by value), so `delete[]` always got null. Worst for the 2nd-derivative payload (`3N(3N+1)/2 × nbf²` doubles leaked per Hessian) | `free_result` first, then null (`source/ecp.F90`) |
| 2 | **32-bit size overflow** — the 2nd-derivative element count exceeds `INT_MAX` around ~50 atoms / 500 bf | `int64_t`/`integer(c_int64_t)` end to end: `ResultArray.size`, `ecp_result%size`, accumulators and Fortran slice offsets (`full_size`, `mat_sz`) |
| 3 | **Open-shell Raman activities silently wrong** — the vibrational-intensity path always called the closed-shell `cphf_static_polarizability`, even for UHF/ROHF Hessians | per-spin (UHF) and single-MO (ROHF) polarizability tensors extracted from their selftests into real kernels; the C entry point now dispatches on `scftype`, fixing every caller with no Python changes |
| 4 | **Silent ECP-centre mapping failure** (ROHF semi-numerical path) — an unmapped ECP centre would stay frozen while its atom is displaced → silently wrong Hessian | completeness check; aborts with a clear message |
| 5 | **CPHF preconditioner Inf/NaN** on exact occ-vir degeneracy (closed-shell + UHF solvers) | clamp `1/sign(max(|d|,1e-8),d)`, matching the ROHF solver |

## Tests

New `tests/test_polarizability_dispatch.py`: for closed-shell H₂O run as RHF, UHF and ROHF, the dispatched polarizability tensors must coincide — guards the scftype routing and both new kernels.

## Known remaining limitation (not addressed here)

The libecpint API materializes the full second-derivative set, and the wrapper concatenates a copy (~2× payload peak). Now documented in a comment; a chunked hand-off needs upstream libecpint API support.

Validation context: #177 post-merge benchmark — 10 analytic-vs-numerical cases (RHF/RKS/UHF/UKS/ROHF/ROKS/ECP/CAM, d- and f-bases) all at FD-truncation accuracy (1e-5–9e-5), exactly symmetric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)