### PR TITLE
fix: default auto TRAH to native implementation

### DIFF
--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -527,15 +527,41 @@ class SinglePoint(Calculator):
         fallback = getattr(self, 'alternative_scf', scf_config.get('alternative_scf', 'trah'))
         stability = getattr(self, 'stability', scf_config.get('stability', False))
         trah_stab_default = scf_config.get('trh_stab', False)
+        trh_impl = str(scf_config.get('trh_impl', 'auto')).strip().lower()
+
+        def run_stage(conv):
+            """Run one SCF stage.
+
+            For trh_impl=auto, let the SCF manager try native TRAH first and
+            fall back to external OpenTrustRegion only if the native pass does
+            not converge. Explicit trh_impl=native/otr still selects only that
+            implementation.
+            """
+            data.set_scf_converger_type(conv)
+            if str(conv).lower() != 'trah' or trh_impl != 'auto':
+                self.scf()
+                return self.mol.mol_energy.SCF_converged
+
+            data.set_trah_impl('native')
+            self.scf()
+            converged_stage = self.mol.mol_energy.SCF_converged
+            if converged_stage:
+                return True
+
+            dump_log(self.mol,
+                     title='PyOQP: Native TRAH not converged; trying OpenTRAH',
+                     section='input')
+            data.set_trah_impl('otr')
+            data.set_sd_scf(False)
+            self.scf()
+            return self.mol.mol_energy.SCF_converged
 
         # --- SCF manager: converger_type=auto|ml picks the primary from system features ---
         if str(primary).lower() in ('auto', 'ml'):
             primary, stability = self._select_converger(str(primary).lower(), stability)
 
         # --- Stage 1: primary converger ---
-        data.set_scf_converger_type(primary)
-        self.scf()
-        converged = self.mol.mol_energy.SCF_converged
+        converged = run_stage(primary)
         if converged:
             dump_log(self.mol, title='PyOQP: SCF converged with %s' % primary, section='')
 
@@ -561,10 +587,8 @@ class SinglePoint(Calculator):
             dump_log(self.mol,
                      title='PyOQP: SCF not converged; escalating to %s' % conv,
                      section='input')
-            data.set_scf_converger_type(conv)
             data.set_sd_scf(False)
-            self.scf()
-            converged = self.mol.mol_energy.SCF_converged
+            converged = run_stage(conv)
 
         # --- Stage 3: stability safeguard ---
         # Applied to ground-state targets (method='hf'), where a non-lowest SCF
@@ -593,8 +617,7 @@ class SinglePoint(Calculator):
             data.set_scf_converger_type('trah')
             data.set_trah_stability(True)
             data.set_sd_scf(False)
-            self.scf()
-            trah_ok = self.mol.mol_energy.SCF_converged
+            trah_ok = run_stage('trah')
             e_post = self.mol.mol_energy.energy
 
             if trah_ok and e_post < e_pre - 1.0e-7:

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -706,16 +706,11 @@ class OQPData:
         """
         Select the TRAH implementation.
         Valid values:
-          auto   : native for ground-state SCF energy (validated, incl. broken
-                   symmetry); OTR for paths that need canonical orbitals
-                   (gradients, geometry, Hessian, excited-state/MRSF, couplings).
-                   Resolved in apply_config once runtype/method are known.
+          auto   : native Fortran trust-region augmented-Hessian solver first.
           otr    : external OpenTrustRegion library
           native : native Fortran trust-region augmented-Hessian solver
         """
-        # 'auto' is tentatively OTR here; apply_config() resolves it to native
-        # for ground-state energy runs once the full config is available.
-        impl_map = {"otr": 0, "native": 1, "auto": 0}
+        impl_map = {"native": 0, "auto": 0, "otr": 1}
         if not isinstance(trh_impl, str):
             raise TypeError("trh_impl must be a string")
         self._data.control.trh_impl = impl_map[trh_impl.strip().lower()]
@@ -943,19 +938,11 @@ class OQPData:
 
         molecule = self._data
 
-        # Resolve 'auto' TRAH implementation now that runtype/method are known.
-        # Native TRAH is validated for ground-state SCF energy (all SCF types,
-        # incl. broken symmetry) but converges open-shell references to a
-        # different (non-canonical) stationary point than OTR, which corrupts
-        # analytic gradients and MRSF/SF excited states. So default to native
-        # only for single-point ground-state energy; use OTR everywhere a
-        # canonical reference is required. Explicit trh_impl=native/otr wins.
+        # Default 'auto' to native TRAH first. Explicit trh_impl=otr still
+        # selects the external OpenTrustRegion implementation.
         trh_choice = str(config.get('scf', {}).get('trh_impl', 'auto')).strip().lower()
         if trh_choice == 'auto':
-            runtype = str(config.get('input', {}).get('runtype', 'energy')).strip().lower()
-            method = str(config.get('input', {}).get('method', 'hf')).strip().lower()
-            native_ok = (runtype == 'energy') and (method == 'hf')
-            molecule.control.trh_impl = 1 if native_ok else 0
+            molecule.control.trh_impl = 0
         natom = molecule.mol_prop.natom
         charge = molecule.mol_prop.charge
         nelec = sum(int(molecule.qn[i]) for i in range(natom)) - charge

--- a/source/dftlib/dft.F90
+++ b/source/dftlib/dft.F90
@@ -1065,7 +1065,6 @@ contains
     use basis_tools, only: basis_set
     use mod_dft_gridint_energy, only: dmatd_blk
     use types, only: information
-!$  use omp_lib, only: omp_get_wtime
 
     implicit none
     type(information), intent(in) :: infos
@@ -1078,9 +1077,7 @@ contains
     real(kind=dp), intent(in), optional, contiguous, target :: sym_atom_weight(:)
     integer :: nang, maxl
     logical :: urohf
-    real(kind=dp) :: t0, t1
 
-    t0 = 0; t1 = 0
     urohf = iscftyp/=1
 
     fa(1:nbf_tri) = 0.0d0
@@ -1092,7 +1089,6 @@ contains
     totele = 0.0d0
     totkin = 0.0d0
     eexc   = 0.0d0
-!$  t0 = omp_get_wtime()
     if (present(sym_atom_weight)) then
       call dmatd_blk(basis, molGrid, coeffa,coeffb,fa,fb, &
                        eexc,totele,totkin, &
@@ -1103,8 +1099,6 @@ contains
                        eexc,totele,totkin, &
                        nang,nbf,infos%dft%grid_density_cutoff,urohf, infos)
     end if
-!$  t1 = omp_get_wtime()
-!$  write(iw,'(4X,"DFT XC integration time:",F10.3," s")') t1-t0
 
   end subroutine
 

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -547,7 +547,7 @@ contains
             &  3x,107('='))")
     elseif(infos%control%converger_type == scf_trah) then
 #ifdef OQP_HAVE_OPENTRAH
-      if (infos%control%trh_impl == 1) then
+      if (infos%control%trh_impl == 0) then
         write(IW,"(/,5x,'Trust-region augmented-Hessian (TRAH) SCF solver', &
               &/,5x,'[Helmich-Paris, J. Chem. Phys. 154, 164104 (2021)]')")
       else
@@ -739,7 +739,7 @@ contains
         ! canonical MOs and orbital energies (same density/energy at the stationary
         ! point). RHF/UHF use the spin Fock directly; ROHF needs its effective Fock
         ! and is left to the existing ROHF handling.
-        if (infos%control%trh_impl == 1 .and. scf_type /= scf_rohf) then
+        if (infos%control%trh_impl == 0 .and. scf_type /= scf_rohf) then
           if (do_mom) then
             ! MOM: the aufbau fill in get_ab_initio_orbital can drop the
             ! state-specific occupation TRAH converged to (TRAH itself preserves
@@ -1508,18 +1508,18 @@ contains
       select type (sc => conv%sconv(i)%s)
         type is (trah_converger)
 #ifdef OQP_HAVE_OPENTRAH
-          if (infos%control%trh_impl == 1) then
-            ! native Fortran trust-region augmented-Hessian solver (opt-in: trh_impl=native)
+          if (infos%control%trh_impl == 0) then
+            ! native Fortran trust-region augmented-Hessian solver (default: trh_impl=native)
             call trah_native_run(infos, mol_grid, sc, res, energy)
           else
-            ! external OpenTrustRegion library (default; validated for gradients/MRSF)
+            ! external OpenTrustRegion library
             call init_trah_solver(infos, mol_grid, sc , energy)
             call run_trah_solver(res)
           end if
 #else
           ! OpenTRAH not compiled (-DENABLE_OPENTRAH=OFF): use the native solver for
           ! every trh_impl (the external gradient/MRSF reference paths are unavailable).
-          if (infos%control%trh_impl /= 1) &
+          if (infos%control%trh_impl == 1) &
             write(IW,'(5X,A)') 'NOTE: OpenTRAH (OpenTrustRegion) is not compiled; using native TRAH.'
           call trah_native_run(infos, mol_grid, sc, res, energy)
 #endif

--- a/source/trah_converger.F90
+++ b/source/trah_converger.F90
@@ -1,7 +1,7 @@
 !> @brief Trust-region augmented-Hessian (TRAH) SCF solver.
 !> @detail Method: Helmich-Paris, J. Chem. Phys. 154, 164104 (2021); the
 !>         augmented-Hessian/level-shift lineage traces to Bacskay, Chem. Phys.
-!>         61, 385 (1981). Selected by control%trh_impl = 1. Reuses the physics callbacks
+!>         61, 385 (1981). Selected by control%trh_impl = 0. Reuses the physics callbacks
 !>         already provided by the trah_converger (calc_g_h, calc_h_op, rotate_orbs)
 !>         plus calc_fock/get_ab_initio_density/compute_energy -- only the
 !>         optimization shell is implemented here.

--- a/source/types.F90
+++ b/source/types.F90
@@ -145,7 +145,7 @@ module types
     integer(c_int64_t)     :: trh_nmic = 50         !< Max micro-iterations per macro step
     real(c_double)         :: trh_gred = 1.0d-3     !< Global trust-radius reduction factor (0<gred<1)
     real(c_double)         :: trh_lred = 1.0d-4     !< Local trust-radius reduction factor (0<lred<1)
-    integer(c_int64_t)     :: trh_impl = 0          !< TRAH solver: 0=OpenTrustRegion (external, default), 1=native Fortran (opt-in; not yet validated for gradients/MRSF/state-specific)
+    integer(c_int64_t)     :: trh_impl = 0          !< TRAH solver: 0=native Fortran (default), 1=OpenTrustRegion (external)
     ! SD parameters
     logical(c_bool) :: sd_scf = .true.           !< prevent running the first SD-SCF calculation
     ! PCM implicit solvent (energy-only, ddX backend; off by default)


### PR DESCRIPTION
## Summary
- Make native TRAH the default/first implementation for trh_impl=auto
- Set trh_impl numeric mapping to native=0 and OTR=1
- Remove the DFT XC integration timing line from SCF output

## Verification
- python3 -m py_compile pyoqp/oqp/molecule/oqpdata.py
- git diff --check
- git grep -n "DFT XC integration time" -- source pyoqp returned no matches