### PR TITLE
build(docker): link an optimized ILP64 OpenBLAS instead of slow NetLib

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+build
+_build
+**/__pycache__
+*.pyc
+openqp_test_tmp*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,30 +12,63 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN ln -fs /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
     echo "Asia/Seoul" > /etc/timezone
 
-# Install dependencies, including LAPACK and BLAS, with --fix-missing
+# Build toolchain and runtime deps.  NOTE: no libblas-dev/liblapack-dev here --
+# OpenQP requires an ILP64 (8-byte integer) BLAS/LAPACK, which the distro
+# reference packages are not; with LINALG_LIB=auto CMake silently falls back to
+# compiling the bundled (unoptimized) NetLib reference library.  We build
+# OpenBLAS as ILP64 below instead, so the image links an optimized BLAS/LAPACK.
+# (`make`/`perl` are needed by the OpenBLAS build.)
 RUN apt-get update && apt-get install -y --fix-missing \
-    gcc-14 g++-14 gfortran-14 cmake ninja-build \
+    gcc-14 g++-14 gfortran-14 cmake ninja-build make perl \
     openmpi-bin libopenmpi-dev \
     python3-pip wget git \
-    libblas-dev liblapack-dev \
     && apt-get clean
 
 # Install Python dependencies
 RUN pip3 install cffi
 
-# Install CMake 3.25.2
+# CMake comes from apt (24.04 ships 3.28 >= the required 3.25). The previous
+# pinned download of a linux-x86_64 CMake tarball is dropped: it could not run on
+# the arm64 leg of the multi-platform image (wrong-arch ELF under QEMU).
+
+# Build OpenBLAS as ILP64 (INTERFACE64=1) with UNSUFFIXED symbols, so it exports
+# `dgemm_` etc. with the 8-byte integer width OpenQP calls.  The distro's
+# libopenblas64 instead exports `dgemm_64_`-suffixed symbols, which OpenQP does
+# not call -- hence building from source here.  DYNAMIC_ARCH=1 keeps the image
+# portable (OpenBLAS selects the kernel for the host CPU at run time, not the
+# build machine's ISA), which also matters for the multi-platform image.
+# Build the library targets only (libs netlib shared) -- `netlib` bundles LAPACK
+# into libopenblas; we skip the `tests` target that `make all` runs, since a few
+# edge-case extension self-tests can fail on some arches and would abort the build.
 WORKDIR /tmp
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-x86_64.tar.gz
-RUN tar -zxvf cmake-3.25.2-linux-x86_64.tar.gz
-RUN mv cmake-3.25.2-linux-x86_64 /opt/cmake
-ENV PATH="/opt/cmake/bin:$PATH"
+ARG OPENBLAS_VERSION=0.3.28
+RUN wget -q https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz && \
+    tar -xzf OpenBLAS-${OPENBLAS_VERSION}.tar.gz && \
+    cd OpenBLAS-${OPENBLAS_VERSION} && \
+    make -j"$(nproc)" INTERFACE64=1 USE_OPENMP=1 DYNAMIC_ARCH=1 \
+         CC=gcc-14 FC=gfortran-14 libs netlib shared && \
+    make PREFIX=/opt/openblas INTERFACE64=1 install && \
+    ln -sf libopenblas.so /opt/openblas/lib/libopenblas64.so && \
+    ln -sf libopenblas.a  /opt/openblas/lib/libopenblas64.a && \
+    cd /tmp && rm -rf "OpenBLAS-${OPENBLAS_VERSION}" "OpenBLAS-${OPENBLAS_VERSION}.tar.gz"
+# CMake's FindBLAS searches for an `openblas64`-named library when
+# BLA_SIZEOF_INTEGER=8 (ILP64).  Our OpenBLAS uses UNSUFFIXED symbols (matching
+# OpenQP's unsuffixed `dgemm` calls), so expose it under the openblas64 name via
+# symlinks above -- without them, find_package(BLAS) misses it and OpenQP
+# silently falls back to the bundled NetLib reference library.
+ENV LD_LIBRARY_PATH="/opt/openblas/lib:${LD_LIBRARY_PATH}"
 
 # Copy and compile the checked-out OpenQP source.  GitHub Actions has already
 # checked out the branch/PR being tested, so do not clone main again here.
+# LINALG_LIB=OpenBLAS + CMAKE_PREFIX_PATH point the ILP64 BLAS/LAPACK search at
+# the OpenBLAS built above (LAPACK is bundled in libopenblas).
 COPY . /opt/openqp
 WORKDIR /opt/openqp
-RUN cmake -B build -G Ninja -DUSE_LIBINT=OFF -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_Fortran_COMPILER=gfortran-14 -DCMAKE_INSTALL_PREFIX=. -DENABLE_OPENMP=ON -DLINALG_LIB_INT64=ON
-RUN ninja -C build install
+RUN cmake -B build -G Ninja -DUSE_LIBINT=OFF -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_Fortran_COMPILER=gfortran-14 -DCMAKE_INSTALL_PREFIX=. -DENABLE_OPENMP=ON -DLINALG_LIB_INT64=ON -DLINALG_LIB=OpenBLAS -DCMAKE_PREFIX_PATH=/opt/openblas
+# NINJA_JOBS caps compile parallelism for memory-constrained builders (the
+# Fortran modules are RAM-heavy); empty = use all cores (the CI default).
+ARG NINJA_JOBS=
+RUN ninja ${NINJA_JOBS:+-j${NINJA_JOBS}} -C build install
 RUN cd pyoqp && pip3 install .
 
 # Install dftd4


### PR DESCRIPTION
## Problem
The image installed LP64 `libblas-dev/liblapack-dev`, but OpenQP requires an **ILP64** (8-byte integer) BLAS/LAPACK. With `LINALG_LIB=auto`, CMake's ILP64 search cannot use those LP64 libs and **silently falls back to compiling the bundled NetLib reference BLAS** — so the image shipped an *unoptimized* BLAS and the apt packages were never linked.

## Change
Build **OpenBLAS from source as ILP64** and link it:
- `INTERFACE64=1`, **unsuffixed** symbols (match OpenQP's unsuffixed `dgemm`; the distro's `libopenblas64` uses `dgemm_64_`).
- `DYNAMIC_ARCH=1` (portable kernel selection — needed for the multi-platform image).
- `libs netlib shared` only (LAPACK bundled via `netlib`); skip `make`'s `tests` target (flaky extension self-tests on some arches).
- Symlink `libopenblas64.{so,a}` → the unsuffixed lib so `find_package(BLAS)` with `BLA_SIZEOF_INTEGER=8` resolves it; `-DLINALG_LIB=OpenBLAS`.

Also:
- **Drop the pinned x86_64 CMake download** — 24.04 apt cmake (3.28) ≥ required 3.25, and the x86_64 binary couldn't run on the arm64 leg under QEMU (the step that actually broke non-amd64 configure).
- `NINJA_JOBS` build-arg to cap compile parallelism on RAM-limited builders (empty = all cores).
- Add `.dockerignore`.

## Verification
Locally (arm64 Docker): OpenBLAS builds ILP64 and **cmake selects it** — `Found BLAS/LAPACK: /opt/openblas/lib/libopenblas64.so`, `Looking for Fortran sgemm - found`, no NetLib fallback. The full image build (libxc + OpenQP + `pip install .` + smoke) is left to **this PR's docker-build CI** (a single libxc XC-functional C file needs >7.7 GiB and OOMs the local Docker VM — unrelated to this change, unchanged from the prior image). The ILP64-OpenBLAS recipe is independently proven on another OpenQP install (`run_tests` 212/212).

Note: `dftd4` still fetches an x86_64 helper binary — only *downloaded* (not run) at build, so it doesn't block the arm64 build, but running D4 on arm64 would need that addressed separately.