### PR TITLE
Use PATH patch tools for external builds

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -301,7 +301,7 @@ ExternalProject_Add(libtagarray
         BINARY_DIR ${TAGARRAY_BUILD_DIR}
         STAMP_DIR  ${TAGARRAY_STAMP_DIR}
         UPDATE_COMMAND ""
-        PATCH_COMMAND /bin/sh -c "grep -q reserve_data_default <SOURCE_DIR>/source/API/Fortran/container.f90 || patch -p1 -i ${CMAKE_SOURCE_DIR}/cmake/patches/libtagarray-v0.0.6-default-integer-shapes.patch"
+        PATCH_COMMAND sh -c "grep -q reserve_data_default <SOURCE_DIR>/source/API/Fortran/container.f90 || patch -p1 -i ${CMAKE_SOURCE_DIR}/cmake/patches/libtagarray-v0.0.6-default-integer-shapes.patch"
         INSTALL_COMMAND ""
         CMAKE_ARGS -DENABLE_FORTRAN=ON
                    -DENABLE_TESTING=OFF
@@ -381,7 +381,7 @@ if(_LINALG_LIB_TYPE STREQUAL NetLib)
         BUILD_BYPRODUCTS ${LIBLAPACK}
                          ${LIBBLAS}
         UPDATE_COMMAND ""
-        PATCH_COMMAND /usr/bin/perl -0pi -e "s/cmake_minimum_required\\(VERSION 3\\.2\\)/cmake_minimum_required(VERSION 3.5)/g" <SOURCE_DIR>/CMakeLists.txt <SOURCE_DIR>/INSTALL/CMakeLists.txt
+        PATCH_COMMAND perl -0pi -e "s/cmake_minimum_required\\(VERSION 3\\.2\\)/cmake_minimum_required(VERSION 3.5)/g" <SOURCE_DIR>/CMakeLists.txt <SOURCE_DIR>/INSTALL/CMakeLists.txt
         INSTALL_COMMAND ""
         CMAKE_ARGS -DBUILD_INDEX64=${LINALG_LIB_INT64}
                    -DBUILD_SINGLE=ON

--- a/tests/test_opentrustregion_linalg_config.py
+++ b/tests/test_opentrustregion_linalg_config.py
@@ -37,7 +37,7 @@ class OpenTrustRegionLinalgConfigTests(unittest.TestCase):
         self.assertIn("LIST_SEPARATOR ${OQP_EXTERNAL_LIST_SEPARATOR}", external_cmake)
         self.assertIn("add_dependencies(libopentrustregion LAPACK)", external_cmake)
         self.assertIn("CMAKE_POLICY_VERSION_MINIMUM=3.5", external_cmake)
-        self.assertIn("PATCH_COMMAND /usr/bin/perl", external_cmake)
+        self.assertIn("PATCH_COMMAND perl", external_cmake)
         self.assertIn("cmake_minimum_required(VERSION 3.5)", external_cmake)
         self.assertLess(
             external_cmake.index("ExternalProject_Add(LAPACK"),
@@ -93,6 +93,7 @@ class OpenTrustRegionLinalgConfigTests(unittest.TestCase):
         patch = (ROOT / "cmake" / "patches" / "libtagarray-v0.0.6-default-integer-shapes.patch").read_text()
 
         self.assertIn("libtagarray-v0.0.6-default-integer-shapes.patch", external_cmake)
+        self.assertIn("PATCH_COMMAND sh -c", external_cmake)
         self.assertIn("grep -q reserve_data_default", external_cmake)
         self.assertIn("generic, public    :: reserve_data => reserve_data_i64, reserve_data_default", patch)
         self.assertIn("integer,                              optional, intent(in) :: array_shape(:)", patch)


### PR DESCRIPTION
## Summary
- avoid absolute POSIX tool paths in ExternalProject patch commands
- let MSYS2/Windows builds resolve sh and perl from PATH under CMake's cmd.exe wrapper
- update regression coverage for the external patch commands

## Validation
- python -m unittest tests.test_opentrustregion_linalg_config tests.test_windows_msys2_packaging