### PR TITLE
Fix libecpint MinGW M_PI build

### DIFF
--- a/cmake/patches/libecpint-v1.0.7-mingw-m-pi.patch
+++ b/cmake/patches/libecpint-v1.0.7-mingw-m-pi.patch
@@ -1,0 +1,15 @@
+diff --git a/src/lib/gaussquad.cpp b/src/lib/gaussquad.cpp
+index e0484eb..5389dad 100644
+--- a/src/lib/gaussquad.cpp
++++ b/src/lib/gaussquad.cpp
+@@ -27,6 +27,10 @@
+ #include <cassert>
+ #include <iostream>
+ 
++#ifndef M_PI
++#define M_PI 3.14159265358979323846
++#endif
++
+ namespace libecpint {
+ 
+ 	// Constructor

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(_OQP_EXTERNALS_CACHE_REVISION "1")
+set(_OQP_EXTERNALS_CACHE_REVISION "2")
 set(_OQP_LIBINT2_VERSION "2.7.1.1-am4")
 set(_OQP_NLOPT_VERSION "2.9.1")
 set(_OQP_LIBXC_VERSION "7.0.0")
@@ -336,6 +336,7 @@ ExternalProject_Add(libecpint
         STAMP_DIR  ${LIBECPINT_STAMP_DIR}
 	INSTALL_DIR ${LIBECPINT_INSTALL_DIR}
         UPDATE_COMMAND ""
+        PATCH_COMMAND sh -c "grep -q 'define M_PI 3.14159265358979323846' <SOURCE_DIR>/src/lib/gaussquad.cpp || patch -p1 -i ${CMAKE_SOURCE_DIR}/cmake/patches/libecpint-v1.0.7-mingw-m-pi.patch"
         CMAKE_ARGS -DLIBECPINT_BUILD_DOCS=OFF
                    -DLIBECPINT_BUILD_TESTS=OFF
 		   -DLIBECPINT_USE_PUGIXML=OFF

--- a/tests/test_opentrustregion_linalg_config.py
+++ b/tests/test_opentrustregion_linalg_config.py
@@ -111,6 +111,22 @@ class OpenTrustRegionLinalgConfigTests(unittest.TestCase):
         self.assertIn("CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}", libecpint_block)
         self.assertIn("CMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}", libecpint_block)
 
+    def test_libecpint_defines_m_pi_for_mingw(self):
+        external_cmake = (ROOT / "external" / "CMakeLists.txt").read_text()
+        patch = (ROOT / "cmake" / "patches" / "libecpint-v1.0.7-mingw-m-pi.patch").read_text()
+
+        libecpint_block = external_cmake[
+            external_cmake.index("ExternalProject_Add(libecpint"):
+            external_cmake.index("if(_LINALG_LIB_TYPE STREQUAL NetLib)")
+        ]
+
+        self.assertIn('set(_OQP_EXTERNALS_CACHE_REVISION "2")', external_cmake)
+        self.assertIn("libecpint-v1.0.7-mingw-m-pi.patch", libecpint_block)
+        self.assertIn("PATCH_COMMAND sh -c", libecpint_block)
+        self.assertIn("define M_PI 3.14159265358979323846", libecpint_block)
+        self.assertIn("#ifndef M_PI", patch)
+        self.assertIn("#define M_PI 3.14159265358979323846", patch)
+
     def test_external_projects_receive_make_program_when_set(self):
         external_cmake = (ROOT / "external" / "CMakeLists.txt").read_text()
 


### PR DESCRIPTION
## Summary

- patch bundled libecpint v1.0.7 so MinGW builds define `M_PI` when `<cmath>` does not expose it
- apply the patch from the libecpint ExternalProject before configuring/building it
- bump the bundled externals cache revision so Windows CI does not reuse the already-extracted unpatched libecpint source
- add a regression assertion for the libecpint patch wiring

## Root cause

The Windows MSYS2 preflight on `main` failed in the package build while compiling libecpint:

```text
src/lib/gaussquad.cpp:86:29: error: 'M_PI' was not declared in this scope
```

MinGW does not guarantee `M_PI` from `<cmath>` unless the source defines it or requests nonstandard math constants. The small patch keeps the upstream source behavior unchanged on platforms that already provide `M_PI`.

## Validation

- `python -m unittest tests.test_opentrustregion_linalg_config tests.test_windows_msys2_packaging`
