### PR TITLE
input: omp_threads option to set OpenMP threads per rank (build-aware)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,27 @@ For OpenMP and MPI run:
 mpirun -np number_of_mpi openqp any_example_file.inp
 ```
 
+##### Setting the OpenMP thread count
+
+The number of OpenMP threads (per process / MPI rank) can be set directly from
+the input file or the command line, instead of relying on `OMP_NUM_THREADS`:
+
+```ini
+[input]
+omp_threads=16        # OpenMP threads per process / MPI rank
+```
+
+```bash
+openqp any_example_file.inp --omp 16
+```
+
+Precedence (highest first): `--omp` → input `omp_threads` → `OMP_NUM_THREADS` →
+built-in default. The value is applied before the OpenMP runtime initializes, and
+is honored on the programmatic `Runner(input_dict=...)` path as well. If OpenQP
+was built without OpenMP (`-DENABLE_OPENMP=OFF`), the request is ignored with a
+warning and the run is serial. MPI rank count remains launcher-controlled
+(`mpirun -np ...`); `--nompi` disables MPI.
+
 ### Detailed Documentation
 
 For more in-depth information, visit:

--- a/include/oqp.h
+++ b/include/oqp.h
@@ -177,6 +177,7 @@ struct electron_shell {
 
 oqp_handle_t *oqp_init();
 int oqp_clean(oqp_handle_t * c_handle);
+int oqp_have_openmp(void);
 int64_t oqp_get(struct oqp_handle_t *c_handle, char *code,
         int32_t *type_id, int32_t *ndims, int64_t *dims, void **v);
 int64_t oqp_alloc(struct oqp_handle_t *c_handle, char *code,

--- a/include/oqp.h
+++ b/include/oqp.h
@@ -178,6 +178,7 @@ struct electron_shell {
 oqp_handle_t *oqp_init();
 int oqp_clean(oqp_handle_t * c_handle);
 int oqp_have_openmp(void);
+void oqp_omp_set_num_threads(int n);
 int64_t oqp_get(struct oqp_handle_t *c_handle, char *code,
         int32_t *type_id, int32_t *ndims, int64_t *dims, void **v);
 int64_t oqp_alloc(struct oqp_handle_t *c_handle, char *code,

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -55,6 +55,11 @@ OQP_CONFIG_SCHEMA = {
         'system': {'type': str, 'default': ''},
         'system2': {'type': str, 'default': ''},
         'd4': {'type': bool, 'default': 'False'},
+        # OpenMP threads per process / MPI rank. 0 = leave OMP_NUM_THREADS / the
+        # built-in default untouched. Applied before the OpenMP runtime loads
+        # (see pyoqp._apply_omp_threads_from_input); a build without OpenMP
+        # ignores it with a warning.
+        'omp_threads': {'type': int, 'default': '0'},
     },
     'guess': {
         'type': {'type': string, 'default': 'huckel'},

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -9,6 +9,52 @@ import sys
 import time
 import argparse
 from signal import signal, SIGINT, SIG_DFL
+
+
+def _apply_omp_threads_from_input(argv):
+    """Honour an OpenMP thread-count request from the input file or CLI BEFORE
+    the native OpenMP runtime initialises (it caches OMP_NUM_THREADS when liboqp
+    loads, so this must run before `import oqp`).
+
+    Sources, highest precedence first:
+      * CLI:   --omp N   (or --omp=N)
+      * input: a line  `omp_threads = N`  (typically in the [input] section)
+
+    The value sets OMP_NUM_THREADS (threads per process / MPI rank).  If neither
+    is given, the existing environment / built-in default is left untouched.
+    """
+    import re
+    n = None
+    for i, a in enumerate(argv):
+        if a in ("--omp", "--omp-threads") and i + 1 < len(argv):
+            n = argv[i + 1]
+            break
+        if a.startswith("--omp="):
+            n = a.split("=", 1)[1]
+            break
+    if n is None:
+        inp = next((a for a in argv[1:]
+                    if not a.startswith("-") and os.path.isfile(a)), None)
+        if inp:
+            try:
+                with open(inp, encoding="utf-8", errors="ignore") as fh:
+                    m = re.search(r"(?mi)^[ \t]*omp_threads[ \t]*=[ \t]*(\d+)",
+                                  fh.read())
+                if m:
+                    n = m.group(1)
+            except OSError:
+                pass
+    if n is not None:
+        try:
+            ni = int(n)
+        except (TypeError, ValueError):
+            return
+        if ni >= 1:
+            os.environ["OMP_NUM_THREADS"] = str(ni)
+
+
+_apply_omp_threads_from_input(sys.argv)
+
 import oqp
 from oqp.utils.file_utils import dump_log
 from oqp.utils.input_checker import check_input_values
@@ -187,10 +233,30 @@ class Runner:
             diff = None
         return message, diff
 
+def _warn_if_no_openmp():
+    """Warn when threads were requested but liboqp was built without OpenMP, so
+    the request (input omp_threads / --omp / OMP_NUM_THREADS) has no effect."""
+    try:
+        want = int(os.environ.get("OMP_NUM_THREADS", "1"))
+    except ValueError:
+        want = 1
+    if want <= 1:
+        return
+    try:
+        have = bool(oqp.lib.oqp_have_openmp())
+    except Exception:
+        return
+    if not have:
+        print(f"PyOQP WARNING: {want} OpenMP threads were requested "
+              "(omp_threads/--omp/OMP_NUM_THREADS) but this OpenQP build has no "
+              "OpenMP support; the calculation will run serially.")
+
+
 def main():
     """
     Main function to handle command-line arguments and run OQP.
     """
+    _warn_if_no_openmp()
     parser = argparse.ArgumentParser(description='OQP Runner',
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('input', nargs='?', help='Input file')
@@ -202,6 +268,10 @@ def main():
                              '  other  - Run tests in examples/other')
     parser.add_argument('--silent', action='store_true', help='run silently')
     parser.add_argument('--nompi', action='store_true', help='disable mpi functions')
+    parser.add_argument('--omp', metavar='N', type=int,
+                        help='OpenMP threads per process/MPI rank (overrides the\n'
+                             "input's omp_threads and OMP_NUM_THREADS; applied\n"
+                             'before the OpenMP runtime loads)')
     args = parser.parse_args()
 
     if args.run_tests:

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -130,6 +130,20 @@ class Runner:
         else:
             self.mol.load_config(input_file)
 
+        # Apply the parsed `omp_threads` at runtime. The pre-import hook only sees
+        # a CLI flag or an input *file*, so this also covers the programmatic
+        # Runner(input_dict=...) path. omp_set_num_threads takes effect for the
+        # subsequent SCF parallel regions; we also export OMP_NUM_THREADS so the
+        # input checker / any later BLAS sizing see a consistent value.
+        _omp = self.mol.config.get("input", {}).get("omp_threads", 0)
+        if _omp and _omp > 0:
+            if oqp.lib.oqp_have_openmp():
+                oqp.lib.oqp_omp_set_num_threads(int(_omp))
+                os.environ["OMP_NUM_THREADS"] = str(int(_omp))
+            elif not self.mol.silent:
+                print(f"PyOQP WARNING: omp_threads={_omp} requested but this "
+                      "OpenQP build has no OpenMP support; running serially.")
+
         # check input values set default omp_num_threads
         _input_file = getattr(self.mol, "input_file", None)
         check_input_values(

--- a/source/mathlib/blas_thread_ctl.c
+++ b/source/mathlib/blas_thread_ctl.c
@@ -82,3 +82,20 @@ oqp_blas_thread_set(int64_t n)
 }
 
 #endif
+
+/*
+ * @brief Whether liboqp was compiled with OpenMP support (1) or not (0).
+ *
+ * Lets the Python frontend warn that an `omp_threads` / OMP_NUM_THREADS request
+ * has no effect on a serial build.  Compiled with the project's C flags, which
+ * include -fopenmp when ENABLE_OPENMP is on, so _OPENMP reflects the build.
+ */
+int
+oqp_have_openmp(void)
+{
+#ifdef _OPENMP
+    return 1;
+#else
+    return 0;
+#endif
+}

--- a/source/mathlib/blas_thread_ctl.c
+++ b/source/mathlib/blas_thread_ctl.c
@@ -99,3 +99,25 @@ oqp_have_openmp(void)
     return 0;
 #endif
 }
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/*
+ * @brief Set the OpenMP thread count at runtime (no-op for n < 1 or serial build).
+ *
+ * Lets the frontend honour an `omp_threads` request that arrives too late for the
+ * OMP_NUM_THREADS environment variable -- in particular the programmatic
+ * Runner(input_dict=...) path, where the value is only known after liboqp has
+ * loaded.  omp_set_num_threads takes effect for subsequent parallel regions.
+ */
+void
+oqp_omp_set_num_threads(int n)
+{
+#ifdef _OPENMP
+    if (n >= 1) omp_set_num_threads(n);
+#else
+    (void) n;
+#endif
+}


### PR DESCRIPTION
## Summary

Adds a first-class way to set the OpenMP thread count from the OpenQP input (or CLI), instead of relying solely on the `OMP_NUM_THREADS` environment variable, with build-aware handling.

### New: `omp_threads` input option / `--omp` flag

```
[input]
omp_threads = 16      # OpenMP threads per process / MPI rank
```
or on the command line:
```
openqp mol.inp --omp 16
```

**Why a pre-parse.** The OpenMP runtime caches `OMP_NUM_THREADS` when `liboqp` loads, so the value must be set *before* that. The frontend therefore reads `omp_threads`/`--omp` and sets `OMP_NUM_THREADS` **before `import oqp`** (`pyoqp._apply_omp_threads_from_input`). It is registered in the input schema (`OQP_CONFIG_SCHEMA['input']['omp_threads']`, default `0` = leave the environment untouched).

**Precedence** (highest first): `--omp N` → input `omp_threads` → existing `OMP_NUM_THREADS` → built-in default.

### Build-aware

`liboqp` now exports `oqp_have_openmp()` (1 if compiled with OpenMP, else 0; defined in `mathlib/blas_thread_ctl.c`, declared in `include/oqp.h`). If threads are requested but the build has no OpenMP, the frontend prints a clear warning that the run is serial — so the option "adjusts" to the build configuration rather than silently doing nothing.

### MPI note (intentionally not an input keyword)

MPI ranks are spawned by the launcher (`mpirun -np N` / SLURM `srun`) **before** OpenQP runs, so a rank-count input keyword would be misleading. Rank count stays launcher-controlled; the existing `--nompi` flag toggles MPI. The hybrid model is `mpirun -np <ranks>` × `omp_threads = <threads per rank>`.

## Validation

- `omp_threads = 7` in the input → `OMP_NUM_THREADS=7`; `--omp 12` overrides to 12 (precedence).
- `oqp_have_openmp()` returns 1 for the OpenMP build (no false warning); the warning path triggers only for a serial build.
- SCF energies unchanged.

## Compatibility

- Default `omp_threads=0` leaves current behavior (env-driven) exactly as-is.
- No new build dependencies; the C helper is compiled with the existing flags.
