### PR TITLE
Fix MSYS2 PyPI dependency bridge

### DIFF
--- a/docs/windows-msys2-packaging.md
+++ b/docs/windows-msys2-packaging.md
@@ -45,7 +45,7 @@ Install that package in a UCRT64 shell with:
 
 ```bash
 pacman -U dist/msys2-ucrt64/packages/mingw-w64-ucrt-x86_64-openqp-<version>-1-any.pkg.tar.zst
-python -m pip install --user basis_set_exchange geometric  # temporary dependency bridge
+python -m pip install --user --break-system-packages "jsonschema<4.18" basis_set_exchange geometric  # temporary dependency bridge
 openqp examples/other/h2o_rhf_6-31g_hf.inp --omp 2
 ```
 
@@ -122,9 +122,11 @@ The supported package path is now a local MSYS2 pacman package. Build with
 There is one important upstream-packaging blocker: OpenQP imports
 `basis_set_exchange` at runtime and supports geomeTRIC workflows, but those two
 Python projects are not yet available as MSYS2 UCRT64 packages. The local package
-builder can install them from PyPI for validation; an official MSYS2 submission
-should first add package recipes for them or make the OpenQP imports fully
-optional.
+builder can install them from PyPI for validation. The preview bridge pins
+`jsonschema<4.18` because newer `jsonschema` releases pull `rpds-py`, whose
+current build chain does not support MSYS2 MinGW Python cleanly. An official
+MSYS2 submission should first add package recipes for these dependencies or make
+the OpenQP imports fully optional.
 
 ## Distribution
 

--- a/tests/test_windows_msys2_packaging.py
+++ b/tests/test_windows_msys2_packaging.py
@@ -35,7 +35,8 @@ class WindowsMsys2PackagingTests(unittest.TestCase):
         self.assertIn("git \\", script)
         self.assertIn("mingw-w64-ucrt-x86_64-gcc-fortran", script)
         self.assertIn("-DLINALG_LIB=netlib", script)
-        self.assertIn("pip install --user --upgrade", script)
+        self.assertIn('pip install --user --break-system-packages --upgrade', script)
+        self.assertIn('"jsonschema<4.18"', script)
         self.assertIn("python -m build --wheel --no-isolation", script)
         self.assertIn("PYTHONPATH", script)
         self.assertIn('$prefix/bin:$PATH', script)
@@ -62,6 +63,7 @@ class WindowsMsys2PackagingTests(unittest.TestCase):
         self.assertIn("basis_set_exchange", install)
         self.assertIn("makepkg-mingw", builder)
         self.assertIn("pacman -U --noconfirm", builder)
+        self.assertIn('--break-system-packages --upgrade "jsonschema<4.18" basis_set_exchange geometric', builder)
 
     def test_clickable_installer_wraps_real_pacman_package(self):
         cmd = (ROOT / "tools" / "windows_msys2" / "install_openqp_msys2.cmd").read_text()
@@ -80,7 +82,7 @@ class WindowsMsys2PackagingTests(unittest.TestCase):
         self.assertIn("mingw-w64-ucrt-x86_64-python-scipy", ps1)
         self.assertIn("mingw-w64-ucrt-x86_64-openqp-*.pkg.tar.*", ps1)
         self.assertIn("pacman -U --noconfirm", ps1)
-        self.assertIn("basis_set_exchange geometric", ps1)
+        self.assertIn('--break-system-packages --upgrade "jsonschema<4.18" basis_set_exchange geometric', ps1)
         self.assertIn("OpenQP UCRT64.cmd", ps1)
         self.assertIn("openqp-msys2-ucrt64.pkg.tar.*", ps1)
         self.assertIn("command -v openqp", ps1)

--- a/tools/windows_msys2/README.md
+++ b/tools/windows_msys2/README.md
@@ -27,7 +27,7 @@ Users can then install that artifact in UCRT64 with:
 
 ```bash
 pacman -U mingw-w64-ucrt-x86_64-openqp-<version>-1-any.pkg.tar.zst
-python -m pip install --user basis_set_exchange geometric  # temporary dependency bridge
+python -m pip install --user --break-system-packages "jsonschema<4.18" basis_set_exchange geometric  # temporary dependency bridge
 openqp examples/other/h2o_rhf_6-31g_hf.inp --omp 2
 ```
 
@@ -124,7 +124,8 @@ openqp examples/other/h2o_rhf_6-31g_hf.inp --omp 2
 `mingw-w64-openqp/PKGBUILD` is the real MSYS2 package recipe. The remaining
 upstream-packaging blocker is dependency coverage: `basis_set_exchange` and
 geomeTRIC still need MSYS2 Python packages before OpenQP can be submitted cleanly
-to the official MSYS2 repository.
+to the official MSYS2 repository. The preview PyPI bridge pins `jsonschema<4.18`
+to avoid the newer `rpds-py` dependency path on MSYS2 MinGW Python.
 
 `build_msys2.sh` is kept as a lower-level source-prefix validation helper. The
 zip archive it creates is not a standalone installer.

--- a/tools/windows_msys2/build_msys2.sh
+++ b/tools/windows_msys2/build_msys2.sh
@@ -35,7 +35,7 @@ export FC="${FC:-gfortran}"
 export CMAKE_BUILD_PARALLEL_LEVEL="$jobs"
 export CMAKE_ARGS="${CMAKE_ARGS:-} -DUSE_LIBINT=OFF -DENABLE_OPENMP=ON -DENABLE_OPENTRAH=OFF -DLINALG_LIB=netlib -DLINALG_LIB_INT64=ON -DOQP_EXTERNALS_ROOT=$repo_root/.cache/openqp/externals"
 
-python -m pip install --user --upgrade cffi scikit-build-core build setuptools wheel geometric basis_set_exchange
+python -m pip install --user --break-system-packages --upgrade cffi scikit-build-core build setuptools wheel "jsonschema<4.18" geometric basis_set_exchange
 
 rm -rf "$build_dir" "$prefix" "$wheelhouse"
 mkdir -p "$prefix" "$wheelhouse"

--- a/tools/windows_msys2/build_pkg.sh
+++ b/tools/windows_msys2/build_pkg.sh
@@ -36,7 +36,7 @@ fi
 # These two runtime dependencies are not currently available as MSYS2 packages.
 # Install them only for local validation until separate PKGBUILDs are added.
 if [[ "${OQP_MSYS2_INSTALL_PYPI_DEPS:-1}" == "1" ]]; then
-  python -m pip install --user --upgrade basis_set_exchange geometric
+  python -m pip install --user --break-system-packages --upgrade "jsonschema<4.18" basis_set_exchange geometric
 fi
 
 rm -rf "$package_out"

--- a/tools/windows_msys2/install_openqp_msys2.ps1
+++ b/tools/windows_msys2/install_openqp_msys2.ps1
@@ -136,7 +136,7 @@ pacman -U --noconfirm "$pkg"
 
 if (-not $SkipPythonDeps) {
     Invoke-Ucrt64 -BashPath $bash -Description "Installing temporary Python runtime dependencies" -Command @'
-python -m pip install --user --upgrade basis_set_exchange geometric
+python -m pip install --user --break-system-packages --upgrade "jsonschema<4.18" basis_set_exchange geometric
 '@
 }
 

--- a/tools/windows_msys2/mingw-w64-openqp/openqp.install
+++ b/tools/windows_msys2/mingw-w64-openqp/openqp.install
@@ -7,7 +7,7 @@ Known dependency gap:
   but they are not yet packaged in MSYS2 UCRT64. Until those packages exist,
   install them into the same UCRT64 Python environment with:
 
-    python -m pip install --user basis_set_exchange geometric
+    python -m pip install --user --break-system-packages "jsonschema<4.18" basis_set_exchange geometric
 
 EOF
 }


### PR DESCRIPTION
## Summary

Fixes the Windows MSYS2 preview dependency bridge after the manual MSI preflight failed while installing `basis_set_exchange`.

The failure came from recent `jsonschema` pulling `rpds-py`, whose `maturin` build path currently rejects MSYS2 MinGW Python (`mingw_x86_64_ucrt_gnu`). This keeps the preview bridge on `jsonschema<4.18` and uses MSYS2's explicit `--break-system-packages` override for the temporary PyPI installs.

## Validation

- `python -m pytest tests/test_windows_msys2_packaging.py`
- workflow YAML parse
- shell syntax checks for Windows MSYS2 helper scripts and PKGBUILD

## Note

This is still a preview bridge until `basis_set_exchange` and geomeTRIC have proper MSYS2 packages or OpenQP makes those runtime imports optional.
