### PR TITLE
Add automated release packaging workflow

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -8,6 +8,7 @@ name: Build and publish wheels
       - "CMakeLists.txt"
       - "MANIFEST.in"
       - "pyproject.toml"
+      - "basis_sets/**"
       - "cmake/**"
       - "external/**"
       - "include/**"
@@ -108,7 +109,7 @@ jobs:
         env:
           CIBW_PLATFORM: ${{ matrix.platform }}
           CIBW_ARCHS: ${{ matrix.archs }}
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-musllinux_* pp*"
           CIBW_BEFORE_ALL: ${{ matrix.before_all }}
           CIBW_ENVIRONMENT: ${{ matrix.environment }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,42 +1,195 @@
-name: Build wheels
+name: Build and publish wheels
 
-on:
-  push:
-    branches: [pypi]
+"on":
+  workflow_dispatch:
   pull_request:
-    branches: [pypi]
+    paths:
+      - ".github/workflows/build_wheels.yml"
+      - "CMakeLists.txt"
+      - "MANIFEST.in"
+      - "pyproject.toml"
+      - "cmake/**"
+      - "external/**"
+      - "include/**"
+      - "pyoqp/**"
+      - "source/**"
+  push:
+    tags:
+      - "v*"
+  release:
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build sdist
+        run: |
+          python -m pip install --upgrade build
+          python -m build --sdist --outdir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openqp-sdist
+          path: dist/*
+          if-no-files-found: error
+
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        include:
+          - name: linux-x86_64
+            os: ubuntu-24.04
+            platform: linux
+            archs: x86_64
+            before_all: yum install -y gcc-gfortran
+            environment: >-
+              CMAKE_ARGS='-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
+              -DLINALG_LIB=auto
+              -DLINALG_LIB_INT64=ON'
+            repair: >-
+              LD_LIBRARY_PATH="oqp/lib:$LD_LIBRARY_PATH"
+              auditwheel repair -w {dest_dir} {wheel}
+
+          - name: macos-x86_64
+            os: macos-15-intel
+            platform: macos
+            archs: x86_64
+            before_all: brew install gcc@15
+            environment: >-
+              CMAKE_ARGS='-DCMAKE_C_COMPILER=gcc-15
+              -DCMAKE_CXX_COMPILER=g++-15
+              -DCMAKE_Fortran_COMPILER=gfortran-15
+              -DLINALG_LIB=auto
+              -DLINALG_LIB_INT64=OFF'
+            repair: >-
+              delocate-wheel --require-archs {delocate_archs}
+              -w {dest_dir} -v {wheel}
+
+          - name: macos-arm64
+            os: macos-15
+            platform: macos
+            archs: arm64
+            before_all: brew install gcc@15
+            environment: >-
+              CMAKE_ARGS='-DCMAKE_C_COMPILER=gcc-15
+              -DCMAKE_CXX_COMPILER=g++-15
+              -DCMAKE_Fortran_COMPILER=gfortran-15
+              -DLINALG_LIB=auto
+              -DLINALG_LIB_INT64=OFF'
+            repair: >-
+              delocate-wheel --require-archs {delocate_archs}
+              -w {dest_dir} -v {wheel}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
+        run: python -m pip install --upgrade cibuildwheel
 
       - name: Build wheels
         env:
-          CIBW_PLATFORM: linux
-          CIBW_SKIP: "*-musllinux_*"
-          CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel gcc-gfortran"
-          CIBW_ENVIRONMENT: "CMAKE_ARGS='-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH'"
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "LD_LIBRARY_PATH=\"oqp/lib:$LD_LIBRARY_PATH\" auditwheel repair -w {dest_dir} {wheel}"
+          CIBW_PLATFORM: ${{ matrix.platform }}
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "*-musllinux_* pp*"
+          CIBW_BEFORE_ALL: ${{ matrix.before_all }}
+          CIBW_ENVIRONMENT: ${{ matrix.environment }}
+          CIBW_REPAIR_WHEEL_COMMAND: ${{ matrix.repair }}
+          CIBW_TEST_COMMAND: >-
+            python -c "import oqp, pathlib;
+            root = pathlib.Path(oqp.oqp_root);
+            assert (root / 'include' / 'oqp.h').exists();
+            assert any((root / 'lib').glob('liboqp.*'));
+            assert (root / 'share' / 'basis_sets').exists();
+            print('OpenQP runtime root:', root)"
+        run: python -m cibuildwheel --output-dir dist
 
-        run: cibuildwheel --output-dir dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openqp-wheels-${{ matrix.name }}
+          path: dist/*
+          if-no-files-found: error
 
-        #      - name: Upload wheels as artifacts
-        #        uses: actions/upload-artifact@v4
-        #        with:
-        #          name: wheels-${{ matrix.os }}
-        #          path: wheelhouse/*.whl
+  verify_release_version:
+    name: Verify release tag matches pyproject version
+    if: github.event_name == 'release'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check tag and package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          tag = os.environ["RELEASE_TAG"]
+          version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          expected = f"v{version}"
+          if tag != expected:
+              raise SystemExit(
+                  f"Release tag {tag!r} does not match pyproject.toml version {version!r}. "
+                  f"Expected {expected!r}."
+              )
+          print(f"Release tag matches OpenQP version {version}.")
+          PY
+
+  publish:
+    name: Publish release artifacts
+    if: github.event_name == 'release'
+    needs:
+      - build_sdist
+      - build_wheels
+      - verify_release_version
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/openqp
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: openqp-*
+          path: dist
+          merge-multiple: true
+
+      - name: Show artifacts
+        run: ls -lh dist
+
+      - name: Attach artifacts to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" dist/* --clobber
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -71,6 +71,7 @@ jobs:
             archs: x86_64
             before_all: brew install gcc@15
             environment: >-
+              MACOSX_DEPLOYMENT_TARGET=15.0
               CMAKE_ARGS='-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15
@@ -86,6 +87,7 @@ jobs:
             archs: arm64
             before_all: brew install gcc@15
             environment: >-
+              MACOSX_DEPLOYMENT_TARGET=15.0
               CMAKE_ARGS='-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -44,8 +44,8 @@ that job runs only after a GitHub Release is published.
 The first automated release workflow builds:
 
 - Linux x86_64 manylinux wheels
-- macOS x86_64 wheels
-- macOS arm64 wheels
+- macOS x86_64 wheels for macOS 15 or newer
+- macOS arm64 wheels for macOS 15 or newer
 - Source distribution
 
 Windows wheels should be added after native Windows runtime layout is validated.

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -1,0 +1,66 @@
+# OpenQP Release Packaging
+
+This repository owns the build and publication of the `openqp` Python package.
+The user-facing install command is:
+
+```bash
+pip install openqp
+```
+
+The `.github/workflows/build_wheels.yml` workflow builds source distributions
+and binary wheels whenever release-sensitive files change in a pull request,
+whenever a `v*` tag is pushed, and whenever a GitHub Release is published.
+Only the `release: published` event uploads to PyPI.
+
+## Release Checklist
+
+1. Update `project.version` in `pyproject.toml`.
+2. Create and push a matching tag, for example `v1.2.0`.
+3. Publish a GitHub Release from that tag.
+4. Wait for the wheel workflow to finish.
+5. Confirm that the release assets and PyPI files include the expected wheels.
+
+The workflow verifies that the GitHub Release tag is exactly `v` plus the
+`pyproject.toml` version. For example, `version = "1.2.0"` must be released as
+`v1.2.0`.
+
+## PyPI Trusted Publishing
+
+Configure the `openqp` project on PyPI with a GitHub Trusted Publisher instead
+of storing a PyPI token in repository secrets.
+
+Use these values:
+
+- Owner: `Open-Quantum-Platform`
+- Repository: `openqp`
+- Workflow: `.github/workflows/build_wheels.yml`
+- Environment: `pypi`
+
+The workflow requests GitHub OIDC credentials only in the publishing job, and
+that job runs only after a GitHub Release is published.
+
+## Current Platform Plan
+
+The first automated release workflow builds:
+
+- Linux x86_64 manylinux wheels
+- macOS x86_64 wheels
+- macOS arm64 wheels
+- Source distribution
+
+Windows wheels should be added after native Windows runtime layout is validated.
+Until then, Windows users should use WSL2, Docker, or a future conda-forge
+package.
+
+## Installer Site Repository
+
+A separate `Open-Quantum-Platform/openqp-install` repository provides the public
+install page without owning the package build itself. It should link to:
+
+- PyPI: `https://pypi.org/project/openqp/`
+- GitHub Releases from this repository
+- Docker image instructions
+- Windows WSL2/Docker instructions until native Windows wheels are available
+
+Keep source builds, wheel builds, PyPI publishing, and release assets in this
+main `openqp` repository so every package is built from the exact source tag.

--- a/pyoqp/CMakeLists.txt
+++ b/pyoqp/CMakeLists.txt
@@ -71,6 +71,17 @@ add_custom_target(liboqp
         ${CMAKE_CURRENT_BINARY_DIR}/_oqp${_cffi_ext_suffix}
 )
 
+if(APPLE)
+  add_custom_command(
+    TARGET liboqp
+    POST_BUILD
+    COMMAND install_name_tool -change @rpath/liboqp.dylib
+            @loader_path/liboqp.dylib
+            ${CMAKE_CURRENT_BINARY_DIR}/_oqp.abi3${OQP_ABI3_SUFFIX}
+    COMMENT "Rewriting PyOQP extension load path for package-local liboqp.dylib"
+  )
+endif()
+
 add_dependencies(liboqp oqp)
 
 get_filename_component(OQP_INSTALL ${CMAKE_INSTALL_PREFIX} ABSOLUTE)

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -144,3 +144,10 @@ class RuntimeRootResolutionTests(unittest.TestCase):
 
         self.assertIn("install_name_tool -change @rpath/liboqp.dylib", source)
         self.assertIn("@loader_path/liboqp.dylib", source)
+
+    def test_macos_wheel_target_matches_runner_gcc_runtime(self):
+        source = (ROOT / ".github" / "workflows" / "build_wheels.yml").read_text()
+
+        self.assertIn("os: macos-15-intel", source)
+        self.assertIn("os: macos-15", source)
+        self.assertEqual(source.count("MACOSX_DEPLOYMENT_TARGET=15.0"), 2)

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -138,3 +138,9 @@ class RuntimeRootResolutionTests(unittest.TestCase):
         self.assertIn("Forcing LINALG_LIB_INT64=ON", source)
         self.assertIn("set(LINALG_LIB_INT64 ON CACHE BOOL", source)
         self.assertIn("FORCE)", source)
+
+    def test_macos_cffi_extension_uses_package_local_liboqp(self):
+        source = (ROOT / "pyoqp" / "CMakeLists.txt").read_text()
+
+        self.assertIn("install_name_tool -change @rpath/liboqp.dylib", source)
+        self.assertIn("@loader_path/liboqp.dylib", source)


### PR DESCRIPTION
## Summary
- Replace the old Linux-only wheel job with a release-oriented workflow that builds sdist, Linux x86_64 wheels, macOS x86_64 wheels, and macOS arm64 wheels.
- Publish artifacts to GitHub Releases and PyPI only from the GitHub Release published event.
- Add release packaging notes for the openqp install path, PyPI Trusted Publishing, and the separate install-site repo.

## Validation
- Parsed the workflow YAML locally and verified triggers/jobs.
- Ran git diff --check.
- Ran the package-local runtime-root resolver tests relevant to wheel layout.

## Follow-up
- Configure PyPI Trusted Publisher for the openqp project with repository Open-Quantum-Platform/openqp, workflow .github/workflows/build_wheels.yml, environment pypi.