### PR TITLE
ci: key the externals cache by full compiler version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,14 +25,21 @@ jobs:
          # compiler flags, build type, and bundled versions, so a stale restore is
          # never reused for an incompatible build -- it just falls back to a cold
          # externals build. The externals do not depend on MPI, so both MPI matrix
-         # legs share one cache entry per OS.
+         # legs share one cache entry per OS. The full compiler version must be in
+         # the outer key: when a runner image update bumps gcc, the internal key
+         # changes but an unchanged outer key would match exactly and actions/cache
+         # would never save the rebuilt externals, leaving CI permanently cold.
+         - name: Get toolchain version for the externals cache key
+           id: toolchain
+           run: echo "gcc=$(gfortran-${{ matrix.version }} -dumpfullversion)" >> "$GITHUB_OUTPUT"
          - name: Cache bundled externals
            uses: actions/cache@v4
            with:
             path: ~/.cache/openqp/externals
-            key: oqp-externals-${{ matrix.os }}-gcc${{ matrix.version }}-${{ hashFiles('external/CMakeLists.txt') }}
+            key: oqp-externals-${{ matrix.os }}-gcc${{ steps.toolchain.outputs.gcc }}-${{ hashFiles('external/CMakeLists.txt') }}
             restore-keys: |
-               oqp-externals-${{ matrix.os }}-gcc${{ matrix.version }}-
+               oqp-externals-${{ matrix.os }}-gcc${{ steps.toolchain.outputs.gcc }}-
+               oqp-externals-${{ matrix.os }}-
          - name: Install OpenBLAS (ubuntu-latest)
            if: ${{ matrix.os == 'ubuntu-latest' || contains(matrix.os, 'ubuntu-24.04') }}
            run: |

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -61,8 +61,23 @@ if(OQP_REUSE_EXTERNALS)
   endforeach()
   string(MD5 _oqp_external_flags_hash "${_oqp_external_flag_blob}")
   string(SUBSTRING "${_oqp_external_flags_hash}" 0 12 _oqp_external_flags_hash)
+  # _LINALG_LIB_TYPE collapses every non-MKL system BLAS to "other", but some
+  # cached externals bake the concrete provider into their artifacts (the
+  # shared libddx.so links BLAS/LAPACK at its own build time, and ddX receives
+  # BLA_VENDOR), so hash the resolved provider and library paths into the key.
+  # The bundled-NetLib route is normalized to a constant: it must produce the
+  # same key whether netlib was chosen explicitly or reached by fallback, and
+  # any BLAS variables left over from a failed system search must not split it.
+  if(_LINALG_LIB_TYPE STREQUAL "NetLib")
+    set(_oqp_external_blas_blob "netlib-bundled")
+  else()
+    set(_oqp_external_blas_blob
+        "${LINALG_LIB}|${BLA_VENDOR}|${BLAS_LIBRARIES}|${LAPACK_LIBRARIES}")
+  endif()
+  string(MD5 _oqp_external_blas_hash "${_oqp_external_blas_blob}")
+  string(SUBSTRING "${_oqp_external_blas_hash}" 0 12 _oqp_external_blas_hash)
   set(_oqp_external_key
-      "${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}-${_oqp_external_generator}-${CMAKE_C_COMPILER_ID}${CMAKE_C_COMPILER_VERSION}-${CMAKE_CXX_COMPILER_ID}${CMAKE_CXX_COMPILER_VERSION}-${CMAKE_Fortran_COMPILER_ID}${CMAKE_Fortran_COMPILER_VERSION}-${CMAKE_BUILD_TYPE}-${_oqp_external_linkage}-${_LINALG_LIB_TYPE}-blasint${BLA_SIZEOF_INTEGER}-flags${_oqp_external_flags_hash}-${_OQP_EXTERNALS_VERSION_KEY}")
+      "${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}-${_oqp_external_generator}-${CMAKE_C_COMPILER_ID}${CMAKE_C_COMPILER_VERSION}-${CMAKE_CXX_COMPILER_ID}${CMAKE_CXX_COMPILER_VERSION}-${CMAKE_Fortran_COMPILER_ID}${CMAKE_Fortran_COMPILER_VERSION}-${CMAKE_BUILD_TYPE}-${_oqp_external_linkage}-${_LINALG_LIB_TYPE}-blas${_oqp_external_blas_hash}-blasint${BLA_SIZEOF_INTEGER}-flags${_oqp_external_flags_hash}-${_OQP_EXTERNALS_VERSION_KEY}")
   string(REGEX REPLACE "[^A-Za-z0-9_.+-]" "_" _oqp_external_key "${_oqp_external_key}")
   set(OQP_EXTERNALS_SOURCE_ROOT "${_OQP_EXTERNALS_ROOT}/${_oqp_external_key}/src" CACHE INTERNAL "OQP_EXTERNALS_SOURCE_ROOT" FORCE)
   set(OQP_EXTERNALS_BUILD_ROOT "${_OQP_EXTERNALS_ROOT}/${_oqp_external_key}/build" CACHE INTERNAL "OQP_EXTERNALS_BUILD_ROOT" FORCE)


### PR DESCRIPTION
## Summary

Follow-up to #203 (this commit was pushed moments after the merge and missed it).

The CI externals cache key from #203 only encodes the gcc major version (`gcc14`). When a GitHub runner image update bumps the gcc patch version, the *internal* externals cache key (which hashes the full compiler version) changes, so the restored cache contents are unusable and the run builds cold — but the *outer* GitHub key still matches exactly, so `actions/cache` never re-saves. CI would then stay permanently cold until `external/CMakeLists.txt` happens to change.

- Key the cache by `gfortran -dumpfullversion` (e.g. `gcc14.2.0`) instead of the matrix major version.
- Add a broad `restore-keys` fallback (`oqp-externals-<os>-`) so any key transition — including this PR's own migration from the old `gcc14` entries and future runner toolchain bumps — restores the previous cache and runs warm instead of starting cold, then re-saves under the new key.

## Validation

- `ruby -ryaml` parse check of the workflow.
- The internal per-toolchain key inside the cache directory continues to guarantee correctness regardless of which outer entry is restored; the outer key only affects save/restore behavior.
- This PR's own CI run exercises the fallback live: its new outer key cannot exact-match the existing `oqp-externals-<os>-gcc14-…` entries, so a warm result here demonstrates the restore-keys path works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update

Also includes `721fa29` (addresses the Codex review comment): the internal externals cache key now hashes `LINALG_LIB`, `BLA_VENDOR`, and the resolved BLAS/LAPACK library paths, so distinct non-NetLib BLAS providers (or relocated libraries) get distinct cache namespaces; the bundled-NetLib route is normalized so explicit `netlib` and auto-fallback-to-netlib share one namespace (verified on macOS configure runs).

