### PR TITLE
[codex] Cache Docker build dependencies

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Docker Hub
         if: github.event_name == 'push' && env.HAS_DOCKER_CREDENTIALS == 'true'
         env:
@@ -33,14 +37,52 @@ jobs:
       # bump) the pull fails and we build it here; the next push-to-main run
       # with Docker Hub credentials publishes it.
       - name: Prepare build environment image
+        id: buildenv
         run: |
-          if ! docker pull "${BUILDENV_IMAGE}"; then
+          if docker pull "${BUILDENV_IMAGE}"; then
+            echo "source=registry" >> "${GITHUB_OUTPUT}"
+          else
             echo "::warning::${BUILDENV_IMAGE} not in registry; building it from docker/buildenv.Dockerfile"
             docker build -t "${BUILDENV_IMAGE}" -f docker/buildenv.Dockerfile docker
+            echo "source=local" >> "${GITHUB_OUTPUT}"
           fi
 
+      - name: Cache Docker build mounts
+        if: steps.buildenv.outputs.source == 'registry'
+        id: docker-cache-mounts
+        uses: actions/cache@v4
+        with:
+          path: docker-cache-mounts
+          key: docker-cache-mounts-${{ runner.os }}-${{ hashFiles('Dockerfile', 'pyproject.toml', 'external/CMakeLists.txt') }}
+          restore-keys: |
+            docker-cache-mounts-${{ runner.os }}-
+
+      - name: Restore Docker build mounts
+        if: steps.buildenv.outputs.source == 'registry'
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-dir: docker-cache-mounts
+          dockerfile: Dockerfile
+          skip-extraction: ${{ steps.docker-cache-mounts.outputs.cache-hit }}
+
       - name: Build OpenQP image
-        run: docker build -t openqp/openqp:v1.0 .
+        if: steps.buildenv.outputs.source == 'registry'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: openqp/openqp:v1.0
+          load: true
+          # BuildKit's GitHub cache keeps source-independent Docker layers.
+          # actions/cache + buildkit-cache-dance above keep the pip/OpenQP
+          # externals cache mounts. pyproject.toml or external/CMakeLists.txt
+          # changes get a new mount-cache key and refresh subsequent builds.
+          cache-from: type=gha,scope=openqp-docker
+          cache-to: type=gha,mode=max,scope=openqp-docker
+
+      - name: Build OpenQP image with local buildenv fallback
+        if: steps.buildenv.outputs.source == 'local'
+        run: DOCKER_BUILDKIT=1 docker build -t openqp/openqp:v1.0 .
 
       - name: Push images
         if: github.event_name == 'push' && env.HAS_DOCKER_CREDENTIALS == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # OpenQP image: install the checked-out sources with the standard
 # `pip install .` route (scikit-build-core builds the native library and the
 # Python package together) on top of the prebuilt build environment (compiler
@@ -6,6 +7,31 @@
 # Keep the tag below in sync with .github/workflows/docker-build.yml and
 # docker/buildenv.Dockerfile.
 FROM openqp/openqp-buildenv:1
+
+# Install Python build/runtime dependencies in a source-independent layer.
+# Changes to pyproject.toml invalidate this layer automatically; source-only
+# PRs then reuse it instead of re-downloading scipy, basis_set_exchange, etc.
+COPY pyproject.toml /tmp/openqp-pyproject.toml
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    python3 - <<'PY'
+import subprocess
+import sys
+import tomllib
+
+with open("/tmp/openqp-pyproject.toml", "rb") as handle:
+    project = tomllib.load(handle)
+
+requirements = []
+requirements.extend(project.get("build-system", {}).get("requires", []))
+requirements.extend(project.get("project", {}).get("dependencies", []))
+
+deduped = []
+for requirement in requirements:
+    if requirement not in deduped:
+        deduped.append(requirement)
+
+subprocess.check_call([sys.executable, "-m", "pip", "install", *deduped])
+PY
 
 # Copy and install the checked-out OpenQP source.  GitHub Actions has already
 # checked out the branch/PR being tested, so do not clone main again here.
@@ -18,11 +44,14 @@ FROM openqp/openqp-buildenv:1
 COPY . /opt/openqp
 WORKDIR /opt/openqp
 ENV CC=gcc-14 CXX=g++-14 FC=gfortran-14
-ENV CMAKE_ARGS="-DLINALG_LIB=OpenBLAS -DCMAKE_PREFIX_PATH=/opt/openblas"
+ENV CMAKE_ARGS="-DLINALG_LIB=OpenBLAS -DCMAKE_PREFIX_PATH=/opt/openblas -DOQP_EXTERNALS_ROOT=/root/.cache/openqp/externals"
 # NINJA_JOBS caps compile parallelism for memory-constrained builders (the
 # Fortran modules are RAM-heavy); empty = use all cores (the CI default).
 ARG NINJA_JOBS=
-RUN ${NINJA_JOBS:+env CMAKE_BUILD_PARALLEL_LEVEL=${NINJA_JOBS}} pip3 install .
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    --mount=type=cache,target=/root/.cache/openqp/externals,sharing=locked \
+    ${NINJA_JOBS:+env CMAKE_BUILD_PARALLEL_LEVEL=${NINJA_JOBS}} \
+    pip3 install --no-build-isolation --no-deps .
 
 ENV OMP_NUM_THREADS=4
 


### PR DESCRIPTION
## Summary

This PR reduces repeated work in the Docker image CI without changing the normal local build path documented in the README.

- Use Docker Buildx with GitHub layer cache for the image build.
- Persist BuildKit cache mounts for pip and OpenQP bundled externals in GitHub Actions.
- Install Python build/runtime dependencies in a source-independent Docker layer derived from `pyproject.toml`.
- Run the final source install with `--no-build-isolation --no-deps` so source-only PRs do not repeatedly resolve/download Python dependencies.
- Point Docker-only CMake builds at `/root/.cache/openqp/externals` so bundled externals can be reused inside Docker CI.

## Cache invalidation

- `pyproject.toml` changes invalidate the Python dependency layer and the mount-cache key, then the refreshed cache is saved for later builds.
- `external/CMakeLists.txt` changes invalidate the Docker mount-cache key, while OpenQP's internal externals key continues to separate incompatible external builds by toolchain, flags, BLAS/LAPACK settings, build type, and bundled external versions.
- Source-only changes still rebuild OpenQP itself, but should reuse the Python dependency setup and compatible bundled externals.

## Validation

- `git diff --check`
- Parsed `.github/workflows/docker-build.yml` with Ruby YAML loader
- `docker buildx build --check .` completed Dockerfile frontend checks locally; it reported only the expected platform warning because this Mac is arm64 while `openqp/openqp-buildenv:1` is linux/amd64.