### PR TITLE
Normalize MSYS2 package metadata line endings

### DIFF
--- a/tests/test_windows_msys2_packaging.py
+++ b/tests/test_windows_msys2_packaging.py
@@ -62,6 +62,7 @@ class WindowsMsys2PackagingTests(unittest.TestCase):
         self.assertIn('python -m installer --destdir="${pkgdir}"', pkgbuild)
         self.assertIn("basis_set_exchange", install)
         self.assertIn("makepkg-mingw", builder)
+        self.assertIn("sed -i 's/\\r$//' PKGBUILD ./*.install", builder)
         self.assertIn("pacman -U --noconfirm", builder)
         self.assertIn('--break-system-packages --upgrade "jsonschema<4.18" basis_set_exchange geometric', builder)
 

--- a/tools/windows_msys2/build_pkg.sh
+++ b/tools/windows_msys2/build_pkg.sh
@@ -43,6 +43,9 @@ rm -rf "$package_out"
 mkdir -p "$package_out"
 
 cd "$pkgbuild_dir"
+# GitHub's Windows checkout may apply CRLF line endings depending on
+# repository settings. makepkg sources these files directly and rejects CRLF.
+sed -i 's/\r$//' PKGBUILD ./*.install
 rm -f ./*.pkg.tar.*
 makepkg-mingw --noconfirm --syncdeps --cleanbuild --clean
 


### PR DESCRIPTION
## Summary
- normalize PKGBUILD and .install line endings before makepkg-mingw reads them
- add a packaging test assertion so the Windows checkout behavior stays covered

## Why
The manual Windows MSYS2 preflight on main failed after PR #220 because the Windows checkout supplied CRLF line endings and makepkg refused to source PKGBUILD:

```
==> ERROR: PKGBUILD contains CRLF characters and cannot be sourced.
```

## Testing
- python -m pytest tests/test_windows_msys2_packaging.py
- bash -n tools/windows_msys2/build_pkg.sh
- bash -n tools/windows_msys2/build_msys2.sh
- bash -n tools/windows_msys2/mingw-w64-openqp/PKGBUILD
- bash -n tools/windows_msys2/mingw-w64-openqp/openqp.install