### PR TITLE
perf(grad): opt-in OQP_GRAD_CUTOFF to loosen derivative-2e Schwarz screening

### DIFF
--- a/GRAD_SCREENING_NOTES.md
+++ b/GRAD_SCREENING_NOTES.md
@@ -1,0 +1,163 @@
+# Gradient derivative-2e screening lever (`OQP_GRAD_CUTOFF`)
+
+Performance push, derivative side. Companion to PR #236 (MRSF response:
+digestion + FP32 + `OQP_MRSF_RESP_CUTOFF`) and PR #238 (SCF progressive
+screening). Goal: speed up nuclear gradients (HF, DFT ground state,
+MRSF-TDDFT excited state) by tolerating looser settings on work that is
+recomputed at the **converged** density, validated against gradient accuracy
+(Hartree/Bohr), which is stricter than energy.
+
+All changes are **default-OFF** (env-gated). With no env set the code path is
+byte-identical to baseline.
+
+## STEP 0 — where the gradient time goes (cc-pVDZ, `OMP_NUM_THREADS=8`)
+
+Per-stage wall (and CPU) from the in-tree `measure_time` markers
+(1e-grad / XC-grad / 2e-deriv build):
+
+| system (atoms)      | method | 1e (s) | XC (s) | **2e-deriv (s)** | 2e share |
+|---------------------|--------|-------:|-------:|-----------------:|---------:|
+| benzene (12)        | HF     | 0.006  |   –    | **1.41**         | 99.6%    |
+| benzene (12)        | DFT    | 0.006  | 0.061  | **1.43**         | 94.4%    |
+| benzene (12)        | MRSF   | 0.006  | 0.121  | **1.55**         | 92.4%    |
+| naphthalene (18)    | HF     | 0.016  |   –    | **5.87**         | 99.7%    |
+| naphthalene (18)    | DFT    | 0.016  | 0.127  | **6.01**         | 97.7%    |
+| naphthalene (18)    | MRSF   | 0.017  | 0.293  | **6.87**         | 95.7%    |
+| pentacene (36)      | HF     | 0.103  |   –    | **41.5**         | 99.7%    |
+
+**Conclusion:** the derivative two-electron (gradient-Fock) build dominates the
+gradient for all three methods (>92%, growing with size). The XC-gradient
+quadrature is 4–7%; 1e/overlap-derivative is negligible. Every method funnels
+through the same `grd2_driver_gen` (HF: 1 density; DFT: hybrid-scaled; MRSF:
+`mrsf_2e_grad` with 11 densities), so **one lever in `grd2_driver_gen` helps all
+three.**
+
+For MRSF the *whole gradient* (1e+XC+2e) is only ~23% of the wall clock; the
+preceding SCF + response + **Z-vector** solve dominates — but that is a separate
+work item (Z-vector chip), not this task.
+
+## The lever — `OQP_GRAD_CUTOFF`
+
+`source/integrals/grd2.F90:grd2_driver_gen` screens shell quartets with a
+hard-coded Schwarz block cutoff `cutoff = 1.0d-10` (and density-weighted fine
+screen `cutoff2 = cutoff/2`). The converged-density gradient tolerates a looser
+cutoff. `OQP_GRAD_CUTOFF=<value>` overrides it (default 1e-10 = baseline).
+
+## Accuracy (max |Δgradient| vs the tight 1e-10 baseline, Hartree/Bohr)
+
+Exact (gradient values, independent of timing). Consistent across methods;
+HF is the most sensitive (full exact exchange):
+
+| cutoff  | benzene HF | benzene DFT | benzene MRSF | verdict |
+|---------|-----------:|------------:|-------------:|---------|
+| 1e-8    | 5.8e-7     | 4.8e-7      | 5.1e-7       | ≤1e-6 ✓ (conservative) |
+| 1e-7    | 3.0e-6     | 3.2e-6      | 3.5e-6       | ≤1e-5 ✓ (**recommended**) |
+| 3e-7    | 1.4e-5     | 1.9e-5      | 1.7e-5       | ~1e-5 borderline |
+| 1e-6    | 1.8e-4     | 4.8e-5      | 4.6e-5       | ✗ exceeds 1e-5 |
+| 1e-5    | 8.8e-4     | 3.1e-4      | 2.9e-4       | ✗ |
+
+The error grows steeply past 1e-7 (derivative integrals amplify the dropped
+contributions by ~exponent, so the integral-magnitude Schwarz bound
+under-protects the gradient). **Recommended opt-in: `OQP_GRAD_CUTOFF=1e-7`**
+(≤3.5e-6, comfortably within the 1e-5 budget; ~3× the 1e-6 ideal).
+`1e-8` for a ≤1e-6 conservative setting.
+
+## Speedup — scales with system size
+
+CPU = total compute work (`OMP_WAIT_POLICY=passive`, so OpenMP barrier-wait does
+not inflate it); runs serial, no concurrent jobs. Wall tracks CPU (e.g. pentacene
+HF cut1e-7: wall 39.4→31.4 s = 1.25×). `OMP_NUM_THREADS=8`.
+
+2e-deriv-build speedup (×) vs the tight baseline:
+
+| cutoff | benzene (12 at) | naphthalene (18) | pentacene (36) | max\|ΔG\| trend |
+|--------|----------------:|-----------------:|---------------:|----------------|
+| 1e-8   | 1.05            | 1.07             | **1.12**       | 5.8e-7 → 1.3e-6 (size-stable, ≤~1e-6 ✓) |
+| 1e-7   | 1.10            | 1.16             | **1.25**       | 3e-6 → 2.5e-5 (grows; >1e-5 past ~18 at, HF) |
+
+HF baseline 2e CPU: benzene 10.9 s, naphthalene 45.7 s, pentacene 310 s
+(2e-deriv build is ~constant share, so this is the gradient speedup).
+
+The table is HF; **DFT and MRSF track it within ~0.03×** (same `grd2_driver_gen`):
+at cut1e-7, naphthalene HF 1.16× / DFT 1.16× / MRSF 1.13×. DFT/MRSF are also
+slightly *less* error-sensitive (HF-exchange scale ≤0.5), so cut1e-7 stays within
+1e-5 for them up to ~18 atoms where HF already breaches it.
+
+**Recommendation:**
+- `OQP_GRAD_CUTOFF=1e-8` — universally safe (max\|ΔG\| ≤ ~1.3e-6 a.u. across all
+  sizes & methods), **~5–12 %** faster (grows with size). Good default opt-in.
+- `OQP_GRAD_CUTOFF=1e-7` — **~10–25 %** faster, but max\|ΔG\| reaches ~2.5e-5 on
+  ~36-atom HF (exceeds the 1e-5 target). Safe within 1e-5 only for ≲18-atom HF;
+  DFT/MRSF (HF-exchange scale ≤0.5) tolerate it better (≤~7e-6 at naphthalene).
+
+## Ceiling / honest limits
+
+- Screening reduces quartet **count** far more than **work**: at cut1e-5
+  benzene HF drops 55% of quartets but only 32% of CPU — the screened quartets
+  are disproportionately cheap (diffuse, low angular momentum). The expensive
+  (compact, high-am) quartets have large Schwarz integrals and are never
+  screenable, capping any screening lever at ~30% even at absurd cutoffs, and
+  ~10% within the gradient-accuracy budget on benzene.
+
+## Geometry-optimization safety
+
+Benzene HF/cc-pVDZ optimize from the (slightly off-eq) acene geometry: baseline
+and `OQP_GRAD_CUTOFF=1e-7` both converge in **5 geometry steps** (identical
+trajectory), to final energy −230.72234960 Ha (Δ 6e-10) and the same step-size
+convergence (max step 0.000136 vs 0.000133). The loosened gradient does not
+perturb the optimizer path or the converged minimum.
+
+## Finite-difference cross-check (absolute correctness)
+
+Benzene HF/cc-pVDZ, analytic vs central-difference energy gradient (h=0.005 Å):
+**max|analytic − FD| = 2.4e-5 Ha/Bohr**, every component agreeing to 3 sig figs
+with a uniform offset consistent with FD truncation at this step (energies logged
+to 1e-8). Confirms the analytic baseline gradient is correct; the lever's
+deviation from baseline (3e-6 at cut1e-7) is below the FD-truncation floor, so the
+loosened gradient also tracks the true gradient. (`fd_grad.py`.)
+
+## Derivative-aware Schwarz screen — TESTED, strictly worse (not shipped)
+
+The natural next idea (and the one an adversarial review flagged): screen on the
+*derivative* bound `Schwarz_ij * Schwarz_kl * amp`, with `amp = 2·sqrt(max
+exponent over the 4 shells)` approximating |∂_A(ab|cd)| ~ 2α·(raised ERI), to
+protect compact (high-derivative) quartets and kill the error cliff. Implemented
+and measured (benzene HF) — it is **strictly worse than the plain integral
+cutoff on the error-vs-work frontier**:
+
+| computed quartets ≈ | plain cutoff max\|ΔG\| | deriv-aware max\|ΔG\| |
+|--------------------:|-----------------------:|----------------------:|
+| 800k                | 3.0e-6 (cut 1e-7)      | 8.5e-5 (dcut 3e-6) — 28× worse |
+| 730k                | 1.4e-5 (cut 3e-7)      | 4.4e-4 (dcut 1e-5) — 30× worse |
+
+Reason: the integral magnitude (with the existing density-weighted fine screen)
+already predicts the actual gradient contribution better than the exponent-
+amplified bound — the `amp` weighting wastes work protecting compact quartets
+that don't need it while over-screening diffuse quartets that *do* contribute to
+the valence gradient. No `amp` recalibration helps (the whole frontier is worse),
+so the code was reverted. A *rigorous* derivative-Schwarz (evaluate the raised-
+angular-momentum pair `(a+1,b|a+1,b)`) might do better but is a large new kernel
+for, at best, a few percent — not pursued.
+
+## Dead ends (measured, not assumed)
+
+- **`OQP_GRAD_PRIM_TOL`** (loosen primitive-pair / Rys tolerance `tol_int`
+  20→12→10): **no speedup** (≤1% CPU) — the cc-pVDZ contractions are short, so
+  the Rys evaluation cost is insensitive to `dtol`. (tol 20→12 also gives
+  *zero* gradient change; tol 10 gives ~9e-6.) Not shipped.
+- **FP32 / mixed precision for the 2e-deriv contraction:** the build is
+  **eval-bound, not digestion-bound** — naphthalene MRSF 2e (11 densities) is
+  only ~17% more CPU than HF 2e (1 density), so `get_density`/contraction is a
+  small fraction; the cost is the FP64 Rys kernel. FP32-izing that kernel is a
+  large, risky rewrite very likely to exceed the 1e-6 gradient budget (response
+  lesson: all-FP32 gave ~6% at ~µeV energy). Not pursued.
+- **XC-gradient grid/Φ reuse:** XC-grad is only 4–7% of the gradient, and the
+  gradient needs 2nd-derivative AO collocation (`aoG2`) that an SCF-Vxc Φ-cache
+  (≤1st derivative) would not hold. Low ceiling, high complexity. Not pursued.
+
+## Reproduce
+
+Build (this Mac, gcc-15): see brief. Run via staged `OPENQP_ROOT`.
+`OQP_GRAD_STATS=1` prints the coarse/fine skip + computed quartet counts.
+Geometry/inputs + sweep harness: session scratchpad `gen_acenes.py`,
+`sweep.py`, `fd_grad.py`.

--- a/source/integrals/grd2.F90
+++ b/source/integrals/grd2.F90
@@ -173,6 +173,12 @@ contains
 
     real(kind=dp) :: rtol, dtol
 
+    integer :: itmp
+    character(len=64) :: sval
+    integer :: ln
+    real(kind=dp) :: cutval
+    logical :: lstats
+
     type(grd2_int_data_t) :: gdat
 
     type(int2_pair_storage) :: ppairs
@@ -190,7 +196,25 @@ contains
 
 !    `cutoff` is the Schwarz screening cutoff
 !    `dabcut` is the two particle density cutoff
+!
+!   The gradient is evaluated at the CONVERGED density, so the derivative-ERI
+!   screening may be loosened relative to the SCF Fock build without changing
+!   the converged gradient beyond a controllable tolerance.  Opt-in, default-OFF
+!   (env unset => byte-identical to the historic 1.0d-10):
+!     OQP_GRAD_CUTOFF - Schwarz block cutoff (default 1.0d-10).  1.0d-8 is the
+!                       size-robust opt-in (max|dG| <= ~1e-6 a.u. through the
+!                       36-atom systems tested).  1.0d-7 is more aggressive but
+!                       max|dG| GROWS with system size and exceeds 1e-5 past
+!                       ~18-atom HF (DFT/MRSF, HF-exchange scale <=0.5, tolerate
+!                       it to larger sizes).  Looser still is unsafe: derivative
+!                       integrals amplify the dropped contributions.  See
+!                       GRAD_SCREENING_NOTES.md for the per-size/method table.
     cutoff = 1.0d-10
+    call get_environment_variable("OQP_GRAD_CUTOFF", sval, ln)
+    if (ln > 0) then
+      read(sval,*,iostat=itmp) cutval
+      if (itmp == 0 .and. cutval > 0.0_dp) cutoff = cutval
+    end if
     cutoff2 = cutoff/2.0d+00
 
     zbig = maxval(basis%ex)
@@ -200,6 +224,12 @@ contains
 
     dtol = 10.0d0**(-tol_int)
     rtol = log(10.0_dp)*tol_int
+
+!   Opt-in screening diagnostics (auto-enabled when the lever is active).
+    lstats = (cutoff /= 1.0d-10)
+    call get_environment_variable("OQP_GRAD_STATS", sval, ln)
+    if (ln > 0) lstats = (sval(1:1)=='1' .or. sval(1:1)=='y' .or. sval(1:1)=='Y' &
+                          .or. sval(1:1)=='t' .or. sval(1:1)=='T')
 
     call cutoffs%set(&
             cutoff_integral_value=dabcut,&
@@ -332,6 +362,13 @@ contains
 !   Project rotational contaminant from gradients
 !   call dfinal(1)
 
+    if (lstats) then
+      write(iw, fmt="(&
+        &/1X,'[grd2] screening: cutoff=',ES9.2,'  pass=',I1,&
+        &/1X,'[grd2] blocks coarse/fine skipped ',I12,'/',I12,&
+        &'  computed ',I12)") &
+        cutoff, gcomp%cur_pass, skip1, skip2, numint
+    end if
 
   end subroutine grd2_driver_gen
 


### PR DESCRIPTION
## Summary

Opt-in, **default-OFF** lever to speed up nuclear gradients (HF, DFT, MRSF-TDDFT) by loosening the derivative-2e (gradient-Fock) Schwarz screening. The gradient is built at the **converged** density, so its ERI screening tolerates a looser cutoff than the SCF Fock build. With no env var set the path is byte-identical to baseline (`1.0d-10`).

Profiling (cc-pVDZ; benzene/naphthalene/pentacene; HF/DFT/MRSF) shows the 2e-derivative build dominates the gradient (92–99.7%), and all three methods funnel through the same `grd2_driver_gen`, so one knob helps all three.

- `OQP_GRAD_CUTOFF=<value>` overrides the `1.0d-10` Schwarz block cutoff. Recommended `1e-8` (size-robust, ≤~1e-6 a.u., ~5–12%) or `1e-7` (~10–25%, but >1e-5 past ~18-atom HF).
- `OQP_GRAD_STATS=1` prints coarse/fine-skipped + computed quartet counts.

Validated: gradient error vs the tight baseline within budget per method/size; analytic gradient cross-checked vs finite difference (2.4e-5); geometry optimization converges in identical step counts. Full profile, scaling, and measured dead ends (primitive-tol, FP32, XC-grid reuse, derivative-aware screen) in `GRAD_SCREENING_NOTES.md`.

_Note: a follow-up flips the default to `1.0d-8`._
