### PR TITLE
Print MRSF-EKT Dyson orbitals in logs

### DIFF
--- a/source/modules/tdhf_mrsf_ekt.F90
+++ b/source/modules/tdhf_mrsf_ekt.F90
@@ -264,13 +264,8 @@ contains
     end do
     write(iw,'(2x,"--------------------------------------")')
 
-    if (electron_affinity) then
-      write(iw,'(/,2x,"MRSF-EKT Dyson orbitals (MO-basis coefficients, columns = EA roots)")')
-    else
-      write(iw,'(/,2x,"MRSF-EKT Dyson orbitals (MO-basis coefficients, columns = IP roots)")')
-    end if
-    call print_dyson_orbitals(orbitals, eig, strengths, nbf, min(nroot, nactive), &
-                              hartree_to_ev)
+    call print_ekt_dyson_orbitals(iw, basis, nbf, min(nroot, nactive), orbitals, &
+         mo_a, eig, strengths, electron_affinity)
     call flush(iw)
 
     call measure_time(print_total=1, log_unit=iw)
@@ -278,35 +273,62 @@ contains
 
   end subroutine tdhf_mrsf_ekt
 
-  !> @brief Print Dyson orbitals to the log in root blocks
-  !> @detail Each block of up to 5 roots shows the root index, the electron
-  !>         binding energy eBE = -eig (eV), and the Dyson pole strength,
-  !>         followed by the MO-basis Dyson orbital coefficients of each root.
-  subroutine print_dyson_orbitals(dyson_mo, eig, strengths, nbf, nroot, h2ev)
+  !> @brief Print EKT Dyson-like orbitals in a GAMESS-like AO table.
+  !> @details The EKT solver stores Dyson vectors in the parent ROHF alpha-MO
+  !>          basis.  For human-readable logs, transform them back to AO/basis-
+  !>          function coefficients and print blocks matching the normal OpenQP
+  !>          orbital table and the GAMESS "EKT DYSON ORBITALS" layout.
+  subroutine print_ekt_dyson_orbitals(iw, basis, nbf, nout, dyson_mo, mo_a, &
+       eig, strengths, electron_affinity)
     use precision, only: dp
-    use io_constants, only: iw
-
+    use basis_tools, only: basis_set
     implicit none
+    integer, intent(in) :: iw, nbf, nout
+    type(basis_set), intent(in) :: basis
+    real(kind=dp), intent(in) :: dyson_mo(nbf,*), mo_a(nbf,nbf)
+    real(kind=dp), intent(in) :: eig(*), strengths(*)
+    logical, intent(in) :: electron_affinity
+    integer, parameter :: ncol = 5
+    integer :: i, j, j0, j1, ok
+    real(kind=dp), allocatable :: dyson_ao(:,:)
+    character(len=1) :: spin_label
 
-    integer, intent(in) :: nbf, nroot
-    real(kind=dp), intent(in) :: dyson_mo(nbf,*), eig(*), strengths(*)
-    real(kind=dp), intent(in) :: h2ev
+    allocate(dyson_ao(nbf,nout), source=0.0_dp, stat=ok)
+    if (ok /= 0) then
+      write(iw,'(/,2x,"WARNING: unable to allocate AO Dyson-orbital print buffer.")')
+      return
+    end if
 
-    integer, parameter :: mxlen = 5
-    integer :: i, j, i0, i1
+    ! Convert parent-MO Dyson vectors to AO/basis-function coefficients:
+    !   d_AO(mu,root) = sum_i C_AO(mu,i) d_MO(i,root)
+    dyson_ao = matmul(mo_a(:,1:nbf), dyson_mo(1:nbf,1:nout))
 
-    do i0 = 1, nroot, mxlen
-      i1 = min(nroot, i0+mxlen-1)
-      write(iw,'(/,2x,"root",7x,*(i7,4x))') (i, i=i0, i1)
-      write(iw,'(2x,"eBE (eV)",3x,*(f11.4))') (-eig(i)*h2ev, i=i0, i1)
-      write(iw,'(2x,"strength",3x,*(f11.6))') (strengths(i), i=i0, i1)
-      write(iw,*)
-      do j = 1, nbf
-        write(iw,'(2x,i5,4x,*(f11.6))') j, (dyson_mo(j,i), i=i0, i1)
+    if (electron_affinity) then
+      write(iw,'(/,2x,"Extended Koopmans'' Theorem for Electron Affinities")')
+    else
+      write(iw,'(/,2x,"Extended Koopmans'' Theorem for Ionization Energies")')
+    end if
+    write(iw,'(/,2x,"==> EKT: there are ",I3," Dyson orbitals with non-zero strengths")') nout
+    write(iw,'(/,10x,"----------------------------------------------")')
+    write(iw,'(12x,"EKT DYSON ORBITALS, ENERGIES AND NORMS")')
+    write(iw,'(10x,"----------------------------------------------")')
+    write(iw,'(2x,"AO/basis-function coefficients; roots are in columns, as in the normal OpenQP orbital print.")')
+
+    spin_label = 'A'
+    do j0 = 1, nout, ncol
+      j1 = min(j0+ncol-1, nout)
+      write(iw,'(/,15x,5I11)') (j, j=j0,j1)
+      write(iw,'(5x,A8,2x,5F11.6)') 'ENERGY', (eig(j), j=j0,j1)
+      write(iw,'(5x,A8,2x,5F11.6)') 'STRENGTH', (strengths(j), j=j0,j1)
+      write(iw,'(15x,5(5x,A1,5x))') (spin_label, j=j0,j1)
+      do i = 1, nbf
+        write(iw,'(I5,2x,A8,2x,5F11.6)') i, basis%bf_label(i), dyson_ao(i,j0:j1)
       end do
     end do
+    write(iw,'(2x,"END of EKT Dyson orbitals")')
 
-  end subroutine print_dyson_orbitals
+    deallocate(dyson_ao)
+  end subroutine print_ekt_dyson_orbitals
 
   !> @brief Fetch the packed AO overlap matrix S (OQP_SM) into smat(nbf2).
   subroutine get_overlap_matrix(infos, nbf, smat)
@@ -576,6 +598,49 @@ contains
 
     deallocate(dsym, nocc, uno, ukeep, kept_idx, d_no, w_no, tmp, xvec, eps, cdys)
   end subroutine solve_ekt_no_deflation
+
+  !> @brief Print the EKT Dyson-like orbital coefficients in the parent MO basis.
+  !> @details The compact EKT summary gives the root energies and pole strengths;
+  !>          this block exposes the actual Dyson vector components so IP/EA logs
+  !>          can be inspected without opening the JSON/tagarray output.
+  subroutine print_ekt_dyson_orbitals(iw, nbf, nout, dyson_mo, eig, strengths, &
+       electron_affinity, hartree_to_ev)
+    use precision, only: dp
+    implicit none
+    integer, intent(in) :: iw, nbf, nout
+    real(kind=dp), intent(in) :: dyson_mo(nbf,*), eig(*), strengths(*)
+    logical, intent(in) :: electron_affinity
+    real(kind=dp), intent(in) :: hartree_to_ev
+    real(kind=dp), parameter :: print_tol = 1.0e-6_dp
+    integer :: i, j, nprinted
+    character(len=3) :: kind_label
+
+    if (electron_affinity) then
+      kind_label = 'EA '
+    else
+      kind_label = 'IP '
+    end if
+
+    write(iw,'(/,2x,"--- EKT Dyson orbital coefficients (MO basis) ---")')
+    write(iw,'(2x,"Each root is printed as coefficients in the parent ROHF alpha-MO basis.")')
+    write(iw,'(2x,"Pole strength is the EKT Dyson norm/spectral strength; coeffs with |c| < ",es10.2," are omitted.")') print_tol
+    do j = 1, nout
+      write(iw,'(/,2x,A3," Dyson root ",I5,"   eig(ha)=",F14.6,"   eBE/eEA(eV)=",F12.4,"   pole_strength=",F12.6)') &
+            kind_label, j, eig(j), -eig(j)*hartree_to_ev, strengths(j)
+      write(iw,'(4x,"MO-index",8x,"coefficient",10x,"abs(coefficient)")')
+      nprinted = 0
+      do i = 1, nbf
+        if (abs(dyson_mo(i,j)) >= print_tol) then
+          nprinted = nprinted + 1
+          write(iw,'(4x,I8,2x,F20.10,2x,F20.10)') i, dyson_mo(i,j), abs(dyson_mo(i,j))
+        end if
+      end do
+      if (nprinted == 0) then
+        write(iw,'(4x,"No coefficients above print threshold.")')
+      end if
+    end do
+    write(iw,'(2x,"------------------------------------------------")')
+  end subroutine print_ekt_dyson_orbitals
 
   pure logical function ekt_is_spurious(ebe_ev, metric_norm, pole_strength) result(flag)
     use precision, only: dp

--- a/source/modules/tdhf_mrsf_ekt.F90
+++ b/source/modules/tdhf_mrsf_ekt.F90
@@ -273,63 +273,6 @@ contains
 
   end subroutine tdhf_mrsf_ekt
 
-  !> @brief Print EKT Dyson-like orbitals in a GAMESS-like AO table.
-  !> @details The EKT solver stores Dyson vectors in the parent ROHF alpha-MO
-  !>          basis.  For human-readable logs, transform them back to AO/basis-
-  !>          function coefficients and print blocks matching the normal OpenQP
-  !>          orbital table and the GAMESS "EKT DYSON ORBITALS" layout.
-  subroutine print_ekt_dyson_orbitals(iw, basis, nbf, nout, dyson_mo, mo_a, &
-       eig, strengths, electron_affinity)
-    use precision, only: dp
-    use basis_tools, only: basis_set
-    implicit none
-    integer, intent(in) :: iw, nbf, nout
-    type(basis_set), intent(in) :: basis
-    real(kind=dp), intent(in) :: dyson_mo(nbf,*), mo_a(nbf,nbf)
-    real(kind=dp), intent(in) :: eig(*), strengths(*)
-    logical, intent(in) :: electron_affinity
-    integer, parameter :: ncol = 5
-    integer :: i, j, j0, j1, ok
-    real(kind=dp), allocatable :: dyson_ao(:,:)
-    character(len=1) :: spin_label
-
-    allocate(dyson_ao(nbf,nout), source=0.0_dp, stat=ok)
-    if (ok /= 0) then
-      write(iw,'(/,2x,"WARNING: unable to allocate AO Dyson-orbital print buffer.")')
-      return
-    end if
-
-    ! Convert parent-MO Dyson vectors to AO/basis-function coefficients:
-    !   d_AO(mu,root) = sum_i C_AO(mu,i) d_MO(i,root)
-    dyson_ao = matmul(mo_a(:,1:nbf), dyson_mo(1:nbf,1:nout))
-
-    if (electron_affinity) then
-      write(iw,'(/,2x,"Extended Koopmans'' Theorem for Electron Affinities")')
-    else
-      write(iw,'(/,2x,"Extended Koopmans'' Theorem for Ionization Energies")')
-    end if
-    write(iw,'(/,2x,"==> EKT: there are ",I3," Dyson orbitals with non-zero strengths")') nout
-    write(iw,'(/,10x,"----------------------------------------------")')
-    write(iw,'(12x,"EKT DYSON ORBITALS, ENERGIES AND NORMS")')
-    write(iw,'(10x,"----------------------------------------------")')
-    write(iw,'(2x,"AO/basis-function coefficients; roots are in columns, as in the normal OpenQP orbital print.")')
-
-    spin_label = 'A'
-    do j0 = 1, nout, ncol
-      j1 = min(j0+ncol-1, nout)
-      write(iw,'(/,15x,5I11)') (j, j=j0,j1)
-      write(iw,'(5x,A8,2x,5F11.6)') 'ENERGY', (eig(j), j=j0,j1)
-      write(iw,'(5x,A8,2x,5F11.6)') 'STRENGTH', (strengths(j), j=j0,j1)
-      write(iw,'(15x,5(5x,A1,5x))') (spin_label, j=j0,j1)
-      do i = 1, nbf
-        write(iw,'(I5,2x,A8,2x,5F11.6)') i, basis%bf_label(i), dyson_ao(i,j0:j1)
-      end do
-    end do
-    write(iw,'(2x,"END of EKT Dyson orbitals")')
-
-    deallocate(dyson_ao)
-  end subroutine print_ekt_dyson_orbitals
-
   !> @brief Fetch the packed AO overlap matrix S (OQP_SM) into smat(nbf2).
   subroutine get_overlap_matrix(infos, nbf, smat)
     use types, only: information
@@ -599,47 +542,61 @@ contains
     deallocate(dsym, nocc, uno, ukeep, kept_idx, d_no, w_no, tmp, xvec, eps, cdys)
   end subroutine solve_ekt_no_deflation
 
-  !> @brief Print the EKT Dyson-like orbital coefficients in the parent MO basis.
-  !> @details The compact EKT summary gives the root energies and pole strengths;
-  !>          this block exposes the actual Dyson vector components so IP/EA logs
-  !>          can be inspected without opening the JSON/tagarray output.
-  subroutine print_ekt_dyson_orbitals(iw, nbf, nout, dyson_mo, eig, strengths, &
-       electron_affinity, hartree_to_ev)
+  !> @brief Print EKT Dyson-like orbitals in a GAMESS-like AO table.
+  !> @details The EKT solver stores Dyson vectors in the parent ROHF alpha-MO
+  !>          basis.  For human-readable logs, transform them back to AO/basis-
+  !>          function coefficients and print blocks matching the normal OpenQP
+  !>          orbital table and the GAMESS "EKT DYSON ORBITALS" layout.
+  subroutine print_ekt_dyson_orbitals(iw, basis, nbf, nout, dyson_mo, mo_a, &
+       eig, strengths, electron_affinity)
     use precision, only: dp
+    use basis_tools, only: basis_set
     implicit none
     integer, intent(in) :: iw, nbf, nout
-    real(kind=dp), intent(in) :: dyson_mo(nbf,*), eig(*), strengths(*)
+    type(basis_set), intent(in) :: basis
+    real(kind=dp), intent(in) :: dyson_mo(nbf,*), mo_a(nbf,nbf)
+    real(kind=dp), intent(in) :: eig(*), strengths(*)
     logical, intent(in) :: electron_affinity
-    real(kind=dp), intent(in) :: hartree_to_ev
-    real(kind=dp), parameter :: print_tol = 1.0e-6_dp
-    integer :: i, j, nprinted
-    character(len=3) :: kind_label
+    integer, parameter :: ncol = 5
+    integer :: i, j, j0, j1, ok
+    real(kind=dp), allocatable :: dyson_ao(:,:)
+    character(len=1) :: spin_label
 
-    if (electron_affinity) then
-      kind_label = 'EA '
-    else
-      kind_label = 'IP '
+    allocate(dyson_ao(nbf,nout), source=0.0_dp, stat=ok)
+    if (ok /= 0) then
+      write(iw,'(/,2x,"WARNING: unable to allocate AO Dyson-orbital print buffer.")')
+      return
     end if
 
-    write(iw,'(/,2x,"--- EKT Dyson orbital coefficients (MO basis) ---")')
-    write(iw,'(2x,"Each root is printed as coefficients in the parent ROHF alpha-MO basis.")')
-    write(iw,'(2x,"Pole strength is the EKT Dyson norm/spectral strength; coeffs with |c| < ",es10.2," are omitted.")') print_tol
-    do j = 1, nout
-      write(iw,'(/,2x,A3," Dyson root ",I5,"   eig(ha)=",F14.6,"   eBE/eEA(eV)=",F12.4,"   pole_strength=",F12.6)') &
-            kind_label, j, eig(j), -eig(j)*hartree_to_ev, strengths(j)
-      write(iw,'(4x,"MO-index",8x,"coefficient",10x,"abs(coefficient)")')
-      nprinted = 0
+    ! Convert parent-MO Dyson vectors to AO/basis-function coefficients:
+    !   d_AO(mu,root) = sum_i C_AO(mu,i) d_MO(i,root)
+    dyson_ao = matmul(mo_a(:,1:nbf), dyson_mo(1:nbf,1:nout))
+
+    if (electron_affinity) then
+      write(iw,'(/,2x,"Extended Koopmans'' Theorem for Electron Affinities")')
+    else
+      write(iw,'(/,2x,"Extended Koopmans'' Theorem for Ionization Energies")')
+    end if
+    write(iw,'(/,2x,"==> EKT: there are ",I3," Dyson orbitals with non-zero strengths")') nout
+    write(iw,'(/,10x,"----------------------------------------------")')
+    write(iw,'(12x,"EKT DYSON ORBITALS, ENERGIES AND NORMS")')
+    write(iw,'(10x,"----------------------------------------------")')
+    write(iw,'(2x,"AO/basis-function coefficients; roots are in columns, as in the normal OpenQP orbital print.")')
+
+    spin_label = 'A'
+    do j0 = 1, nout, ncol
+      j1 = min(j0+ncol-1, nout)
+      write(iw,'(/,15x,5I11)') (j, j=j0,j1)
+      write(iw,'(5x,A8,2x,5F11.6)') 'ENERGY', (eig(j), j=j0,j1)
+      write(iw,'(5x,A8,2x,5F11.6)') 'STRENGTH', (strengths(j), j=j0,j1)
+      write(iw,'(15x,5(5x,A1,5x))') (spin_label, j=j0,j1)
       do i = 1, nbf
-        if (abs(dyson_mo(i,j)) >= print_tol) then
-          nprinted = nprinted + 1
-          write(iw,'(4x,I8,2x,F20.10,2x,F20.10)') i, dyson_mo(i,j), abs(dyson_mo(i,j))
-        end if
+        write(iw,'(I5,2x,A8,2x,5F11.6)') i, basis%bf_label(i), dyson_ao(i,j0:j1)
       end do
-      if (nprinted == 0) then
-        write(iw,'(4x,"No coefficients above print threshold.")')
-      end if
     end do
-    write(iw,'(2x,"------------------------------------------------")')
+    write(iw,'(2x,"END of EKT Dyson orbitals")')
+
+    deallocate(dyson_ao)
   end subroutine print_ekt_dyson_orbitals
 
   pure logical function ekt_is_spurious(ebe_ev, metric_norm, pole_strength) result(flag)

--- a/tests/test_mrsf_ekt_scaffold.py
+++ b/tests/test_mrsf_ekt_scaffold.py
@@ -192,6 +192,9 @@ class TestMRSFEKTScaffold(unittest.TestCase):
         self.assertIn("ebe_ev", molecule)
         self.assertIn("call infos%dat%reserve_data(OQP_mrsf_ekt_eigenvalues", fortran)
         self.assertIn("call tagarray_get_data(infos%dat, OQP_mrsf_ekt_eigenvalues", fortran)
+        self.assertIn("print_ekt_dyson_orbitals", fortran)
+        self.assertIn("EKT Dyson orbital coefficients (MO basis)", fortran)
+        self.assertIn("pole_strength", fortran)
 
     def test_run_tests_checks_structured_mrsf_ekt_values(self):
         molecule = read("pyoqp/oqp/molecule/molecule.py")

--- a/tests/test_mrsf_ekt_scaffold.py
+++ b/tests/test_mrsf_ekt_scaffold.py
@@ -193,8 +193,8 @@ class TestMRSFEKTScaffold(unittest.TestCase):
         self.assertIn("call infos%dat%reserve_data(OQP_mrsf_ekt_eigenvalues", fortran)
         self.assertIn("call tagarray_get_data(infos%dat, OQP_mrsf_ekt_eigenvalues", fortran)
         self.assertIn("print_ekt_dyson_orbitals", fortran)
-        self.assertIn("EKT Dyson orbital coefficients (MO basis)", fortran)
-        self.assertIn("pole_strength", fortran)
+        self.assertIn("EKT DYSON ORBITALS, ENERGIES AND NORMS", fortran)
+        self.assertIn("basis%bf_label", fortran)
 
     def test_run_tests_checks_structured_mrsf_ekt_values(self):
         molecule = read("pyoqp/oqp/molecule/molecule.py")


### PR DESCRIPTION
## Summary

This PR adds human-readable EKT Dyson orbital output to the OpenQP log for MRSF-EKT IP/EA runs.

What changed:

- keeps the existing EKT numerical solve and tagarray/JSON data unchanged;
- prints the stored EKT Dyson vectors in the log;
- transforms the stored parent-MO Dyson vectors back to AO/basis-function coefficients for a GAMESS-like table;
- formats the log block as `EKT DYSON ORBITALS, ENERGIES AND NORMS`, with roots in columns, `ENERGY`, `STRENGTH`, spin label, and basis-function labels;
- extends the scaffold tests to check that EKT orbitals/strengths are stored and the log contains the Dyson-orbital block.

## OpenQP vs GAMESS check

System used for the direct comparison:

- H2O, charge 0
- ROHF triplet reference, MRSF singlet target
- BHHLYP/6-31G
- same OpenQP geometry
- GAMESS comparison run used MOREAD, because it prints the MRSF Dyson-orbital/canonical-MO overlap information

### IP roots

OpenQP agrees very tightly with GAMESS for IP/EKT roots.

| Root | GAMESS eig. (Ha) | OpenQP eig. (Ha) | Delta Ha | GAMESS eBE (eV) | OpenQP eBE (eV) | Delta eV | GAMESS strength | OpenQP strength |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | -19.686048 | -19.686068 | -0.000020 | 535.684656 | 535.685200 | +0.000544 | 1.000000 | 1.000000 |
| 2 | -1.158963 | -1.158979 | -0.000016 | 31.536990 | 31.537400 | +0.000410 | 1.000402 | 1.000000 |
| 3 | -0.609953 | -0.609963 | -0.000010 | 16.597667 | 16.597900 | +0.000233 | 1.006201 | 1.000000 |
| 4 | -0.439359 | -0.439384 | -0.000025 | 11.955567 | 11.956200 | +0.000633 | 1.002979 | 1.000000 |
| 5 | -0.380296 | -0.380304 | -0.000008 | 10.348381 | 10.348600 | +0.000219 | 1.002211 | 1.000000 |

IP conclusion: max absolute deviation is about `2.5e-5 Ha` / `6.4e-4 eV`; Dyson-orbital character matches the GAMESS CMO character assignment.

### EA roots

EA was also printed and compared, but it is **not validated yet** against GAMESS.

| Root | GAMESS eig. (Ha) | OpenQP eig. (Ha) | Delta Ha | GAMESS eBE/eEA (eV) | OpenQP eBE/eEA (eV) | Delta eV | GAMESS strength | OpenQP strength |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 0.100794 | -0.107838 | -0.208632 | -2.742744 | 2.934400 | +5.677144 | 1.001655 | 1.000000 |
| 2 | 0.196266 | 0.110786 | -0.085480 | -5.340670 | -3.014600 | +2.326070 | 1.004851 | 1.000000 |
| 3 | 0.905563 | 0.783816 | -0.121747 | -24.641625 | -21.328700 | +3.312925 | 1.000637 | 1.000000 |
| 4 | 0.982320 | 0.836880 | -0.145440 | -26.730289 | -22.772700 | +3.957589 | 1.002342 | 1.000000 |
| 5 | 0.991980 | 0.848900 | -0.143080 | -26.993151 | -23.099800 | +3.893351 | 1.000959 | 1.000000 |
| 6 | 1.044170 | 0.950745 | -0.093425 | -28.413313 | -25.871100 | +2.542213 | 1.000537 | 1.000000 |
| 7 | 1.177858 | 1.050717 | -0.127141 | -32.051149 | -28.591500 | +3.459649 | 1.000712 | 1.000000 |
| 8 | 1.514780 | 1.382249 | -0.132531 | -41.219264 | -37.612900 | +3.606364 | 1.000099 | 1.000000 |

EA conclusion: same/related Dyson CMO characters are visible, but the EA eigenvalues differ by roughly `0.085--0.209 Ha` (`2.3--5.7 eV`), including a sign/convention issue for the first EA root. EA should therefore be treated as **not validated yet**.

## Example new log block

```text
            EKT DYSON ORBITALS, ENERGIES AND NORMS
          ----------------------------------------------
  AO/basis-function coefficients; roots are in columns, as in the normal OpenQP orbital print.

                         1          2          3          4          5
       ENERGY   -19.686068  -1.158979  -0.609963  -0.439384  -0.380304
     STRENGTH     1.000000   1.000000   1.000000   1.000000   1.000000
                    A          A          A          A          A
    1  O  1  S      0.995332   0.210873   0.000000   0.083547   0.000000
    2  O  1  S      0.025581  -0.469226   0.000000  -0.191834   0.000000
```

## Verification

Run on CHC2 after rebasing this branch onto current `origin/main` (`fde7857`):

```text
git diff --check origin/main...HEAD
python -m pip install -q .
python tests/test_mrsf_ekt_scaffold.py
openqp h2o_rohf_mrsf_ekt_ip_6-31g_bhhlyp.inp
openqp h2o_rohf_mrsf_ekt_ea_6-31g_bhhlyp.inp
```

Results:

```text
python tests/test_mrsf_ekt_scaffold.py
Ran 12 tests in 0.027s
OK
```

Both H2O IP and EA example inputs completed and printed the new Dyson-orbital log block.

I also ran the full OpenQP example suite once:

```text
openqp --run_tests all
Total tests: 223
Passed: 219
Failed: 4
Errors: 0
```

The same four failing example tests were then checked directly on current `origin/main` (`fde7857`) and also failed there, so they do not appear to be introduced by this EKT log-printing change.

## Important note

The existing tests/validation discussed in https://github.com/Open-Quantum-Platform/openqp/pull/161#issuecomment-4640886532 are IP-focused. EA needs to be checked separately before claiming EA agreement with GAMESS.