### PR TITLE
fix(scf): make post-SCF stability check opt-in (scf.stability default off)

### DIFF
--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -454,8 +454,9 @@ class SinglePoint(Calculator):
         Data summary (OpenQP, 58 cells): C-DIIS is the best primary (wins 52/58, mean
         ~21 Fock builds vs A-DIIS 39, E-DIIS 53); the hard class is open-shell
         transition-metal systems (esp. DFT), where C-DIIS can stall/find a wrong basin
-        -> keep C-DIIS but enable the TRAH stability safeguard. The reactive escalation
-        ladder (DIIS->SOSCF->TRAH) remains the safety net for all classes.
+        -> keep C-DIIS and rely on the reactive escalation ladder
+        (DIIS->SOSCF->TRAH) as the safety net for all classes. The TRAH stability
+        safeguard is opt-in (scf.stability) and is never enabled here automatically.
 
         mode='ml' uses a trained, distilled model if shipped in pyoqp; otherwise it
         transparently falls back to these rules.
@@ -472,13 +473,12 @@ class SinglePoint(Calculator):
             except Exception:
                 used = 'ML(no model -> rules)'
 
-        # ROHF/UHF stability is the priority: ROKS is the MRSF-TDDFT reference, so an
-        # open-shell SCF that lands on a non-lowest (unstable) solution corrupts the
-        # excited-state calculation. Enable the stability safeguard for open-shell
-        # references (especially DFT/ROKS and transition-metal), where it matters most.
-        hard = f['open_shell'] and (f['transition_metal'] or f['is_dft'])
-        if used != 'ML-model' and hard:
-            stability = True
+        # Stability following is opt-in: it runs only when the user sets
+        # scf.stability in the input. The SCF manager never enables it on its
+        # own -- not even for the hard class (open-shell DFT/ROKS or
+        # transition-metal references), where it matters most. The reactive
+        # escalation ladder (DIIS->SOSCF->TRAH) remains the convergence safety
+        # net for all classes regardless.
 
         dump_log(self.mol, section='',
                  title='PyOQP SCF manager [%s]: %s%s%s%s -> primary=%s%s' % (
@@ -487,7 +487,7 @@ class SinglePoint(Calculator):
                      'TM ' if f['transition_metal'] else '',
                      'DFT' if f['is_dft'] else 'HF',
                      ' natom=%d' % f['natom'],
-                     primary, ' +stability' if (stability and hard) else ''))
+                     primary, ' +stability' if stability else ''))
         return primary, stability
 
     def _run_scf(self):
@@ -508,13 +508,14 @@ class SinglePoint(Calculator):
              ``scf.alternative_scf`` (back-compat) sets only the final method.
              The primary converger is dropped from the chain and duplicates are
              removed while preserving order.
-          3. **Stability safeguard** (``scf.stability``, default on) — seed a
+          3. **Stability safeguard** (``scf.stability``, default off,
+             opt-in) — when the user requests it in the input, seed a
              stability-following TRAH pass from the converged orbitals.  At a
              genuine minimum this is a ~0-iteration no-op; when the converged
              point is an unstable saddle it relaxes to the lowest solution.
              This catches the case where DIIS *converges* to a non-aufbau /
              non-lowest open-shell (UHF/ROHF) solution and would otherwise be
-             returned silently.
+             returned silently.  It is never enabled automatically.
 
         Returns
         -------

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -144,7 +144,7 @@ OQP_CONFIG_SCHEMA = {
         'rstctmo': {'type': bool, 'default': 'False'},
         'converger_type': {'type': string, 'default': 'diis'},
         'scal_rel': {'type': int, 'default': '0'},
-        'stability': {'type': bool, 'default': 'True'},
+        'stability': {'type': bool, 'default': 'False'},
         'soscf_lvl_shift': {'type': float, 'default': '0'},
         'alternative_scf': {'type': string, 'default': 'trah'},
         'escalation': {'type': string, 'default': ''},


### PR DESCRIPTION
## Summary

Make the post-SCF stability check **strictly opt-in**. Previously the Stage-3 stability safeguard in the unified SCF driver (`_run_scf`) ran **by default** for converged ground-state runs, and the `auto`/`ml` SCF manager **force-enabled** it for the hard open-shell DFT / transition-metal class. This ran a TRAH stability-following pass the user never requested.

After this change the stability check runs **only when the user sets `scf.stability` in the input**, and the code never enables it on its own.

## Motivation

The safeguard is a ~0-iteration no-op at a genuine minimum, but it still:
- performs an extra Fock build,
- can energy-invariantly re-canonicalize/rotate the converged orbitals, and
- distorts clean SCF-only timing measurements.

Users who want the safeguard can still request it explicitly; users who don't should not pay for it silently.

## Changes

- **`pyoqp/oqp/molecule/oqpdata.py`** — `scf.stability` schema default flipped `True` → `False`.
- **`pyoqp/oqp/library/single_point.py`** — `_select_converger` no longer force-sets `stability = True` for the hard class; the reactive `DIIS → SOSCF → TRAH` escalation ladder remains the convergence safety net for all classes. Docstrings and the SCF-manager log annotation updated for the default-off, opt-in behavior.

## Behavior when opted in (unchanged)

With `scf.stability` set, a converged ground-state SCF (`method='hf'`, non-TRAH primary) seeds a TRAH stability-following pass; it keeps the lower solution if the converged point was unstable, otherwise restores the original orbitals. Excited-state (`tdhf`/`sf`/`mrsf`) runs remain excluded, as before.

## Note on the convergence safety net

This only changes the *stability-following* pass. The reactive escalation ladder that handles non-convergence (DIIS → SOSCF → TRAH) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)