### PR TITLE
perf(grad): default OQP_GRAD_CUTOFF to 1.0d-8 (follow-up to #244)

### DIFF
--- a/GRAD_SCREENING_NOTES.md
+++ b/GRAD_SCREENING_NOTES.md
@@ -7,8 +7,12 @@ MRSF-TDDFT excited state) by tolerating looser settings on work that is
 recomputed at the **converged** density, validated against gradient accuracy
 (Hartree/Bohr), which is stricter than energy.
 
-All changes are **default-OFF** (env-gated). With no env set the code path is
-byte-identical to baseline.
+**Default `OQP_GRAD_CUTOFF = 1.0d-8`** (the historic Schwarz cutoff was an
+unusually tight `1.0d-10`). The env var overrides it; **`=1.0d-10` restores the
+historic tight screening byte-for-byte**. `1e-8` is the size-robust choice
+(max|ΔG| ≤ ~1e-6 a.u. through the 36-atom systems tested) and sits well below
+the regression-suite tolerance (≈5e-5, max-element deviation rounded to 4
+decimals), so it does not perturb the small-molecule example references.
 
 ## STEP 0 — where the gradient time goes (cc-pVDZ, `OMP_NUM_THREADS=8`)
 
@@ -39,9 +43,10 @@ work item (Z-vector chip), not this task.
 ## The lever — `OQP_GRAD_CUTOFF`
 
 `source/integrals/grd2.F90:grd2_driver_gen` screens shell quartets with a
-hard-coded Schwarz block cutoff `cutoff = 1.0d-10` (and density-weighted fine
-screen `cutoff2 = cutoff/2`). The converged-density gradient tolerates a looser
-cutoff. `OQP_GRAD_CUTOFF=<value>` overrides it (default 1e-10 = baseline).
+Schwarz block cutoff (and density-weighted fine screen `cutoff2 = cutoff/2`),
+now **defaulting to `1.0d-8`** (was a hard-coded, unusually tight `1.0d-10`).
+The converged-density gradient tolerates the looser cutoff. `OQP_GRAD_CUTOFF`
+overrides it; **`=1.0d-10` restores the historic tight screening exactly**.
 
 ## Accuracy (max |Δgradient| vs the tight 1e-10 baseline, Hartree/Bohr)
 
@@ -58,9 +63,10 @@ HF is the most sensitive (full exact exchange):
 
 The error grows steeply past 1e-7 (derivative integrals amplify the dropped
 contributions by ~exponent, so the integral-magnitude Schwarz bound
-under-protects the gradient). **Recommended opt-in: `OQP_GRAD_CUTOFF=1e-7`**
-(≤3.5e-6, comfortably within the 1e-5 budget; ~3× the 1e-6 ideal).
-`1e-8` for a ≤1e-6 conservative setting.
+under-protects the gradient). The **default is `1e-8`** (size-robust, ≤~1e-6);
+`OQP_GRAD_CUTOFF=1e-7` is an aggressive override (~3.5e-6 on small systems but
+growing past 1e-5 for larger HF — see below); `=1e-10` restores the tight
+baseline.
 
 ## Speedup — scales with system size
 
@@ -83,12 +89,14 @@ at cut1e-7, naphthalene HF 1.16× / DFT 1.16× / MRSF 1.13×. DFT/MRSF are also
 slightly *less* error-sensitive (HF-exchange scale ≤0.5), so cut1e-7 stays within
 1e-5 for them up to ~18 atoms where HF already breaches it.
 
-**Recommendation:**
-- `OQP_GRAD_CUTOFF=1e-8` — universally safe (max\|ΔG\| ≤ ~1.3e-6 a.u. across all
-  sizes & methods), **~5–12 %** faster (grows with size). Good default opt-in.
+**Settings:**
+- **Default `1e-8`** — size-robust (max\|ΔG\| ≤ ~1.3e-6 a.u. across all sizes &
+  methods), **~5–12 %** faster (grows with size). Below the regression-suite
+  tolerance (≈5e-5), so the small-molecule example references are unaffected.
 - `OQP_GRAD_CUTOFF=1e-7` — **~10–25 %** faster, but max\|ΔG\| reaches ~2.5e-5 on
   ~36-atom HF (exceeds the 1e-5 target). Safe within 1e-5 only for ≲18-atom HF;
   DFT/MRSF (HF-exchange scale ≤0.5) tolerate it better (≤~7e-6 at naphthalene).
+- `OQP_GRAD_CUTOFF=1e-10` — restore the historic tight screening exactly.
 
 ## Ceiling / honest limits
 

--- a/source/integrals/grd2.F90
+++ b/source/integrals/grd2.F90
@@ -198,18 +198,16 @@ contains
 !    `dabcut` is the two particle density cutoff
 !
 !   The gradient is evaluated at the CONVERGED density, so the derivative-ERI
-!   screening may be loosened relative to the SCF Fock build without changing
-!   the converged gradient beyond a controllable tolerance.  Opt-in, default-OFF
-!   (env unset => byte-identical to the historic 1.0d-10):
-!     OQP_GRAD_CUTOFF - Schwarz block cutoff (default 1.0d-10).  1.0d-8 is the
-!                       size-robust opt-in (max|dG| <= ~1e-6 a.u. through the
-!                       36-atom systems tested).  1.0d-7 is more aggressive but
-!                       max|dG| GROWS with system size and exceeds 1e-5 past
-!                       ~18-atom HF (DFT/MRSF, HF-exchange scale <=0.5, tolerate
-!                       it to larger sizes).  Looser still is unsafe: derivative
-!                       integrals amplify the dropped contributions.  See
-!                       GRAD_SCREENING_NOTES.md for the per-size/method table.
-    cutoff = 1.0d-10
+!   screening is loosened relative to the SCF Fock build.  The default block
+!   Schwarz cutoff is 1.0d-8 (vs the historic, unusually tight 1.0d-10): it is
+!   size-robust (max|dG| <= ~1e-6 a.u. through the 36-atom systems tested) and
+!   trims ~5-12% off the dominant 2e-derivative build, growing with size.
+!     OQP_GRAD_CUTOFF - override the cutoff.  Set 1.0d-10 to restore the historic
+!                       tight screening (byte-for-byte).  1.0d-7 is more
+!                       aggressive (~10-25%) but max|dG| GROWS with size and
+!                       exceeds 1e-5 past ~18-atom HF (DFT/MRSF tolerate it
+!                       further).  See GRAD_SCREENING_NOTES.md for the table.
+    cutoff = 1.0d-8
     call get_environment_variable("OQP_GRAD_CUTOFF", sval, ln)
     if (ln > 0) then
       read(sval,*,iostat=itmp) cutval
@@ -225,8 +223,8 @@ contains
     dtol = 10.0d0**(-tol_int)
     rtol = log(10.0_dp)*tol_int
 
-!   Opt-in screening diagnostics (auto-enabled when the lever is active).
-    lstats = (cutoff /= 1.0d-10)
+!   Opt-in screening diagnostics (OQP_GRAD_STATS=1; off by default).
+    lstats = .false.
     call get_environment_variable("OQP_GRAD_STATS", sval, ln)
     if (ln > 0) lstats = (sval(1:1)=='1' .or. sval(1:1)=='y' .or. sval(1:1)=='Y' &
                           .or. sval(1:1)=='t' .or. sval(1:1)=='T')


### PR DESCRIPTION
## Summary

Follow-up to #244 (the opt-in `OQP_GRAD_CUTOFF` lever). #244 kept the historic, unusually tight `1.0d-10` Schwarz block cutoff as the default; this **flips the default to `1.0d-8`**.

The gradient is built at the **converged** density, so the derivative-2e screening — the dominant gradient cost (92–99.7% for HF/DFT/MRSF, all via the same `grd2_driver_gen`) — tolerates a looser default.

## Why `1.0d-8`

- **Size-robust accuracy:** max\|ΔG\| ≤ ~1e-6 a.u. vs the tight `1.0d-10` baseline through the 36-atom systems tested (benzene→pentacene, HF/DFT/MRSF) — well under the 1e-5 budget and near the 1e-6 ideal.
- **Speed:** ~5–12% off the dominant 2e-derivative build, growing with system size.
- **References unaffected:** the drift on the small-molecule example references is ~1e-7, ~500× below the regression-suite tolerance (≈5e-5). The HF/DFT/MRSF/TDDFT gradient and optimize example regressions all pass unchanged at the new default.

## Behavior / overrides

- Default `OQP_GRAD_CUTOFF = 1.0d-8`.
- `=1.0d-10` restores the historic tight screening **byte-for-byte**.
- `=1.0d-7` is more aggressive (~10–25%) but max\|ΔG\| exceeds 1e-5 past ~18-atom HF (DFT/MRSF tolerate it further).
- `OQP_GRAD_STATS=1` prints screening counts (off by default).
- `grd2_hess_driver` (analytic Hessian) is unchanged at `1.0d-10`.

## Validation

Gradient error vs the `1.0d-10` baseline within budget per method/size; analytic gradient cross-checked vs finite difference (2.4e-5, FD-truncation-limited); geometry optimization converges in identical step counts (final energy Δ 6e-10). See `GRAD_SCREENING_NOTES.md` for the full table.
