### PR TITLE
fix(int1): add barrier to one-electron integral worksharing loops nested in replicated outer loops

### DIFF
--- a/source/integrals/int1.F90
+++ b/source/integrals/int1.F90
@@ -973,7 +973,7 @@ contains
             CALL update_rectangular_matrix(shi, shj, sblk, s)
 
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
 !   End of shell loops
@@ -1044,7 +1044,7 @@ contains
             CALL update_triang_matrix(shi, shj, sblk, s)
 
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
 !   End of shell loops
@@ -1122,7 +1122,7 @@ contains
             CALL update_triang_matrix(shi, shj, tblk, t)
 
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
 !   End of shell loops
@@ -1184,7 +1184,7 @@ contains
             end do
 
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
 !   End of shell loops
@@ -1246,7 +1246,7 @@ contains
             end do
 
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
 !   End of shell loops
@@ -1450,7 +1450,7 @@ contains
             CALL update_triang_matrix(shi, shj, vblk, h)
 
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
 !   End of shell loops
@@ -1532,7 +1532,7 @@ contains
             CALL update_triang_matrix(shi, shj, vblk, h)
 
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
 !   End of shell loops
@@ -1954,7 +1954,7 @@ contains
             end do
 
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
  END SUBROUTINE
@@ -2021,7 +2021,7 @@ contains
               CALL update_triang_matrix(shi, shj, blk(:,m), ints(:,m))
             end do
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
  END SUBROUTINE
@@ -2085,7 +2085,7 @@ contains
               CALL update_triang_matrix(shi, shj, blk(:,m), ints(:,m))
             end do
         END DO
-!$omp end do nowait
+!$omp end do
     END DO
 !$omp end parallel
  END SUBROUTINE


### PR DESCRIPTION
## Summary

Ten one-electron integral routines in `source/integrals/int1.F90` share a parallel pattern that can desynchronize OpenMP worker threads. Each has an `!$omp do schedule(dynamic)` over the **inner** shell index nested inside an **outer** shell loop that *every thread executes* (the outer `DO` is not a worksharing construct). The inner loop ended with `!$omp end do nowait`.

Without the implicit barrier, a thread that finishes its chunk of the inner loop races ahead into the next outer iteration and re-enters the worksharing region while other threads are still finishing the current one. With `schedule(dynamic)` this leaves threads spread across two live instances of the same worksharing construct, corrupting the work-share dispatch state. This was observed as an **intermittent segfault in `basis_overlap`** under OpenMP, and is a latent correctness/stability hazard in the siblings.

Removing `nowait` restores the per-outer-iteration barrier, so all threads finish the inner shell loop before any advances to the next outer shell.

## Why this is safe / cheap

- Adding a barrier can never produce incorrect results — worst case is a small synchronization cost.
- These are **one-electron** integral routines (overlap, kinetic, multipole, external-charge, GIAO), evaluated **once per geometry**, not per SCF iteration. The ERI/Fock hot path is untouched. So the added sync cost is negligible.

## Scope

**Fixed (same nested pattern):**
`basis_overlap`, `overlap`, `kin_ovl_ints`, `mult_all_ints`, `mult_ints`, `int1_coul_ext_chg`, `int1_coul_ext_chg_ewaldsr`, `amom_ints`, `giao_overlap_deriv_ints`, `giao_h10_core_ints` — 10 sites.

**Deliberately left unchanged:**
`lzints` and the second parallel region of `int1_coul_ext_chg_ewaldsr` — there the `!$omp do` is a single top-level worksharing loop (not nested in a replicated outer loop), so `nowait` is harmless before the parallel region's own closing barrier.

## Diff

10 single-line changes, each `!$omp end do nowait` → `!$omp end do`. No logic changes.