### PR TITLE
Limit PR wheel builds to cached Linux smoke

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -15,9 +15,6 @@ name: Build and publish wheels
       - "include/**"
       - "pyoqp/**"
       - "source/**"
-  push:
-    tags:
-      - "v*"
   release:
     types: [published]
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -76,10 +76,10 @@ jobs:
           CIBW_SKIP: "*-musllinux_* pp*"
           CIBW_BEFORE_ALL: yum install -y gcc-gfortran
           CIBW_ENVIRONMENT: >-
-            OQP_EXTERNALS_ROOT="$(pwd)/.openqp-externals"
-            CMAKE_ARGS='-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
+            CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
+            -DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals
             -DLINALG_LIB=auto
-            -DLINALG_LIB_INT64=ON'
+            -DLINALG_LIB_INT64=ON"
           CIBW_REPAIR_WHEEL_COMMAND: >-
             LD_LIBRARY_PATH="oqp/lib:$LD_LIBRARY_PATH"
             auditwheel repair -w {dest_dir} {wheel}
@@ -112,10 +112,10 @@ jobs:
             archs: x86_64
             before_all: yum install -y gcc-gfortran
             environment: >-
-              OQP_EXTERNALS_ROOT="$(pwd)/.openqp-externals"
-              CMAKE_ARGS='-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
+              CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
+              -DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals
               -DLINALG_LIB=auto
-              -DLINALG_LIB_INT64=ON'
+              -DLINALG_LIB_INT64=ON"
             repair: >-
               LD_LIBRARY_PATH="oqp/lib:$LD_LIBRARY_PATH"
               auditwheel repair -w {dest_dir} {wheel}
@@ -126,13 +126,13 @@ jobs:
             archs: x86_64
             before_all: brew install gcc@15
             environment: >-
-              OQP_EXTERNALS_ROOT="$(pwd)/.openqp-externals"
               MACOSX_DEPLOYMENT_TARGET=15.0
-              CMAKE_ARGS='-DCMAKE_C_COMPILER=gcc-15
+              CMAKE_ARGS="-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15
+              -DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals
               -DLINALG_LIB=auto
-              -DLINALG_LIB_INT64=OFF'
+              -DLINALG_LIB_INT64=OFF"
             repair: >-
               delocate-wheel --require-archs {delocate_archs}
               -w {dest_dir} -v {wheel}
@@ -143,13 +143,13 @@ jobs:
             archs: arm64
             before_all: brew install gcc@15
             environment: >-
-              OQP_EXTERNALS_ROOT="$(pwd)/.openqp-externals"
               MACOSX_DEPLOYMENT_TARGET=15.0
-              CMAKE_ARGS='-DCMAKE_C_COMPILER=gcc-15
+              CMAKE_ARGS="-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15
+              -DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals
               -DLINALG_LIB=auto
-              -DLINALG_LIB_INT64=OFF'
+              -DLINALG_LIB_INT64=OFF"
             repair: >-
               delocate-wheel --require-archs {delocate_archs}
               -w {dest_dir} -v {wheel}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -3,6 +3,7 @@ name: Build and publish wheels
 "on":
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - ".github/workflows/build_wheels.yml"
       - "CMakeLists.txt"
@@ -45,8 +46,61 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  build_wheel_smoke:
+    name: Build Linux wheel smoke
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache bundled externals
+        uses: actions/cache@v4
+        with:
+          path: .openqp-externals
+          key: oqp-wheel-externals-linux-x86_64-${{ hashFiles('external/CMakeLists.txt', 'CMakeLists.txt', 'pyproject.toml', '.github/workflows/build_wheels.yml') }}
+          restore-keys: |
+            oqp-wheel-externals-linux-x86_64-
+
+      - name: Install cibuildwheel
+        run: python -m pip install --upgrade cibuildwheel
+
+      - name: Build smoke wheel
+        env:
+          CIBW_PLATFORM: linux
+          CIBW_ARCHS: x86_64
+          CIBW_BUILD: "cp311-*"
+          CIBW_SKIP: "*-musllinux_* pp*"
+          CIBW_BEFORE_ALL: yum install -y gcc-gfortran
+          CIBW_ENVIRONMENT: >-
+            OQP_EXTERNALS_ROOT="$(pwd)/.openqp-externals"
+            CMAKE_ARGS='-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
+            -DLINALG_LIB=auto
+            -DLINALG_LIB_INT64=ON'
+          CIBW_REPAIR_WHEEL_COMMAND: >-
+            LD_LIBRARY_PATH="oqp/lib:$LD_LIBRARY_PATH"
+            auditwheel repair -w {dest_dir} {wheel}
+          CIBW_TEST_COMMAND: >-
+            python -c "import oqp, pathlib;
+            root = pathlib.Path(oqp.oqp_root);
+            assert (root / 'include' / 'oqp.h').exists();
+            assert any((root / 'lib').glob('liboqp.*'));
+            assert (root / 'share' / 'basis_sets').exists();
+            print('OpenQP runtime root:', root)"
+        run: python -m cibuildwheel --output-dir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openqp-wheel-smoke-linux-x86_64
+          path: dist/*
+          if-no-files-found: error
+
   build_wheels:
     name: Build wheels (${{ matrix.name }})
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -58,6 +112,7 @@ jobs:
             archs: x86_64
             before_all: yum install -y gcc-gfortran
             environment: >-
+              OQP_EXTERNALS_ROOT="$(pwd)/.openqp-externals"
               CMAKE_ARGS='-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
               -DLINALG_LIB=auto
               -DLINALG_LIB_INT64=ON'
@@ -71,6 +126,7 @@ jobs:
             archs: x86_64
             before_all: brew install gcc@15
             environment: >-
+              OQP_EXTERNALS_ROOT="$(pwd)/.openqp-externals"
               MACOSX_DEPLOYMENT_TARGET=15.0
               CMAKE_ARGS='-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
@@ -87,6 +143,7 @@ jobs:
             archs: arm64
             before_all: brew install gcc@15
             environment: >-
+              OQP_EXTERNALS_ROOT="$(pwd)/.openqp-externals"
               MACOSX_DEPLOYMENT_TARGET=15.0
               CMAKE_ARGS='-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
@@ -103,6 +160,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Cache bundled externals
+        uses: actions/cache@v4
+        with:
+          path: .openqp-externals
+          key: oqp-wheel-externals-${{ matrix.name }}-${{ hashFiles('external/CMakeLists.txt', 'CMakeLists.txt', 'pyproject.toml', '.github/workflows/build_wheels.yml') }}
+          restore-keys: |
+            oqp-wheel-externals-${{ matrix.name }}-
 
       - name: Install cibuildwheel
         run: python -m pip install --upgrade cibuildwheel

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Cache bundled externals
         uses: actions/cache@v4
         with:
-          path: .openqp-externals
+          path: .cache/openqp/externals
           key: oqp-wheel-externals-linux-x86_64-${{ hashFiles('external/CMakeLists.txt', 'CMakeLists.txt', 'pyproject.toml', '.github/workflows/build_wheels.yml') }}
           restore-keys: |
             oqp-wheel-externals-linux-x86_64-
@@ -73,8 +73,8 @@ jobs:
           CIBW_SKIP: "*-musllinux_* pp*"
           CIBW_BEFORE_ALL: yum install -y gcc-gfortran
           CIBW_ENVIRONMENT: >-
+            XDG_CACHE_HOME="$(pwd)/.cache"
             CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
-            -DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals
             -DLINALG_LIB=auto
             -DLINALG_LIB_INT64=ON"
           CIBW_REPAIR_WHEEL_COMMAND: >-
@@ -107,10 +107,11 @@ jobs:
             os: ubuntu-24.04
             platform: linux
             archs: x86_64
+            cache_path: .cache/openqp/externals
             before_all: yum install -y gcc-gfortran
             environment: >-
+              XDG_CACHE_HOME="$(pwd)/.cache"
               CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
-              -DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals
               -DLINALG_LIB=auto
               -DLINALG_LIB_INT64=ON"
             repair: >-
@@ -121,13 +122,13 @@ jobs:
             os: macos-15-intel
             platform: macos
             archs: x86_64
+            cache_path: ~/Library/Caches/openqp/externals
             before_all: brew install gcc@15
             environment: >-
               MACOSX_DEPLOYMENT_TARGET=15.0
               CMAKE_ARGS="-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15
-              -DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals
               -DLINALG_LIB=auto
               -DLINALG_LIB_INT64=OFF"
             repair: >-
@@ -138,13 +139,13 @@ jobs:
             os: macos-15
             platform: macos
             archs: arm64
+            cache_path: ~/Library/Caches/openqp/externals
             before_all: brew install gcc@15
             environment: >-
               MACOSX_DEPLOYMENT_TARGET=15.0
               CMAKE_ARGS="-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15
-              -DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals
               -DLINALG_LIB=auto
               -DLINALG_LIB_INT64=OFF"
             repair: >-
@@ -161,7 +162,7 @@ jobs:
       - name: Cache bundled externals
         uses: actions/cache@v4
         with:
-          path: .openqp-externals
+          path: ${{ matrix.cache_path }}
           key: oqp-wheel-externals-${{ matrix.name }}-${{ hashFiles('external/CMakeLists.txt', 'CMakeLists.txt', 'pyproject.toml', '.github/workflows/build_wheels.yml') }}
           restore-keys: |
             oqp-wheel-externals-${{ matrix.name }}-

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -12,8 +12,8 @@ and one Linux smoke wheel whenever release-sensitive files change in an ordinary
 pull request. The smoke wheel compiles OpenQP source against a restored bundled
 externals cache so source changes are checked without rebuilding third-party
 libraries on every PR. Full Linux and macOS wheel builds run for pull requests
-labeled `release`, manual workflow dispatch, `v*` tag pushes, and GitHub
-Releases. Only the `release: published` event uploads to PyPI.
+labeled `release`, manual workflow dispatch, and GitHub Releases. Only the
+`release: published` event uploads to PyPI.
 
 ## Release Checklist
 
@@ -26,6 +26,10 @@ Releases. Only the `release: published` event uploads to PyPI.
 The workflow verifies that the GitHub Release tag is exactly `v` plus the
 `pyproject.toml` version. For example, `version = "1.2.0"` must be released as
 `v1.2.0`.
+
+Pushing a `v*` tag by itself does not start this workflow. Publish a GitHub
+Release from the tag instead, so the full wheel build and PyPI upload happen
+once from the release event.
 
 ## PyPI Trusted Publishing
 

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -8,16 +8,19 @@ pip install openqp
 ```
 
 The `.github/workflows/build_wheels.yml` workflow builds source distributions
-and binary wheels whenever release-sensitive files change in a pull request,
-whenever a `v*` tag is pushed, and whenever a GitHub Release is published.
-Only the `release: published` event uploads to PyPI.
+and one Linux smoke wheel whenever release-sensitive files change in an ordinary
+pull request. The smoke wheel compiles OpenQP source against a restored bundled
+externals cache so source changes are checked without rebuilding third-party
+libraries on every PR. Full Linux and macOS wheel builds run for pull requests
+labeled `release`, manual workflow dispatch, `v*` tag pushes, and GitHub
+Releases. Only the `release: published` event uploads to PyPI.
 
 ## Release Checklist
 
 1. Update `project.version` in `pyproject.toml`.
 2. Create and push a matching tag, for example `v1.2.0`.
 3. Publish a GitHub Release from that tag.
-4. Wait for the wheel workflow to finish.
+4. Wait for the full wheel workflow to finish.
 5. Confirm that the release assets and PyPI files include the expected wheels.
 
 The workflow verifies that the GitHub Release tag is exactly `v` plus the
@@ -43,6 +46,9 @@ that job runs only after a GitHub Release is published.
 
 The first automated release workflow builds:
 
+- Ordinary pull requests: source distribution and one Linux x86_64 CPython 3.11
+  smoke wheel using the reusable bundled-externals cache
+- Pull requests labeled `release`: full Linux and macOS wheel matrix
 - Linux x86_64 manylinux wheels
 - macOS x86_64 wheels for macOS 15 or newer
 - macOS arm64 wheels for macOS 15 or newer

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -15,6 +15,11 @@ libraries on every PR. Full Linux and macOS wheel builds run for pull requests
 labeled `release`, manual workflow dispatch, and GitHub Releases. Only the
 `release: published` event uploads to PyPI.
 
+The workflow does not require `OQP_EXTERNALS_ROOT`. Linux wheel jobs set the
+standard `XDG_CACHE_HOME` to a cached checkout-local directory so OpenQP's
+existing cache auto-discovery uses `$XDG_CACHE_HOME/openqp/externals`. macOS
+wheel jobs use the default `~/Library/Caches/openqp/externals` location.
+
 ## Release Checklist
 
 1. Update `project.version` in `pyproject.toml`.

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -155,6 +155,7 @@ class RuntimeRootResolutionTests(unittest.TestCase):
     def test_pull_requests_use_cached_smoke_wheel_not_full_matrix(self):
         source = (ROOT / ".github" / "workflows" / "build_wheels.yml").read_text()
 
+        self.assertNotIn("tags:\n      - \"v*\"", source)
         self.assertIn("types: [opened, synchronize, reopened, labeled, unlabeled]", source)
         self.assertIn("build_wheel_smoke:", source)
         self.assertIn(

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -164,7 +164,7 @@ class RuntimeRootResolutionTests(unittest.TestCase):
         )
         self.assertIn("CIBW_BUILD: \"cp311-*\"", source)
         self.assertIn("path: .openqp-externals", source)
-        self.assertIn("OQP_EXTERNALS_ROOT=\"$(pwd)/.openqp-externals\"", source)
+        self.assertEqual(source.count("-DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals"), 4)
         self.assertIn("build_wheels:", source)
         self.assertIn(
             "if: github.event_name != 'pull_request' || contains("

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -151,3 +151,24 @@ class RuntimeRootResolutionTests(unittest.TestCase):
         self.assertIn("os: macos-15-intel", source)
         self.assertIn("os: macos-15", source)
         self.assertEqual(source.count("MACOSX_DEPLOYMENT_TARGET=15.0"), 2)
+
+    def test_pull_requests_use_cached_smoke_wheel_not_full_matrix(self):
+        source = (ROOT / ".github" / "workflows" / "build_wheels.yml").read_text()
+
+        self.assertIn("types: [opened, synchronize, reopened, labeled, unlabeled]", source)
+        self.assertIn("build_wheel_smoke:", source)
+        self.assertIn(
+            "if: github.event_name == 'pull_request' && !contains("
+            "github.event.pull_request.labels.*.name, 'release')",
+            source,
+        )
+        self.assertIn("CIBW_BUILD: \"cp311-*\"", source)
+        self.assertIn("path: .openqp-externals", source)
+        self.assertIn("OQP_EXTERNALS_ROOT=\"$(pwd)/.openqp-externals\"", source)
+        self.assertIn("build_wheels:", source)
+        self.assertIn(
+            "if: github.event_name != 'pull_request' || contains("
+            "github.event.pull_request.labels.*.name, 'release')",
+            source,
+        )
+        self.assertIn("CIBW_BUILD: \"cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*\"", source)

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -163,9 +163,11 @@ class RuntimeRootResolutionTests(unittest.TestCase):
             "github.event.pull_request.labels.*.name, 'release')",
             source,
         )
+        self.assertNotIn("OQP_EXTERNALS_ROOT", source)
         self.assertIn("CIBW_BUILD: \"cp311-*\"", source)
-        self.assertIn("path: .openqp-externals", source)
-        self.assertEqual(source.count("-DOQP_EXTERNALS_ROOT=$(pwd)/.openqp-externals"), 4)
+        self.assertIn("path: .cache/openqp/externals", source)
+        self.assertIn("XDG_CACHE_HOME=\"$(pwd)/.cache\"", source)
+        self.assertIn("cache_path: ~/Library/Caches/openqp/externals", source)
         self.assertIn("build_wheels:", source)
         self.assertIn(
             "if: github.event_name != 'pull_request' || contains("


### PR DESCRIPTION
## Summary\n- keep ordinary PR release-packaging checks to the source distribution plus one Linux CPython 3.11 smoke wheel\n- restore/cache bundled externals for wheel builds via OQP_EXTERNALS_ROOT so source changes do not rebuild third-party libraries every run\n- run the full Linux/macOS wheel matrix only for PRs labeled release, manual runs, tag pushes, and GitHub Releases\n\n## Notes\n- Added a release label as the opt-in switch for release-preparation PRs.\n- Publishing remains restricted to the GitHub Release event.\n- This only changes GitHub Actions/docs/tests; it does not affect local builds after git clone.\n\n## Validation\n- workflow YAML parsed\n- git diff --check\n- python3 -m unittest tests.test_runtime_root_resolution.RuntimeRootResolutionTests.test_macos_wheel_target_matches_runner_gcc_runtime tests.test_runtime_root_resolution.RuntimeRootResolutionTests.test_pull_requests_use_cached_smoke_wheel_not_full_matrix