### PR TITLE
Fix UHF example references (SCF stability), run the suite in CI, and isolate test crashes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,5 @@
 name: CI
 on: [push, pull_request]
-env:
-   BUILD_DIR: _build
 jobs:
    gcc-build:
       runs-on: ${{ matrix.os }}
@@ -50,20 +48,28 @@ jobs:
             sudo apt-get install libopenmpi-dev
          - name: Install CMake
            run: pip install ninja cmake
-         - name: Install pyoqp dependencies
+         - name: Build & install OpenQP
+           env:
+            CC: gcc-${{ matrix.version }}
+            CXX: g++-${{ matrix.version }}
+            FC: gfortran-${{ matrix.version }}
            run: |
-            cd pyoqp && pip install -r requirements.txt
-         - name: Configure build
-           run: |
-            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=Debug -DUSE_LIBINT=OFF -DCMAKE_C_COMPILER=gcc-${{ matrix.version }} -DCMAKE_CXX_COMPILER=g++-${{ matrix.version }} -DCMAKE_Fortran_COMPILER=gfortran-${{ matrix.version }} -DCMAKE_INSTALL_PREFIX=. -DENABLE_OPENMP=ON -DLINALG_LIB_INT64=ON -DENABLE_MPI=${{ matrix.MPI }}
-         - name: Compile & Install
-           run: |
-            # External dependencies (libxc, nlopt, libint, ...) are fetched at build
-            # time via ExternalProject and the upstream hosts intermittently return
-            # HTTP 504. A failed download leaves no stamp file, so re-running ninja
-            # retries only the failed download (already-fetched deps stay cached).
+            # Build + install from the repo root in one step. scikit-build-core
+            # (pyproject [tool.scikit-build], wheel.install-dir = oqp) bundles the
+            # native library, header and share/ data into the installed package,
+            # so "openqp" self-locates via resolve_oqp_root() with no extra wiring
+            # and runtime deps (numpy/scipy/geometric/...) come from pyproject.
+            # USE_LIBINT/ENABLE_OPENMP/LINALG_LIB_INT64 are pyproject defaults; CI
+            # only overrides the build type and the MPI matrix leg.
+            #
+            # External deps (libxc, nlopt, ...) are fetched via ExternalProject and
+            # the upstream hosts intermittently return HTTP 504. The bundled-
+            # externals cache persists across retries, so a re-run only re-fetches
+            # whatever failed.
             n=0
-            until ninja -C ${{ env.BUILD_DIR }} install; do
+            until pip install -v . \
+                --config-settings=cmake.build-type=Debug \
+                --config-settings=cmake.define.ENABLE_MPI=${{ matrix.MPI }}; do
               n=$((n + 1))
               if [ "$n" -ge 3 ]; then
                 echo "::error::build failed after $n attempts"
@@ -72,13 +78,23 @@ jobs:
               echo "::warning::build attempt $n failed (likely a transient dependency download); retrying in 30s"
               sleep 30
             done
-         - name: Install pyoqp
+         # Run the full example/reference regression suite. Each test runs in its
+         # own subprocess, so a hard failure in one example cannot abort the rest
+         # of the run (see oqp_tester.py). Exercised once per OS on the non-MPI
+         # leg: the suite is the same code path and running it under both MPI legs
+         # only doubles wall-clock.
+         - name: Run example test suite
+           if: ${{ matrix.MPI == 'OFF' }}
+           env:
+            # One OMP thread per test so all runner cores run tests concurrently
+            # (max_workers = cpus // omp_threads); the examples are tiny.
+            OQP_TEST_OMP_THREADS: 1
            run: |
-            cd pyoqp && pip install .
+            openqp --run_tests all
 
-# NOTE: the optional ddX continuum-solvation (PCM) path is NOT exercised by the
-# CI above (gcc-build builds with ENABLE_DDX OFF). The ddX-enabled build and the
-# scientific PCM validation gates are run/documented out-of-CI to keep CI fast
-# (building ddX from source + the SCF benchmark suite is expensive). The exact,
-# reproducible build + validation command for reviewers is in
-# docs/pcm_ddx_validation.md.
+# NOTE: the optional ddX continuum-solvation (PCM) backend stays OFF in this CI
+# build to keep it fast (building ddX from source is expensive). "openqp
+# --run_tests all" still walks the PCM/ddX (DDPCM) examples, but the test runner
+# detects that the build lacks ENABLE_DDX and reports them as SKIPPED instead of
+# failing. The ddX-enabled build and the scientific PCM validation gates are run
+# and documented out-of-CI in docs/pcm_ddx_validation.md.

--- a/examples/DFT/H2O_UHF-DFT_ENERGY.inp
+++ b/examples/DFT/H2O_UHF-DFT_ENERGY.inp
@@ -17,6 +17,7 @@ method=hf
 type=huckel
 
 [scf]
+stability=true
 multiplicity=3
 type=uhf
 

--- a/examples/DFT/H2O_UHF-DFT_GRADIENT.inp
+++ b/examples/DFT/H2O_UHF-DFT_GRADIENT.inp
@@ -17,6 +17,7 @@ method=hf
 type=huckel
 
 [scf]
+stability=true
 multiplicity=3
 type=uhf
 

--- a/examples/HF/H2O_UHF-HF_ENERGY.inp
+++ b/examples/HF/H2O_UHF-HF_ENERGY.inp
@@ -16,6 +16,7 @@ method=hf
 type=huckel
 
 [scf]
+stability=true
 type=uhf
 multiplicity=3
 

--- a/examples/HF/H2O_UHF-HF_GRADIENT.inp
+++ b/examples/HF/H2O_UHF-HF_GRADIENT.inp
@@ -16,6 +16,7 @@ method=hf
 type=huckel
 
 [scf]
+stability=true
 type=uhf
 multiplicity=3
 

--- a/examples/other/h2o_uhf-t_6-31g_bhhlyp.inp
+++ b/examples/other/h2o_uhf-t_6-31g_bhhlyp.inp
@@ -15,6 +15,7 @@ type=huckel
 save_mol=False
 
 [scf]
+stability=true
 type=uhf
 maxit=30
 maxdiis=5

--- a/examples/other/h2o_uhf-t_6-31g_cam-b3lyp.inp
+++ b/examples/other/h2o_uhf-t_6-31g_cam-b3lyp.inp
@@ -15,6 +15,7 @@ type=huckel
 save_mol=False
 
 [scf]
+stability=true
 type=uhf
 maxit=30
 maxdiis=5

--- a/examples/other/h2o_uhf-t_6-31g_hf.inp
+++ b/examples/other/h2o_uhf-t_6-31g_hf.inp
@@ -15,6 +15,7 @@ type=huckel
 save_mol=False
 
 [scf]
+stability=true
 type=uhf
 maxit=30
 maxdiis=5

--- a/examples/other/h2o_uhf-t_6-31g_m06-2x.inp
+++ b/examples/other/h2o_uhf-t_6-31g_m06-2x.inp
@@ -15,6 +15,7 @@ type=huckel
 save_mol=False
 
 [scf]
+stability=true
 type=uhf
 maxit=30
 maxdiis=5

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -431,10 +431,17 @@ def run_tests(test_path):
     """
     from oqp.utils.oqp_tester import OQPTester
     mpi_manager = MPIManager()
+    # OMP threads per test. Fewer threads -> more tests run concurrently
+    # (max_workers = total_cpus // omp_threads), which is much faster on the
+    # small CI examples; override with OQP_TEST_OMP_THREADS.
+    try:
+        omp_threads = max(1, int(os.environ.get("OQP_TEST_OMP_THREADS", "4")))
+    except ValueError:
+        omp_threads = 4
     tester = OQPTester(base_test_dir=None,
                        output_dir='openqp_test_tmp',
                        total_cpus=None,
-                       omp_threads=4, mpi_manager=mpi_manager)
+                       omp_threads=omp_threads, mpi_manager=mpi_manager)
     return tester.run(test_path), tester.status
 
 

--- a/pyoqp/oqp/utils/oqp_tester.py
+++ b/pyoqp/oqp/utils/oqp_tester.py
@@ -10,13 +10,31 @@ Email: constlike@gmail.com
 Created: Aug 2024
 """
 import os
+import sys
+import json
 import time
 import subprocess
 from typing import List, Dict, Any
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 
 from oqp.pyoqp import Runner
+from oqp.runtime import resolve_oqp_root
+
+# Marker that the isolated single-test subprocess prints so the parent can
+# recover the structured result from the child's (otherwise noisy) stdout.
+_RESULT_MARKER = "__OQP_TEST_RESULT__"
+
+# Per-test wall-clock ceiling for the isolated subprocess runner. A wedged or
+# pathologically slow test is reported as a failure instead of hanging CI
+# forever. Override with OQP_TEST_TIMEOUT (seconds); 0/empty disables it.
+def _test_timeout():
+    raw = os.environ.get("OQP_TEST_TIMEOUT", "1800").strip()
+    try:
+        val = float(raw)
+    except ValueError:
+        return 1800.0
+    return val if val > 0 else None
 
 class OQPTester:
     """
@@ -34,6 +52,14 @@ class OQPTester:
         max_workers (int): Maximum number of parallel workers.
         results (List[Dict[str, Any]]): List to store test results.
     """
+
+    # Substrings a crashed test's output may contain that mean "this example
+    # needs an optional backend this build was not configured with" -> SKIPPED,
+    # not ERROR. Keep these specific to capability gates, never generic errors.
+    _OPTIONAL_FEATURE_SENTINELS = (
+        "OQP_ENABLE_DDX",  # ddX / PCM continuum solvation built off
+    )
+
     def __init__(self,
                  base_test_dir: str = None,
                  output_dir: str = None,
@@ -44,21 +70,20 @@ class OQPTester:
         Initialize the OQPTester.
 
         Args:
-            base_test_dir (str): Base directory for test files.
-                                 If None, uses $OPENQP_ROOT/examples.
+            base_test_dir (str): Base directory for test files. If None, uses
+                                 the runtime root's share/examples.
             output_dir (str): Directory for storing test output files.
             total_cpus (int): Total number of CPUs to use.
             omp_threads (int): Number of OMP threads per test.
         """
-        try:
-            oqp_root = os.environ["OPENQP_ROOT"]
-        except KeyError:
-            oqp_root =  os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-        if not oqp_root:
-            raise EnvironmentError("OPENQP_ROOT environment variable is not set")
-
-        self.base_test_dir = base_test_dir or os.path.join(oqp_root,
-                                                           'share/examples')
+        if base_test_dir is None:
+            # Examples live under the resolved runtime root's share/ tree. Use
+            # the package location via resolve_oqp_root(); OPENQP_ROOT is only a
+            # compatibility fallback there (see pyoqp/README.md: a normal install
+            # self-locates, "do not set OPENQP_ROOT").
+            oqp_root, _ = resolve_oqp_root()
+            base_test_dir = os.path.join(oqp_root, "share", "examples")
+        self.base_test_dir = base_test_dir
         self.mpi_manager = mpi_manager
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         self.output_dir = os.path.abspath(f"{output_dir}_{timestamp}")
@@ -177,6 +202,80 @@ class OQPTester:
         result["execution_time"] = time.perf_counter() - start_time
         return result
 
+    def _run_isolated(self, input_file: str) -> Dict[str, Any]:
+        """
+        Run a single test in a dedicated subprocess and recover its result.
+
+        Running the Fortran/C backend in a child process means a hard failure
+        in one test (Fortran ERROR STOP, segfault, MKL/abort) terminates only
+        that child. We translate a non-zero exit (or a timeout) into an ERROR
+        result for that one test rather than letting it crash the whole run.
+        """
+        project_name = os.path.splitext(os.path.basename(input_file))[0]
+        log = os.path.join(self.output_dir, f"{project_name}.log")
+        self.log(f"Running test for {project_name}")
+
+        cmd = [
+            sys.executable, "-m", "oqp.utils.oqp_tester",
+            "--isolated", input_file,
+            "--output-dir", self.output_dir,
+            "--omp", str(self.omp_threads),
+        ]
+        start_time = time.perf_counter()
+        try:
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=_test_timeout(),
+            )
+            stdout, stderr, rc = proc.stdout, proc.stderr, proc.returncode
+        except subprocess.TimeoutExpired as err:
+            return {
+                "project": project_name, "input_file": input_file,
+                "log_file": log, "status": "ERROR",
+                "message": f"PyOQP test exceeded time limit "
+                           f"({_test_timeout()} s); see OQP_TEST_TIMEOUT",
+                "execution_time": time.perf_counter() - start_time,
+            }
+
+        # The child prints exactly one marker line carrying the JSON result.
+        for line in reversed((stdout or "").splitlines()):
+            if line.startswith(_RESULT_MARKER):
+                try:
+                    return json.loads(line[len(_RESULT_MARKER):])
+                except json.JSONDecodeError:
+                    break
+
+        # No result marker => the child died before reporting (ERROR STOP,
+        # segfault, ...). If it ERROR STOPped only because the build lacks an
+        # optional feature the example needs (e.g. the ddX/PCM backend when
+        # ENABLE_DDX is OFF), report SKIPPED rather than ERROR so an
+        # intentionally-trimmed build still produces a green suite.
+        combined = (stdout or "") + (stderr or "")
+        try:
+            with open(log, "r", encoding="utf-8", errors="ignore") as fh:
+                combined += fh.read()
+        except OSError:
+            pass
+        for feature in self._OPTIONAL_FEATURE_SENTINELS:
+            if feature in combined:
+                self.log(f"Skipping test {project_name}: build lacks {feature}")
+                return {
+                    "project": project_name, "input_file": input_file,
+                    "log_file": log, "status": "SKIPPED",
+                    "message": f"requires a build feature not enabled "
+                               f"({feature}); skipped",
+                    "execution_time": time.perf_counter() - start_time,
+                }
+
+        tail = combined.strip().splitlines()[-3:]
+        self.log(f"Error in test {project_name}: subprocess exit {rc}")
+        return {
+            "project": project_name, "input_file": input_file,
+            "log_file": log, "status": "ERROR",
+            "message": f"PyOQP test crashed (subprocess exit {rc}): "
+                       + " | ".join(tail),
+            "execution_time": time.perf_counter() - start_time,
+        }
+
     def run_tests(self, test_path: str = 'all'):
         """
         Run OpenQP tests based on the specified test path.
@@ -205,14 +304,17 @@ class OQPTester:
             # tests can leak state between independent inputs; in particular,
             # running a TRAH SCF test before an ECP/MRSF energy test in the
             # same worker can make the later SCF exit after 0 iterations.
-            # Use one calculation per child process to preserve test isolation
-            # while still allowing tests to run concurrently.
-            with ProcessPoolExecutor(
-                max_workers=self.max_workers,
-                max_tasks_per_child=1,
-            ) as executor:
+            #
+            # Each test therefore runs in its own short-lived subprocess (see
+            # _run_isolated). Besides isolating that process-global state, this
+            # contains hard failures: a Fortran ERROR STOP or a segfault kills
+            # only that child, so it is reported as a single ERROR instead of
+            # tearing down a shared worker pool (BrokenProcessPool) and aborting
+            # every still-pending test. A thread pool just supervises the child
+            # processes, so the GIL is irrelevant here.
+            with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
                 future_to_file = {
-                    executor.submit(self.run_single_test, input_file): input_file
+                    executor.submit(self._run_isolated, input_file): input_file
                     for input_file in input_files
                 }
                 for future in as_completed(future_to_file):
@@ -261,6 +363,10 @@ class OQPTester:
             1 for result in self.results
             if result['status'] == 'ERROR'
         )
+        skipped = sum(
+            1 for result in self.results
+            if result['status'] == 'SKIPPED'
+        )
         self.status = 1 if failed > 0 or errors > 0 else 0
 
         total_time = self.end_time - self.start_time
@@ -279,6 +385,7 @@ Total tests: {len(self.results)}
 Passed: {passed}
 Failed: {failed}
 Errors: {errors}
+Skipped: {skipped}
 
 Total CPUs: MPI Processors = {self.mpi_manager.size}, OpenMp Threads = {self.omp_threads}
 Max parallel tests: {self.max_workers}
@@ -327,3 +434,40 @@ Total execution time: {self.format_time(total_time)}
             return report
         else:
             return 1
+
+
+def _run_isolated_main(argv=None):
+    """
+    Entry point for the per-test subprocess (``python -m oqp.utils.oqp_tester
+    --isolated <input> --output-dir <dir> --omp <n>``).
+
+    Runs exactly one test in this fresh process and prints the structured
+    result as a single marker line. If the Fortran backend ERROR STOPs or
+    crashes, this process simply dies with a non-zero exit and the parent
+    records an ERROR for this test alone.
+    """
+    import argparse
+    from oqp.pyoqp import MPIManager
+
+    parser = argparse.ArgumentParser(description="Run one OpenQP test in isolation")
+    parser.add_argument("--isolated", required=True, help="input .inp file")
+    parser.add_argument("--output-dir", required=True, help="shared output dir")
+    parser.add_argument("--omp", type=int, default=1, help="OMP threads")
+    args = parser.parse_args(argv)
+
+    os.environ["OMP_NUM_THREADS"] = str(args.omp)
+
+    # Build a tester shell without re-creating a timestamped output dir: the
+    # parent already created the shared one and passes it in.
+    tester = OQPTester.__new__(OQPTester)
+    tester.output_dir = args.output_dir
+    tester.mpi_manager = MPIManager()
+
+    result = tester.run_single_test(args.isolated)
+    sys.stdout.flush()
+    print(_RESULT_MARKER + json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_isolated_main())


### PR DESCRIPTION
## Summary

Several fixes surfaced while running `openqp --run_tests all` on a clean `main` build across macOS (arm64 + x86) and Linux.

### 1. UHF examples fail their own references
The eight UHF examples (multiplicity-3 H₂O) converge under plain DIIS to a higher *symmetric* UHF stationary point (e.g. −75.6545 Ha for HF), but their reference `.json` files were regenerated in 7ee5cbf against the lower **broken-symmetry** solution (−75.7445 Ha) that the TRAH stability-following safeguard relaxes to. Since the inputs never set `scf.stability`, the shipped suite reproduces the higher solution and the energy/gradient checks fail by ~0.09–0.13. Reproduced identically on 3 platforms.

**Fix:** set `stability=true` on the 8 UHF inputs so DIIS→TRAH follows the instability to the reference solution. Each then matches to <1e-4.

### 2. CI never ran the tests
The `gcc-build` job only configured, compiled and `pip install`ed — it never invoked `openqp --run_tests`, so neither the UHF mismatch nor a hard test crash could be caught.

**Fix:** add a `Run example test suite` step (once per OS, non-MPI leg, `OQP_TEST_OMP_THREADS=1` for concurrency). The job now builds with a single root **`pip install .`** instead of the `cmake/ninja` + `cd pyoqp && pip install .` split — scikit-build-core (`wheel.install-dir = oqp`) bundles the native library, header and `share/` data into the package, so `openqp` self-locates via `resolve_oqp_root()` with **no `OPENQP_ROOT` and no copying of build artifacts** into site-packages. CI overrides only the build type and the MPI matrix leg via `--config-settings`.

### 3. One hard crash aborted the whole suite
Tests ran in a `ProcessPoolExecutor` worker via the in-process cffi backend, so a Fortran `ERROR STOP` (e.g. a PCM/ddX example when the build lacks `ENABLE_DDX`) or a segfault killed the worker → `BrokenProcessPool` → every pending test failed with no report.

**Fix:** run each test in a dedicated short-lived subprocess (`python -m oqp.utils.oqp_tester --isolated ...`) supervised by a thread pool. A child that crashes/times out dies alone and is recorded as a single `ERROR`; all other tests still run and the report is still produced. Adds `OQP_TEST_TIMEOUT` (default 1800 s).

ddX stays **OFF** in CI (kept fast; the ddX+TRAH PCM path is slow/heavy and validated out-of-CI per `docs/pcm_ddx_validation.md`). `run_tests all` still walks the DDPCM examples, but the runner detects the `OQP_ENABLE_DDX`-absent sentinel and marks them **SKIPPED** rather than failing.

## Validation

- All 8 UHF tests: FAIL → match reference (<1e-4).
- Full `run_tests all` on Linux CI (ddX off): **234 → 232 PASSED, 0 FAILED, 0 ERRORS, 2 SKIPPED (DDPCM)**, both `gcc-build … OFF` legs green.
- Root `pip install .` produces a self-contained package (lib + header + `share/{examples,basis_sets}` bundled); `openqp --run_tests` works with no `OPENQP_ROOT`/assembly.
- Hardened runner: a mixed normal + DDPCM set reports `PASSED / SKIPPED` with a full report where the old runner died with `BrokenProcessPool`.

## Known follow-ups (tracked separately, not blocking)

- **Enable ddX/PCM in CI.** Needs two real fixes first: a Linux-only `DDX::ddx` link failure (the imported target doesn't propagate its BLAS dependency → `libddx.so` undefined `drot_`…) and a DDPCM SCF that floors at ~1e-7 and never meets `conv=1e-8` (escalates DIIS→SOSCF→TRAH and grinds on cavity rebuilds). Tracked in a separate effort.
- **Trim reference JSONs.** Each `examples/**/*.json` carries Nbasis×Nbasis matrices (`DM`/`FOCK`/`VEC_MO`/…) that the test's `skip_keys` already ignores — ~26.8 MB → ~0.24 MB possible. Separate PR.
- **Speed up the geometry-optimization examples.** The `run_tests` step is dominated by the geo-opt tests; capping their optimizer iterations (regenerating those references) brings the suite down from ~22 min. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)