### PR TITLE
Create reusable external cache roots before downloads

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -94,6 +94,10 @@ if(OQP_REUSE_EXTERNALS)
   set(OQP_EXTERNALS_SOURCE_ROOT "${_OQP_EXTERNALS_ROOT}/${_oqp_external_key}/src" CACHE INTERNAL "OQP_EXTERNALS_SOURCE_ROOT" FORCE)
   set(OQP_EXTERNALS_BUILD_ROOT "${_OQP_EXTERNALS_ROOT}/${_oqp_external_key}/build" CACHE INTERNAL "OQP_EXTERNALS_BUILD_ROOT" FORCE)
   set(OQP_EXTERNALS_INSTALL_ROOT "${_OQP_EXTERNALS_ROOT}/${_oqp_external_key}/install" CACHE INTERNAL "OQP_EXTERNALS_INSTALL_ROOT" FORCE)
+  file(MAKE_DIRECTORY
+      "${OQP_EXTERNALS_SOURCE_ROOT}"
+      "${OQP_EXTERNALS_BUILD_ROOT}"
+      "${OQP_EXTERNALS_INSTALL_ROOT}")
   message(STATUS "Reusable bundled externals cache: ${_OQP_EXTERNALS_ROOT}")
   message(STATUS "Reusable bundled externals key: ${_oqp_external_key}")
 endif()

--- a/tests/test_opentrustregion_linalg_config.py
+++ b/tests/test_opentrustregion_linalg_config.py
@@ -119,6 +119,14 @@ class OpenTrustRegionLinalgConfigTests(unittest.TestCase):
         self.assertIn('string(APPEND _oqp_external_generator "-make${_oqp_external_make_program_hash}")', external_cmake)
         self.assertIn("${OQP_EXTERNAL_GENERATOR_ARGS}", external_cmake)
 
+    def test_reusable_external_cache_roots_are_created_before_downloads(self):
+        external_cmake = (ROOT / "external" / "CMakeLists.txt").read_text()
+
+        self.assertIn("file(MAKE_DIRECTORY", external_cmake)
+        self.assertIn('"${OQP_EXTERNALS_SOURCE_ROOT}"', external_cmake)
+        self.assertIn('"${OQP_EXTERNALS_BUILD_ROOT}"', external_cmake)
+        self.assertIn('"${OQP_EXTERNALS_INSTALL_ROOT}"', external_cmake)
+
     def test_gradient_atom_count_uses_explicit_kind(self):
         grd1 = (ROOT / "source" / "integrals" / "grd1.F90").read_text()
 


### PR DESCRIPTION
## Summary
- create reusable external source/build/install cache roots immediately after computing them
- add a regression assertion for the cache-root creation

## Why
The Windows MSYS2 preflight now passes a Windows-style externals path to CMake, but ExternalProject download commands still fail because the shared source root is missing before `cmd.exe` tries to enter it:

```
cd /D D:\a\openqp\...\openqp-externals\...\src
The current directory is invalid.
```

Creating the reusable cache roots before ExternalProject download steps fixes that ordering issue for Windows and is harmless for other platforms.

## Testing
- python -m pytest tests/test_opentrustregion_linalg_config.py tests/test_windows_msys2_packaging.py