### PR TITLE
Prepare OpenQP v1.2.0 release

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -118,6 +118,21 @@ jobs:
               LD_LIBRARY_PATH="oqp/lib:$LD_LIBRARY_PATH"
               auditwheel repair -w {dest_dir} {wheel}
 
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+            platform: linux
+            archs: aarch64
+            cache_path: .cache/openqp/externals
+            before_all: yum install -y gcc-gfortran
+            environment: >-
+              XDG_CACHE_HOME="$(pwd)/.cache"
+              CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
+              -DLINALG_LIB=auto
+              -DLINALG_LIB_INT64=ON"
+            repair: >-
+              LD_LIBRARY_PATH="oqp/lib:$LD_LIBRARY_PATH"
+              auditwheel repair -w {dest_dir} {wheel}
+
           - name: macos-x86_64
             os: macos-15-intel
             platform: macos

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,6 +21,22 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Read package version
+        id: version
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import re
+          from pathlib import Path
+
+          pyproject = Path("pyproject.toml").read_text()
+          match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+          if not match:
+              raise SystemExit("Could not find project.version in pyproject.toml")
+          version = match.group(1)
+          print(f"version={version}")
+          print(f"docker_tag=v{version}")
+          PY
+
       - name: Set up Docker Buildx
         id: setup-buildx
         uses: docker/setup-buildx-action@v3
@@ -72,7 +88,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          tags: openqp/openqp:v1.0
+          tags: openqp/openqp:${{ steps.version.outputs.docker_tag }}
           load: true
           # BuildKit's GitHub cache keeps source-independent Docker layers.
           # actions/cache + buildkit-cache-dance above keep the pip/OpenQP
@@ -85,4 +101,4 @@ jobs:
         if: github.event_name == 'push' && env.HAS_DOCKER_CREDENTIALS == 'true'
         # The buildenv image is published by the openqp-dev companion repo, not
         # here; this repo only publishes the OpenQP application image.
-        run: docker push openqp/openqp:v1.0
+        run: docker push openqp/openqp:${{ steps.version.outputs.docker_tag }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 project(Open-Quantum-Package
-  VERSION 1.0.0
+  VERSION 1.2.0
   LANGUAGES C CXX Fortran)
 
 set(CMAKE_Fortran_STANDARD 2003)

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -59,6 +59,7 @@ The first automated release workflow builds:
   smoke wheel using the reusable bundled-externals cache
 - Pull requests labeled `release`: full Linux and macOS wheel matrix
 - Linux x86_64 manylinux wheels
+- Linux aarch64 manylinux wheels
 - macOS x86_64 wheels for macOS 15 or newer
 - macOS arm64 wheels for macOS 15 or newer
 - Source distribution

--- a/pyoqp/setup.py
+++ b/pyoqp/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="OpenQP",
-    version="1.0",
+    version="1.2.0",
     author="Jingbai Li",
     author_email="lijingbai@zspu.edu.cn",
     description="Python Wrapper for Open Quantum Platform",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "OpenQP"
-version = "0.1.0"
+version = "1.2.0"
 description = "Python bindings for the Open Quantum Platform (Fortran core + Python wrapper)"
 authors = [{ name = "Mohsen Mazaherifar", email = "moh.mazaheri@gmail.com" }]
 readme = "README.md"

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,37 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def find_version(pattern, text, source):
+    match = re.search(pattern, text, re.MULTILINE)
+    if not match:
+        raise AssertionError(f"Could not find version in {source}")
+    return match.group(1)
+
+
+class ReleaseMetadataTests(unittest.TestCase):
+    def test_release_versions_stay_in_sync(self):
+        pyproject = (ROOT / "pyproject.toml").read_text()
+        cmake = (ROOT / "CMakeLists.txt").read_text()
+        setup_py = (ROOT / "pyoqp" / "setup.py").read_text()
+
+        version = find_version(r'^version\s*=\s*"([^"]+)"', pyproject, "pyproject.toml")
+        self.assertEqual(
+            find_version(r"VERSION\s+([0-9]+\.[0-9]+\.[0-9]+)", cmake, "CMakeLists.txt"),
+            version,
+        )
+        self.assertEqual(
+            find_version(r'version="([^"]+)"', setup_py, "pyoqp/setup.py"),
+            version,
+        )
+
+    def test_docker_image_tag_comes_from_pyproject_version(self):
+        workflow = (ROOT / ".github" / "workflows" / "docker-build.yml").read_text()
+
+        self.assertIn("docker_tag=v{version}", workflow)
+        self.assertIn("tags: openqp/openqp:${{ steps.version.outputs.docker_tag }}", workflow)
+        self.assertIn("docker push openqp/openqp:${{ steps.version.outputs.docker_tag }}", workflow)

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -152,6 +152,13 @@ class RuntimeRootResolutionTests(unittest.TestCase):
         self.assertIn("os: macos-15", source)
         self.assertEqual(source.count("MACOSX_DEPLOYMENT_TARGET=15.0"), 2)
 
+    def test_release_wheel_matrix_includes_native_linux_arm64(self):
+        source = (ROOT / ".github" / "workflows" / "build_wheels.yml").read_text()
+
+        self.assertIn("name: linux-aarch64", source)
+        self.assertIn("os: ubuntu-24.04-arm", source)
+        self.assertIn("archs: aarch64", source)
+
     def test_pull_requests_use_cached_smoke_wheel_not_full_matrix(self):
         source = (ROOT / ".github" / "workflows" / "build_wheels.yml").read_text()
 


### PR DESCRIPTION
## Summary\n- bump the Python package version to 1.2.0\n- align the CMake project version with the release version\n\n## Release note\nAfter this PR is merged, create/publish the GitHub Release using tag v1.2.0. The release workflow verifies that the tag matches pyproject.toml before publishing to PyPI.\n\n## Validation\n- git diff --check\n- checked pyproject.toml and CMakeLists.txt both declare 1.2.0