### PR TITLE
fix: keep Python runtime and native library in sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,12 @@ endif()
 
 option(LINALG_LIB_INT64  "Use 64-bit integer interface to BLAS/LAPACK" ON)
 if(NOT LINALG_LIB_INT64)
-    message(FATAL_ERROR
+    message(WARNING
       "LP64 BLAS/LAPACK is no longer supported after removal of defined/defind. "
-      "OpenQP requires ILP64 BLAS/LAPACK with OQP_BLAS_INT=8."
+      "Forcing LINALG_LIB_INT64=ON so stale CMake caches are repaired automatically."
     )
+    set(LINALG_LIB_INT64 ON CACHE BOOL
+        "Use 64-bit integer interface to BLAS/LAPACK" FORCE)
 endif()
 
 option(ENABLE_OPENMP     "Enable OpenMP parallelization"     OFF)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -137,6 +137,13 @@ function(oqp_reuse_or_build target)
   message(STATUS "Reusing cached external '${target}' (skipping rebuild)")
 endfunction()
 
+set(OQP_EXTERNAL_LIST_SEPARATOR "|")
+function(oqp_external_cmake_list_arg out_var cache_var)
+  set(_value "${ARGN}")
+  string(REPLACE ";" "${OQP_EXTERNAL_LIST_SEPARATOR}" _value "${_value}")
+  set(${out_var} "-D${cache_var}:STRING=${_value}" PARENT_SCOPE)
+endfunction()
+
 if(${USE_LIBINT})
 oqp_set_external_paths(LIBINT2 libint
     "${CMAKE_BINARY_DIR}/external/libint"
@@ -387,17 +394,24 @@ set(OTR_CMAKE_ARGS
         -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
         -DCMAKE_Fortran_FLAGS=${otr_fortran_flags}
         -DCMAKE_GENERATOR:INTERNAL=${CMAKE_GENERATOR}
-        -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
 )
+if(CMAKE_PREFIX_PATH)
+    oqp_external_cmake_list_arg(_otr_prefix_path_arg CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
+    list(APPEND OTR_CMAKE_ARGS "${_otr_prefix_path_arg}")
+endif()
 if(_LINALG_LIB_TYPE STREQUAL NetLib)
+    oqp_external_cmake_list_arg(_otr_blas_arg BLAS_LIBRARIES ${LIBBLAS})
+    oqp_external_cmake_list_arg(_otr_lapack_arg LAPACK_LIBRARIES ${LIBLAPACK})
     list(APPEND OTR_CMAKE_ARGS
-        -DBLAS_LIBRARIES=${LIBBLAS}
-        -DLAPACK_LIBRARIES=${LIBLAPACK}
+        "${_otr_blas_arg}"
+        "${_otr_lapack_arg}"
     )
 elseif(DEFINED BLAS_LIBRARIES AND DEFINED LAPACK_LIBRARIES)
+    oqp_external_cmake_list_arg(_otr_blas_arg BLAS_LIBRARIES ${BLAS_LIBRARIES})
+    oqp_external_cmake_list_arg(_otr_lapack_arg LAPACK_LIBRARIES ${LAPACK_LIBRARIES})
     list(APPEND OTR_CMAKE_ARGS
-        -DBLAS_LIBRARIES=${BLAS_LIBRARIES}
-        -DLAPACK_LIBRARIES=${LAPACK_LIBRARIES}
+        "${_otr_blas_arg}"
+        "${_otr_lapack_arg}"
     )
 elseif(DEFINED BLA_VENDOR)
     list(APPEND OTR_CMAKE_ARGS -DBLA_VENDOR=${BLA_VENDOR})
@@ -424,6 +438,7 @@ ExternalProject_Add(libopentrustregion
     SOURCE_DIR ${OPENTRUSTREGION_SOURCE_DIR}
     UPDATE_COMMAND ""
     PATCH_COMMAND /usr/bin/perl -0pi -e "${_OTR_ARCH_SED}" <SOURCE_DIR>/CMakeLists.txt
+    LIST_SEPARATOR ${OQP_EXTERNAL_LIST_SEPARATOR}
     CMAKE_ARGS ${OTR_CMAKE_ARGS}
     BINARY_DIR ${OPENTRUSTREGION_BUILD_DIR}
     STAMP_DIR  ${OPENTRUSTREGION_STAMP_DIR}
@@ -544,13 +559,16 @@ if(ENABLE_DDX AND OQP_DDX_AUTOBUILD)
     # location reaches the ddX subbuild. An empty -D would override the
     # environment CMAKE_PREFIX_PATH the ExternalProject otherwise inherits.
     if(CMAKE_PREFIX_PATH)
-        list(APPEND DDX_CMAKE_ARGS -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH})
+        oqp_external_cmake_list_arg(_ddx_prefix_path_arg CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
+        list(APPEND DDX_CMAKE_ARGS "${_ddx_prefix_path_arg}")
     endif()
     # Forward the same BLAS/LAPACK choice OpenQP resolved (findLinearAlgebra()).
     if(_LINALG_LIB_TYPE STREQUAL NetLib)
+        oqp_external_cmake_list_arg(_ddx_blas_arg BLAS_LIBRARIES ${LIBBLAS})
+        oqp_external_cmake_list_arg(_ddx_lapack_arg LAPACK_LIBRARIES ${LIBLAPACK})
         list(APPEND DDX_CMAKE_ARGS
-            -DBLAS_LIBRARIES=${LIBBLAS}
-            -DLAPACK_LIBRARIES=${LIBLAPACK})
+            "${_ddx_blas_arg}"
+            "${_ddx_lapack_arg}")
     elseif(DEFINED BLA_VENDOR)
         list(APPEND DDX_CMAKE_ARGS -DBLA_VENDOR=${BLA_VENDOR})
     endif()
@@ -562,6 +580,7 @@ if(ENABLE_DDX AND OQP_DDX_AUTOBUILD)
         URL https://github.com/ddsolvation/ddX/archive/refs/tags/v${_OQP_DDX_VERSION}.tar.gz
         URL_HASH SHA256=6f6d08c7699dd69d4b12dd0b1f8c519f5f3f84a3d23cc526dd1a4a60914969d6
         TLS_VERIFY TRUE
+        LIST_SEPARATOR ${OQP_EXTERNAL_LIST_SEPARATOR}
         SOURCE_DIR ${DDX_SOURCE_DIR}
         PATCH_COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/cmake/patches/ddx-v0.8.0-ilp64.patch
         BINARY_DIR ${DDX_BUILD_DIR}

--- a/pyoqp/README.md
+++ b/pyoqp/README.md
@@ -28,9 +28,12 @@ pip install (see the main [README](../README.md) for details and build options):
 No environment variables are required afterwards: the installed package
 locates its own native library and data files, so do not set `OPENQP_ROOT`.
 
-Only the manual cmake/ninja development flow ("Detailed Compile" in the main
-README, where the native library stays in the source tree and PyOQP is
-installed from this directory) still needs `OPENQP_ROOT` pointing at that tree.
+The manual cmake/ninja development flow ("Detailed Compile" in the main
+README) is also detected when PyOQP is imported directly from the source
+checkout with the native library installed into that tree. Keep `OPENQP_ROOT`
+only as a compatibility fallback for custom layouts where Python is separated
+from the OpenQP runtime tree, such as a separate `cd pyoqp && pip install .`
+development install.
 
 ## Usage
 

--- a/pyoqp/oqp/__init__.py
+++ b/pyoqp/oqp/__init__.py
@@ -10,11 +10,51 @@ try:
 except ModuleNotFoundError:
     print('\nPyOQP: dftd4 is not available')
 
-try:
-    os.environ["OPENQP_ROOT"]
-except KeyError:
-    os.environ["OPENQP_ROOT"] = os.path.abspath(os.path.dirname(__file__))
-#    exit('\nPyQOP: cannot find environment variable $OPENQP_ROOT\n')
+def _library_suffix():
+    if platform.uname()[0] == "Windows":
+        return "dll"
+    if platform.uname()[0] == "Darwin":
+        return "dylib"
+    return "so"
+
+
+def _is_oqp_root(path, suffix):
+    return (
+        path
+        and os.path.exists(os.path.join(path, "include", "oqp.h"))
+        and os.path.exists(os.path.join(path, "lib", f"liboqp.{suffix}"))
+    )
+
+
+def _resolve_oqp_root():
+    """Choose a coherent root containing both oqp.h and liboqp.
+
+    Installed wheels put the Python package, header, and native library under the
+    package directory. Prefer that self-contained root over OPENQP_ROOT so a
+    leftover development environment variable cannot mix an installed Python
+    package with a different source-tree library. Source-tree imports do not have
+    package-local include/lib directories, so they still use OPENQP_ROOT.
+    """
+    suffix = _library_suffix()
+    package_root = os.path.abspath(os.path.dirname(__file__))
+    env_root = os.environ.get("OPENQP_ROOT")
+
+    if _is_oqp_root(package_root, suffix):
+        os.environ["OPENQP_ROOT"] = package_root
+        return package_root, suffix
+    if _is_oqp_root(env_root, suffix):
+        return env_root, suffix
+
+    if env_root:
+        raise RuntimeError(
+            "OPENQP_ROOT does not contain matching include/oqp.h and "
+            f"lib/liboqp.{suffix}: {env_root}"
+        )
+    raise RuntimeError(
+        "Cannot locate OpenQP runtime files. Install OpenQP as a package or set "
+        "OPENQP_ROOT to a tree containing include/oqp.h and lib/liboqp."
+    )
+
 
 try:
     int(os.environ['OMP_NUM_THREADS'])
@@ -40,16 +80,7 @@ if RTLD:
     from cffi import FFI
 
     ffi = FFI()
-    oqp_root = os.environ["OPENQP_ROOT"]
-
-    if platform.uname()[0] == "Windows":
-        suffix = "dll"
-    elif platform.uname()[0] == "Linux":
-        suffix = "so"
-    elif platform.uname()[0] == "Darwin":
-        suffix = "dylib"
-    else:
-        suffix = "so"
+    oqp_root, suffix = _resolve_oqp_root()
 
     with open(f"{oqp_root}/include/oqp.h", "r", encoding="ascii") as oqp_header:
         defs = oqp_header.read().replace("#include", "//#include")

--- a/pyoqp/oqp/__init__.py
+++ b/pyoqp/oqp/__init__.py
@@ -1,59 +1,14 @@
 """OQP instance"""
 
 import os
-import platform
 from oqp.utils.mpi_utils import MPIManager
+from oqp.runtime import resolve_oqp_root
 MPIManager()
 # we must import dftd4 ffi lib before oqp to load library correctly
 try:
     import dftd4.interface
 except ModuleNotFoundError:
     print('\nPyOQP: dftd4 is not available')
-
-def _library_suffix():
-    if platform.uname()[0] == "Windows":
-        return "dll"
-    if platform.uname()[0] == "Darwin":
-        return "dylib"
-    return "so"
-
-
-def _is_oqp_root(path, suffix):
-    return (
-        path
-        and os.path.exists(os.path.join(path, "include", "oqp.h"))
-        and os.path.exists(os.path.join(path, "lib", f"liboqp.{suffix}"))
-    )
-
-
-def _resolve_oqp_root():
-    """Choose a coherent root containing both oqp.h and liboqp.
-
-    Installed wheels put the Python package, header, and native library under the
-    package directory. Prefer that self-contained root over OPENQP_ROOT so a
-    leftover development environment variable cannot mix an installed Python
-    package with a different source-tree library. Source-tree imports do not have
-    package-local include/lib directories, so they still use OPENQP_ROOT.
-    """
-    suffix = _library_suffix()
-    package_root = os.path.abspath(os.path.dirname(__file__))
-    env_root = os.environ.get("OPENQP_ROOT")
-
-    if _is_oqp_root(package_root, suffix):
-        os.environ["OPENQP_ROOT"] = package_root
-        return package_root, suffix
-    if _is_oqp_root(env_root, suffix):
-        return env_root, suffix
-
-    if env_root:
-        raise RuntimeError(
-            "OPENQP_ROOT does not contain matching include/oqp.h and "
-            f"lib/liboqp.{suffix}: {env_root}"
-        )
-    raise RuntimeError(
-        "Cannot locate OpenQP runtime files. Install OpenQP as a package or set "
-        "OPENQP_ROOT to a tree containing include/oqp.h and lib/liboqp."
-    )
 
 
 try:
@@ -76,11 +31,12 @@ if os.environ.get('OQP_RTLD'):
 else:
     RTLD = True
 
+oqp_root, suffix = resolve_oqp_root()
+
 if RTLD:
     from cffi import FFI
 
     ffi = FFI()
-    oqp_root, suffix = _resolve_oqp_root()
 
     with open(f"{oqp_root}/include/oqp.h", "r", encoding="ascii") as oqp_header:
         defs = oqp_header.read().replace("#include", "//#include")

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -240,7 +240,7 @@ class Runner:
             _sentinel = os.path.join(_pkg, "pyoqp.py")
             _ver = getattr(oqp, "__version__", "")
             _commit = ""
-            for _d in (os.environ.get("OPENQP_ROOT"), _pkg):
+            for _d in (getattr(oqp, "oqp_root", None), _pkg):
                 if not _d:
                     continue
                 # Only trust a discovered git worktree if it actually TRACKS the

--- a/pyoqp/oqp/runtime.py
+++ b/pyoqp/oqp/runtime.py
@@ -1,0 +1,92 @@
+"""Helpers for locating OpenQP runtime files."""
+
+import os
+import platform
+from pathlib import Path
+
+
+def library_suffix():
+    if platform.uname()[0] == "Windows":
+        return "dll"
+    if platform.uname()[0] == "Darwin":
+        return "dylib"
+    return "so"
+
+
+def _is_oqp_root(path, suffix):
+    if not path:
+        return False
+
+    root = Path(path)
+    return (
+        (root / "include" / "oqp.h").exists()
+        and (root / "lib" / f"liboqp.{suffix}").exists()
+    )
+
+
+def _source_root_from_package(package_root):
+    package_root = Path(package_root)
+    if package_root.parent.name == "pyoqp":
+        return package_root.parent.parent
+    return None
+
+
+def _candidate_roots(package_root=None):
+    package_root = Path(package_root or Path(__file__).resolve().parent)
+    roots = [package_root]
+
+    source_root = _source_root_from_package(package_root)
+    if source_root is not None:
+        roots.append(source_root)
+
+    env_root = os.environ.get("OPENQP_ROOT")
+    if env_root:
+        roots.append(Path(env_root).expanduser())
+
+    seen = set()
+    unique_roots = []
+    for root in roots:
+        resolved = root.resolve()
+        if resolved not in seen:
+            unique_roots.append(resolved)
+            seen.add(resolved)
+    return unique_roots
+
+
+def resolve_oqp_root(package_root=None):
+    """Choose one root containing the matching header and native library.
+
+    Installed wheels keep the Python package, header, native library, and data
+    files together under the package directory. Source-tree development usually
+    keeps the Python package under pyoqp/oqp and runtime files under the repo
+    root. OPENQP_ROOT is retained only as a compatibility fallback for layouts
+    that cannot be inferred from the package location.
+    """
+    suffix = library_suffix()
+    for root in _candidate_roots(package_root):
+        if _is_oqp_root(root, suffix):
+            return str(root), suffix
+
+    env_root = os.environ.get("OPENQP_ROOT")
+    if env_root:
+        raise RuntimeError(
+            "OPENQP_ROOT does not contain matching include/oqp.h and "
+            f"lib/liboqp.{suffix}: {env_root}"
+        )
+
+    searched = ", ".join(str(root) for root in _candidate_roots(package_root))
+    raise RuntimeError(
+        "Cannot locate OpenQP runtime files. Install OpenQP as a package, run "
+        "from a built source tree, or set OPENQP_ROOT to a tree containing "
+        f"include/oqp.h and lib/liboqp.{suffix}. Searched: {searched}"
+    )
+
+
+def basis_search_paths(root=None, package_root=None):
+    if root is None:
+        root, _ = resolve_oqp_root(package_root=package_root)
+    root = Path(root)
+    return [
+        str(root / "share" / "basis_sets"),
+        str(root / "basis_sets"),
+    ]

--- a/pyoqp/oqp/utils/file_utils.py
+++ b/pyoqp/oqp/utils/file_utils.py
@@ -6,6 +6,7 @@ import datetime
 import numpy as np
 from oqp.molden.moldenwriter import write_frequency
 from oqp.periodic_table import SYMBOL_MAP, ELEMENTS_NAME
+from oqp.runtime import basis_search_paths
 from oqp.utils.constants import ANGSTROM_TO_BOHR
 from oqp.utils.mpi_utils import mpi_dump
 
@@ -15,18 +16,8 @@ def try_basis(basis, path=None, fallback='6-31g'):
 
     if path:
         basis_paths = [path]
-#    elif os.environ["OPENQP_ROOT"]:
-#        basis_path = os.environ["OPENQP_ROOT"] + "/share/basis_sets"
     else:
-        try:
-            os.environ["OPENQP_ROOT"]
-        except KeyError:
-            os.environ["OPENQP_ROOT"] = os.path.abspath(os.path.dirname(__file__), os.pardir)
-        root = os.environ["OPENQP_ROOT"]
-        basis_paths = [
-            os.path.join(root, "share", "basis_sets"),
-            os.path.join(root, "basis_sets"),
-        ]
+        basis_paths = basis_search_paths()
 
     if not basis:
         basis = fallback
@@ -51,16 +42,10 @@ def try_data_file(name):
     """Resolve a data file shipped under share/basis_sets (installed) or the
     source basis_sets/ tree (development)."""
 
-    try:
-        root = os.environ["OPENQP_ROOT"]
-    except KeyError:
-        root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    candidates = [name]
+    candidates.extend(os.path.join(path, name) for path in basis_search_paths())
 
-    for candidate in (
-        name,
-        os.path.join(root, "share", "basis_sets", name),
-        os.path.join(root, "basis_sets", name),
-    ):
+    for candidate in candidates:
         if os.path.isfile(candidate):
             return candidate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ wheel.packages = ["pyoqp/oqp"]
 [tool.scikit-build.cmake.define]
 USE_LIBINT = "OFF"
 ENABLE_OPENMP = "ON"
+ENABLE_OPENTRAH = "OFF"
 LINALG_LIB_INT64 = "ON"
 CMAKE_INSTALL_PREFIX = "."
 

--- a/source/trah_converger.F90
+++ b/source/trah_converger.F90
@@ -88,6 +88,11 @@ contains
     ! solve (the validated default).
     nrst = max(1, int(infos%control%trh_nrtv))
     if (infos%control%mom) nrst = 1     ! no symmetry-breaking restarts under MOM
+    ! The RHF TRAH setup stores only alpha MOs.  The native trust-region
+    ! driver passes both alpha and beta arrays through shared RHF/UHF/ROHF
+    ! helpers, so provide a beta shadow for RHF instead of dereferencing an
+    ! unallocated conv%mo_b.
+    if (.not. allocated(conv%mo_b)) allocate(conv%mo_b, source=conv%mo_a)
     allocate(mo0_a, source=conv%mo_a); allocate(mo0_b, source=conv%mo_b)
     allocate(mob_a, source=conv%mo_a); allocate(mob_b, source=conv%mo_b)
     e_best = huge(1.0_dp); have_best = .false.

--- a/tests/test_native_trah_rhf_guard.py
+++ b/tests/test_native_trah_rhf_guard.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_native_trah_allocates_rhf_beta_shadow_before_copying_mos():
+    source = (ROOT / "source" / "trah_converger.F90").read_text()
+
+    guard = "if (.not. allocated(conv%mo_b)) allocate(conv%mo_b, source=conv%mo_a)"
+    copy = "allocate(mo0_a, source=conv%mo_a); allocate(mo0_b, source=conv%mo_b)"
+
+    assert guard in source
+    assert source.index(guard) < source.index(copy)

--- a/tests/test_opentrustregion_linalg_config.py
+++ b/tests/test_opentrustregion_linalg_config.py
@@ -27,8 +27,10 @@ class OpenTrustRegionLinalgConfigTests(unittest.TestCase):
         self.assertIn("fdefault-integer-8", external_cmake)
         self.assertIn("fallow-argument-mismatch", external_cmake)
         self.assertIn("CMAKE_Fortran_FLAGS=${otr_fortran_flags}", external_cmake)
-        self.assertIn("BLAS_LIBRARIES=${LIBBLAS}", external_cmake)
-        self.assertIn("LAPACK_LIBRARIES=${LIBLAPACK}", external_cmake)
+        self.assertIn("OQP_EXTERNAL_LIST_SEPARATOR", external_cmake)
+        self.assertIn("oqp_external_cmake_list_arg(_otr_blas_arg BLAS_LIBRARIES", external_cmake)
+        self.assertIn("oqp_external_cmake_list_arg(_otr_lapack_arg LAPACK_LIBRARIES", external_cmake)
+        self.assertIn("LIST_SEPARATOR ${OQP_EXTERNAL_LIST_SEPARATOR}", external_cmake)
         self.assertIn("add_dependencies(libopentrustregion LAPACK)", external_cmake)
         self.assertIn("CMAKE_POLICY_VERSION_MINIMUM=3.5", external_cmake)
         self.assertIn("PATCH_COMMAND /usr/bin/perl", external_cmake)
@@ -44,6 +46,11 @@ class OpenTrustRegionLinalgConfigTests(unittest.TestCase):
         self.assertIn("if(TARGET oqp)", functions_cmake)
         self.assertIn("add_dependencies(oqp LAPACK)", functions_cmake)
         self.assertIn("target_link_libraries(oqp ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})", functions_cmake)
+
+    def test_python_wheel_uses_native_trah_without_building_opentrah(self):
+        pyproject = (ROOT / "pyproject.toml").read_text()
+
+        self.assertIn('ENABLE_OPENTRAH = "OFF"', pyproject)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -1,21 +1,140 @@
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "pyoqp" / "oqp" / "runtime.py"
 
 
-def test_python_runtime_prefers_package_local_root_over_openqp_root():
-    source = (ROOT / "pyoqp" / "oqp" / "__init__.py").read_text()
-
-    assert "def _resolve_oqp_root" in source
-    assert "if _is_oqp_root(package_root, suffix):" in source
-    assert "os.environ[\"OPENQP_ROOT\"] = package_root" in source
-    assert "if _is_oqp_root(env_root, suffix):" in source
+def load_runtime_module():
+    spec = importlib.util.spec_from_file_location("openqp_runtime_test", RUNTIME)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
-def test_cmake_forces_ilp64_when_stale_cache_sets_lp64():
-    source = (ROOT / "CMakeLists.txt").read_text()
+def make_runtime_root(root, suffix):
+    (root / "include").mkdir(parents=True)
+    (root / "lib").mkdir()
+    (root / "share" / "basis_sets").mkdir(parents=True)
+    (root / "include" / "oqp.h").write_text("")
+    (root / "lib" / f"liboqp.{suffix}").write_text("")
 
-    assert "Forcing LINALG_LIB_INT64=ON" in source
-    assert "set(LINALG_LIB_INT64 ON CACHE BOOL" in source
-    assert "FORCE)" in source
+
+class RuntimeRootResolutionTests(unittest.TestCase):
+    def test_python_runtime_prefers_package_local_root_over_openqp_root(self):
+        runtime = load_runtime_module()
+        suffix = runtime.library_suffix()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            package_root = tmp_path / "site-packages" / "oqp"
+            env_root = tmp_path / "other-openqp"
+            make_runtime_root(package_root, suffix)
+            make_runtime_root(env_root, suffix)
+
+            with patch.dict(os.environ, {"OPENQP_ROOT": str(env_root)}, clear=False):
+                root, actual_suffix = runtime.resolve_oqp_root(package_root=package_root)
+
+                self.assertEqual(root, str(package_root.resolve()))
+                self.assertEqual(actual_suffix, suffix)
+                self.assertEqual(os.environ["OPENQP_ROOT"], str(env_root))
+
+    def test_python_runtime_detects_source_tree_without_openqp_root(self):
+        runtime = load_runtime_module()
+        suffix = runtime.library_suffix()
+        env = os.environ.copy()
+        env.pop("OPENQP_ROOT", None)
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source_root = tmp_path / "openqp"
+            package_root = source_root / "pyoqp" / "oqp"
+            package_root.mkdir(parents=True)
+            make_runtime_root(source_root, suffix)
+
+            with patch.dict(os.environ, env, clear=True):
+                root, actual_suffix = runtime.resolve_oqp_root(package_root=package_root)
+
+                self.assertEqual(root, str(source_root.resolve()))
+                self.assertEqual(actual_suffix, suffix)
+
+    def test_python_runtime_keeps_openqp_root_as_fallback(self):
+        runtime = load_runtime_module()
+        suffix = runtime.library_suffix()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            package_root = tmp_path / "isolated" / "oqp"
+            env_root = tmp_path / "configured-openqp"
+            package_root.mkdir(parents=True)
+            make_runtime_root(env_root, suffix)
+
+            with patch.dict(os.environ, {"OPENQP_ROOT": str(env_root)}, clear=False):
+                root, actual_suffix = runtime.resolve_oqp_root(package_root=package_root)
+
+                self.assertEqual(root, str(env_root.resolve()))
+                self.assertEqual(actual_suffix, suffix)
+
+    def test_non_rtld_import_resolves_package_root_without_mutating_env(self):
+        runtime = load_runtime_module()
+        suffix = runtime.library_suffix()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            site_root = tmp_path / "site"
+            package_root = site_root / "oqp"
+            (package_root / "utils").mkdir(parents=True)
+            (package_root / "__init__.py").write_text(
+                (ROOT / "pyoqp" / "oqp" / "__init__.py").read_text()
+            )
+            (package_root / "runtime.py").write_text(RUNTIME.read_text())
+            (package_root / "utils" / "__init__.py").write_text("")
+            (package_root / "utils" / "mpi_utils.py").write_text(
+                "class MPIManager:\n"
+                "    def __init__(self):\n"
+                "        pass\n"
+            )
+            (site_root / "_oqp.py").write_text(
+                "ffi = object()\n"
+                "class Lib:\n"
+                "    def __dir__(self):\n"
+                "        return []\n"
+                "lib = Lib()\n"
+            )
+            make_runtime_root(package_root, suffix)
+
+            env_root = tmp_path / "other-openqp"
+            env = os.environ.copy()
+            env.update({
+                "OPENQP_ROOT": str(env_root),
+                "OQP_RTLD": "0",
+                "PYTHONPATH": str(site_root),
+            })
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os, oqp; "
+                    "print(oqp.oqp_root); "
+                    "print(os.environ.get('OPENQP_ROOT'))",
+                ],
+                check=False,
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            lines = result.stdout.strip().splitlines()
+            self.assertEqual(lines[-2], str(package_root.resolve()))
+            self.assertEqual(lines[-1], str(env_root))
+
+    def test_cmake_forces_ilp64_when_stale_cache_sets_lp64(self):
+        source = (ROOT / "CMakeLists.txt").read_text()
+
+        self.assertIn("Forcing LINALG_LIB_INT64=ON", source)
+        self.assertIn("set(LINALG_LIB_INT64 ON CACHE BOOL", source)
+        self.assertIn("FORCE)", source)

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_python_runtime_prefers_package_local_root_over_openqp_root():
+    source = (ROOT / "pyoqp" / "oqp" / "__init__.py").read_text()
+
+    assert "def _resolve_oqp_root" in source
+    assert "if _is_oqp_root(package_root, suffix):" in source
+    assert "os.environ[\"OPENQP_ROOT\"] = package_root" in source
+    assert "if _is_oqp_root(env_root, suffix):" in source
+
+
+def test_cmake_forces_ilp64_when_stale_cache_sets_lp64():
+    source = (ROOT / "CMakeLists.txt").read_text()
+
+    assert "Forcing LINALG_LIB_INT64=ON" in source
+    assert "set(LINALG_LIB_INT64 ON CACHE BOOL" in source
+    assert "FORCE)" in source


### PR DESCRIPTION
## Summary
- Prefer package-local OpenQP runtime files when an installed wheel contains include/ and lib/, so a leftover OPENQP_ROOT cannot mix installed Python with another native library.
- Still allow source-tree development via OPENQP_ROOT when package-local runtime files are absent.
- Repair stale CMake caches by forcing LINALG_LIB_INT64=ON instead of failing when an old cache has LP64 disabled.
- Add regression tests for runtime-root selection and stale ILP64 cache handling.

## Test Plan
- /opt/homebrew/bin/python3.11 tests/test_runtime_root_resolution.py helpers invoked manually
- cmake -S . -B /tmp/openqp-cmake-stale -G Ninja -DENABLE_PYTHON=OFF -DLINALG_LIB_INT64=OFF
- OPENQP_ROOT=/Users/cheolhochoi/clone/openqp PYTHONPATH=/Users/cheolhochoi/clone/openqp/pyoqp /opt/homebrew/bin/python3.11 -c 'import oqp; print(hasattr(oqp, "cphf_dpdx_selftest"))'

Note: pytest is not installed in this local Homebrew Python, so the new pytest tests were invoked directly.