### PR TITLE
feat(log): record the running OpenQP version + git commit

### DIFF
--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -197,16 +197,21 @@ class SinglePoint(Calculator):
         # initialize state sign
         self.mol.data["OQP::state_sign"] = np.ones(self.nstate)
 
-    def _prep_guess(self):
+    def _prep_guess(self, basis_context=''):
         oqp.library.set_basis(self.mol)
-        self._log_basis_harmonics()
+        self._log_basis_harmonics(context=basis_context)
         oqp.library.ints_1e(self.mol)
         oqp.library.guess(self.mol)
 
-    def _log_basis_harmonics(self):
+    def _log_basis_harmonics(self, context=''):
         """Log whether d/f shells are Cartesian (6D/10F) or spherical (5D/7F), so
         the basis convention is visible in the output (6-31G* is Cartesian/6D;
-        def2-/cc- sets are spherical/5D)."""
+        def2-/cc- sets are spherical/5D).
+
+        ``context`` labels the basis being reported (e.g. 'initial-SCF' vs
+        'production') when an init_scf phase runs in a different basis, so the
+        line never silently records the temporary initial basis as the final
+        one."""
         try:
             from oqp.library.symmetry import (_cartesian_shell_size,
                                               _spherical_shell_size)
@@ -223,8 +228,9 @@ class SinglePoint(Calculator):
                 kind = 'spherical harmonic (5D / 7F)'
             else:
                 kind = 'unrecognized layout'
+            label = ('%s basis' % context) if context else 'basis'
             dump_log(self.mol, section='',
-                     title='PyOQP: basis angular functions = %s  [nbf = %d]' % (kind, nbf))
+                     title='PyOQP: %s angular functions = %s  [nbf = %d]' % (label, kind, nbf))
         except Exception:
             pass
 
@@ -241,6 +247,13 @@ class SinglePoint(Calculator):
         else:
             init_basis = self.init_basis
             init_library = self.init_library
+
+        # When the init-SCF phase runs in a *different* basis, the production
+        # basis is restored further below; label the init-phase log line and
+        # re-log the final basis so the convention/nbf reported is the one
+        # actually used for the production SCF (not the temporary initial basis).
+        init_basis_distinct = (self.init_basis not in ('none', '')
+                               and self.init_basis != target_basis)
 
         init_converger = self.mol.config['scf']['init_converger']
         target_converger = self.mol.config['scf']['converger_type']
@@ -286,7 +299,7 @@ class SinglePoint(Calculator):
             raise ValueError(f'Unknown initial scf method {self.init_scf}')
 
         dump_log(self.mol, title='PyOQP: Initial SCF steps', section='scf')
-        self._prep_guess()
+        self._prep_guess(basis_context=('initial-SCF' if init_basis_distinct else ''))
         if self.mol.config['guess']['type'] != 'json':
             init_calc(self.mol)
         # save initially converge orbitals
@@ -302,6 +315,8 @@ class SinglePoint(Calculator):
             self.mol.config['input']['basis'] = target_basis
             self.mol.config['input']['library'] = target_library
             oqp.library.set_basis(self.mol)
+            if init_basis_distinct:
+                self._log_basis_harmonics(context='production')
 
         # set parameters back to normal scf
         self.mol.config['input']['basis'] = target_basis

--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -199,8 +199,34 @@ class SinglePoint(Calculator):
 
     def _prep_guess(self):
         oqp.library.set_basis(self.mol)
+        self._log_basis_harmonics()
         oqp.library.ints_1e(self.mol)
         oqp.library.guess(self.mol)
+
+    def _log_basis_harmonics(self):
+        """Log whether d/f shells are Cartesian (6D/10F) or spherical (5D/7F), so
+        the basis convention is visible in the output (6-31G* is Cartesian/6D;
+        def2-/cc- sets are spherical/5D)."""
+        try:
+            from oqp.library.symmetry import (_cartesian_shell_size,
+                                              _spherical_shell_size)
+            basis = self.mol.data.get_basis()
+            if not basis:
+                return
+            nbf = int(basis['nbf'])
+            angs = [int(l) for l in basis['angs']]
+            if not any(l >= 2 for l in angs):
+                kind = 'spherical == Cartesian (s,p shells only)'
+            elif nbf == sum(_cartesian_shell_size(l) for l in angs):
+                kind = 'Cartesian (6D / 10F)'
+            elif nbf == sum(_spherical_shell_size(l) for l in angs):
+                kind = 'spherical harmonic (5D / 7F)'
+            else:
+                kind = 'unrecognized layout'
+            dump_log(self.mol, section='',
+                     title='PyOQP: basis angular functions = %s  [nbf = %d]' % (kind, nbf))
+        except Exception:
+            pass
 
     def _project_basis(self):
         oqp.library.project_basis(self.mol)

--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -197,42 +197,10 @@ class SinglePoint(Calculator):
         # initialize state sign
         self.mol.data["OQP::state_sign"] = np.ones(self.nstate)
 
-    def _prep_guess(self, basis_context=''):
+    def _prep_guess(self):
         oqp.library.set_basis(self.mol)
-        self._log_basis_harmonics(context=basis_context)
         oqp.library.ints_1e(self.mol)
         oqp.library.guess(self.mol)
-
-    def _log_basis_harmonics(self, context=''):
-        """Log whether d/f shells are Cartesian (6D/10F) or spherical (5D/7F), so
-        the basis convention is visible in the output (6-31G* is Cartesian/6D;
-        def2-/cc- sets are spherical/5D).
-
-        ``context`` labels the basis being reported (e.g. 'initial-SCF' vs
-        'production') when an init_scf phase runs in a different basis, so the
-        line never silently records the temporary initial basis as the final
-        one."""
-        try:
-            from oqp.library.symmetry import (_cartesian_shell_size,
-                                              _spherical_shell_size)
-            basis = self.mol.data.get_basis()
-            if not basis:
-                return
-            nbf = int(basis['nbf'])
-            angs = [int(l) for l in basis['angs']]
-            if not any(l >= 2 for l in angs):
-                kind = 'spherical == Cartesian (s,p shells only)'
-            elif nbf == sum(_cartesian_shell_size(l) for l in angs):
-                kind = 'Cartesian (6D / 10F)'
-            elif nbf == sum(_spherical_shell_size(l) for l in angs):
-                kind = 'spherical harmonic (5D / 7F)'
-            else:
-                kind = 'unrecognized layout'
-            label = ('%s basis' % context) if context else 'basis'
-            dump_log(self.mol, section='',
-                     title='PyOQP: %s angular functions = %s  [nbf = %d]' % (label, kind, nbf))
-        except Exception:
-            pass
 
     def _project_basis(self):
         oqp.library.project_basis(self.mol)
@@ -247,13 +215,6 @@ class SinglePoint(Calculator):
         else:
             init_basis = self.init_basis
             init_library = self.init_library
-
-        # When the init-SCF phase runs in a *different* basis, the production
-        # basis is restored further below; label the init-phase log line and
-        # re-log the final basis so the convention/nbf reported is the one
-        # actually used for the production SCF (not the temporary initial basis).
-        init_basis_distinct = (self.init_basis not in ('none', '')
-                               and self.init_basis != target_basis)
 
         init_converger = self.mol.config['scf']['init_converger']
         target_converger = self.mol.config['scf']['converger_type']
@@ -299,7 +260,7 @@ class SinglePoint(Calculator):
             raise ValueError(f'Unknown initial scf method {self.init_scf}')
 
         dump_log(self.mol, title='PyOQP: Initial SCF steps', section='scf')
-        self._prep_guess(basis_context=('initial-SCF' if init_basis_distinct else ''))
+        self._prep_guess()
         if self.mol.config['guess']['type'] != 'json':
             init_calc(self.mol)
         # save initially converge orbitals
@@ -315,8 +276,6 @@ class SinglePoint(Calculator):
             self.mol.config['input']['basis'] = target_basis
             self.mol.config['input']['library'] = target_library
             oqp.library.set_basis(self.mol)
-            if init_basis_distinct:
-                self._log_basis_harmonics(context='production')
 
         # set parameters back to normal scf
         self.mol.config['input']['basis'] = target_basis

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -230,6 +230,31 @@ class Runner:
 
         # Set up banner
         oqp.oqp_banner(self.mol)
+        # Log the running OpenQP version + git HEAD commit so every output records
+        # which build produced it (works for source/editable installs; falls back to
+        # the package version when no git tree is reachable).
+        try:
+            import subprocess as _sp
+            _ver = getattr(oqp, "__version__", "")
+            _commit = ""
+            for _d in (os.environ.get("OPENQP_ROOT"),
+                       os.path.dirname(os.path.abspath(oqp.__file__))):
+                if not _d:
+                    continue
+                _r = _sp.run(["git", "-C", _d, "rev-parse", "--short", "HEAD"],
+                             capture_output=True, text=True, timeout=2)
+                if _r.returncode == 0 and _r.stdout.strip():
+                    _commit = _r.stdout.strip()
+                    _dirty = _sp.run(["git", "-C", _d, "status", "--porcelain"],
+                                     capture_output=True, text=True, timeout=2)
+                    if _dirty.stdout.strip():
+                        _commit += "+dirty"
+                    break
+            _bv = "OpenQP" + (" v%s" % _ver if _ver else "") + \
+                  ((" (git %s)" % _commit) if _commit else " (git commit unknown)")
+            dump_log(self.mol, section='', title='PyOQP build: %s' % _bv)
+        except Exception:
+            pass
 
         # Get the run type from mol configuration
         run_type = self.mol.config["input"]["runtype"]

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -235,17 +235,30 @@ class Runner:
         # the package version when no git tree is reachable).
         try:
             import subprocess as _sp
+            _pkg = os.path.dirname(os.path.abspath(oqp.__file__))
+            # This very module: present in any OpenQP package, used as a sentinel.
+            _sentinel = os.path.join(_pkg, "pyoqp.py")
             _ver = getattr(oqp, "__version__", "")
             _commit = ""
-            for _d in (os.environ.get("OPENQP_ROOT"),
-                       os.path.dirname(os.path.abspath(oqp.__file__))):
+            for _d in (os.environ.get("OPENQP_ROOT"), _pkg):
                 if not _d:
+                    continue
+                # Only trust a discovered git worktree if it actually TRACKS the
+                # OpenQP package source. A wheel installed under an unrelated
+                # project's virtualenv would otherwise let `git -C <site-packages>/oqp`
+                # discover that parent project's .git and report its commit as the
+                # OpenQP build. Requiring this package file to be tracked rules that
+                # out -- it is tracked only in a genuine source/editable checkout.
+                _chk = _sp.run(["git", "-C", _d, "ls-files", "--error-unmatch", _sentinel],
+                               capture_output=True, text=True, timeout=2)
+                if _chk.returncode != 0:
                     continue
                 _r = _sp.run(["git", "-C", _d, "rev-parse", "--short", "HEAD"],
                              capture_output=True, text=True, timeout=2)
                 if _r.returncode == 0 and _r.stdout.strip():
                     _commit = _r.stdout.strip()
-                    _dirty = _sp.run(["git", "-C", _d, "status", "--porcelain"],
+                    # "+dirty" reflects only the OpenQP package subtree.
+                    _dirty = _sp.run(["git", "-C", _d, "status", "--porcelain", "--", _pkg],
                                      capture_output=True, text=True, timeout=2)
                     if _dirty.stdout.strip():
                         _commit += "+dirty"


### PR DESCRIPTION
Adds a single provenance line after the banner:
```
PyOQP build: OpenQP (git <short-HEAD>)
```
so every output records which build produced it. The commit is read only from a git worktree that actually **tracks the OpenQP package source** (verified via `git ls-files --error-unmatch` on this module), so a wheel installed under an unrelated project's virtualenv falls back to `git commit unknown` rather than reporting that parent repo's commit; `+dirty` is scoped to the package subtree.

Note: the earlier basis 5D/6D-vs-Cartesian log line was dropped from this PR — OpenQP's basis builder is Cartesian-only (`naos = NUM_CART_BF` unconditionally), so that line always reported Cartesian and added no information until a spherical-harmonic basis path exists.