### PR TITLE
feat(perf): user-facing `perf` preset + input keys for performance options (+ gfortran-12 tagarray build fix)

### DIFF
--- a/docs/perf_levels.md
+++ b/docs/perf_levels.md
@@ -1,0 +1,82 @@
+# Performance options and the `perf` preset
+
+OpenQP's performance knobs are ordinary **input keys** backed by the shared control
+struct — there are no environment variables involved. A single opt-in preset
+`[input] perf` bundles them into one accuracy↔speed dial.
+
+```
+[input]
+perf = 1        # 0, 1, 2, or 3 (default 1; set perf=-1 to disable the preset)
+```
+
+## The four levels
+
+| `perf` | Use it for | What it does | Accuracy |
+|---|---|---|---|
+| **0** | strict reference / reproducibility | every accelerator off, every cutoff tightest | bit-reference (fixed thread count) |
+| **1** | **recommended production** | only exact, proven-helpful knobs: MRSF response cutoff `1e-8`, z-vector warm-start (+ always-on Fock digestion) | ≈ reference (≤ µEh) |
+| **2** | faster, tiny degradation | `perf=1` + coarse-to-fine XC grid + gradient Schwarz cutoff `1e-8` | gradients within ~5×10⁻⁷ a.u.; SCF exact at convergence |
+| **3** | aggressive, **degradation allowed** | looser cutoffs traded for speed: gradient `1e-7` (~10⁻⁵ a.u.), response `1e-6` (~few µeV) | small, controlled — verify for your system |
+
+**`perf=1` is the default** (recommended production, exact). Set `perf=-1` to disable the preset
+and leave every knob at its control default. All levels were calibrated
+against a CPU benchmark (MKL + Apple Accelerate) across HF/DFT/TDDFT/MRSF energies and MRSF
+gradients.
+
+> **Why these and not the rest.** On the CPU builds benchmarked, the reliable speedups are
+> the `perf=1` knobs (response cutoff, warm-start, Fock digestion) and, at higher levels,
+> *looser integral cutoffs*. The XC Φ-cache, IncDFT, MRSF FP32 and progressive screening
+> (`pscreen`) were performance-neutral to *negative* on CPU (FP32 ~2× slower under MKL), so
+> **no preset enables them** — they remain available as explicit input keys for regimes the
+> CPU benchmark doesn't cover (e.g. GPU XC). `perf=1` is the default; raise it only if your
+> own timing shows a gain.
+
+## Individual input keys
+
+Every knob is also a direct input key. Each defaults to `auto` (defer to the preset);
+an explicit value **overrides** the preset.
+
+| Section | Key | Meaning | Values |
+|---|---|---|---|
+| `[scf]` | `xc_c2f` | coarse-to-fine XC grid during SCF descent | `on`/`off`/`auto` |
+| `[scf]` | `xc_phi_cache` | cache collocation Φ across SCF iters (exact; opt-in) | `on`/`off`/`auto` |
+| `[scf]` | `xc_incdft` | incremental DFT (experimental; opt-in) | `on`/`off`/`auto` |
+| `[scf]` | `pscreen` | progressive integral/grid screening (+ `pscreen_cap`) | `on`/`off` |
+| `[scf]` | `grad_cutoff` | Schwarz cutoff for the 2e-derivative gradient build | a number, e.g. `1.0d-8`, or `auto` |
+| `[tdhf]` | `resp_cutoff` | 2e cutoff for the MRSF response build | a number, e.g. `1e-8`, or `auto` |
+| `[tdhf]` | `fp32` | single-precision MRSF response digestion (opt-in) | `on`/`off`/`auto` |
+| `[tdhf]` | `zv_warmstart` | reuse the previous step's z-vector as the CPHF seed (exact) | `on`/`off`/`auto` |
+
+Precedence (low → high): control default → `perf` preset → explicit input key. Example —
+production speed but keep the full XC grid and tighten the response on one job:
+
+```
+[input]
+perf = 2
+[scf]
+xc_c2f = off
+[tdhf]
+resp_cutoff = 5e-11
+```
+
+The resolved settings (and any warnings) are printed near the top of the run log:
+
+```
+   Performance settings (perf = 2)
+     scf.xc_c2f        = off       (input)
+     scf.grad_cutoff   = 1.0d-8    (preset)
+     tdhf.resp_cutoff  = 5e-11     (input)
+     tdhf.zv_warmstart = on        (preset)
+     ...
+```
+
+## Safety notes
+
+- `perf=0` is the bitwise reference **for a fixed thread count**. The threaded Fock build
+  uses a dynamic-schedule reduction, so results are not bit-identical across thread counts
+  at any level — pin `OMP_NUM_THREADS` for strict reproducibility.
+- `perf=3` deliberately trades a little accuracy for speed; do not use it for reference
+  numbers or tight 2nd-order properties (IR/Raman/NMR) — use `perf ≤ 1` there.
+- `fp32` (opt-in) is non-reproducible, can flip near-degenerate excited states, and was
+  net-slower than fp64 on CPU; only enable it where you have measured a gain.
+- `xc_incdft` (opt-in) is experimental and typically *slows* SCF convergence.

--- a/examples/PERF/H2O_DFT_perf1.inp
+++ b/examples/PERF/H2O_DFT_perf1.inp
@@ -1,0 +1,19 @@
+# Water B3LYP/6-31G* energy at the recommended production preset (perf=1).
+[input]
+system=
+   8   0.000000   0.000000   0.117300
+   1   0.000000   0.757200  -0.469200
+   1   0.000000  -0.757200  -0.469200
+charge=0
+runtype=energy
+functional=b3lypv5
+basis=6-31g*
+method=hf
+perf=1
+[guess]
+type=huckel
+[scf]
+multiplicity=1
+type=rhf
+maxit=100
+conv=1.0e-6

--- a/examples/PERF/H2O_MRSF_perf1.inp
+++ b/examples/PERF/H2O_MRSF_perf1.inp
@@ -1,0 +1,23 @@
+# Water MRSF-TDDFT (BHHLYP/cc-pVDZ) excitation energies, perf=1.
+# perf=1 sets resp_cutoff=1e-8 and zv_warmstart=on (both exact); all else off.
+[input]
+system=
+   8   0.000000   0.000000   0.117300
+   1   0.000000   0.757200  -0.469200
+   1   0.000000  -0.757200  -0.469200
+charge=0
+runtype=energy
+functional=bhhlyp
+basis=cc-pvdz
+method=tdhf
+perf=1
+[guess]
+type=huckel
+[scf]
+multiplicity=3
+type=rohf
+conv=1.0e-8
+maxit=100
+[tdhf]
+type=mrsf
+nstate=3

--- a/examples/PERF/H2O_MRSF_perf2_override.inp
+++ b/examples/PERF/H2O_MRSF_perf2_override.inp
@@ -1,0 +1,28 @@
+# perf=2 (situational acceleration) with two explicit input-key overrides that
+# win over the preset: keep the full XC grid, and use the tight response cutoff.
+[input]
+system=
+   8   0.000000   0.000000   0.117300
+   1   0.000000   0.757200  -0.469200
+   1   0.000000  -0.757200  -0.469200
+charge=0
+runtype=grad
+functional=bhhlyp
+basis=cc-pvdz
+method=tdhf
+perf=2
+[guess]
+type=huckel
+[scf]
+multiplicity=3
+type=rohf
+conv=1.0e-9
+maxit=100
+xc_c2f=off
+[tdhf]
+type=mrsf
+nstate=2
+zvconv=1.0e-10
+resp_cutoff=5e-11
+[properties]
+grad=1

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -322,6 +322,9 @@ ExternalProject_Add(libtagarray
         BINARY_DIR ${TAGARRAY_BUILD_DIR}
         STAMP_DIR  ${TAGARRAY_STAMP_DIR}
         UPDATE_COMMAND ""
+        # tagarray v1.0.0 ships a 144-char iso_c_binding USE line that its own
+        # -std=f2018 build truncates under gfortran>=12; wrap it (idempotent).
+        PATCH_COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/fix_tagarray_linelen.py ${TAGARRAY_SOURCE_DIR}
         INSTALL_COMMAND ""
         CMAKE_ARGS -DENABLE_FORTRAN=ON
                    -DENABLE_TESTING=OFF

--- a/external/fix_tagarray_linelen.py
+++ b/external/fix_tagarray_linelen.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# OpenQP build patch: tagarray v1.0.0 ships container.f90 with a 144-char
+# `use, intrinsic :: iso_c_binding, only: ...` line. tagarray's own CMake
+# compiles the library with -std=f2018, whose 132-char free-form limit
+# truncates that line -> c_null_ptr/c_associated drop out -> cascade of
+# "has no IMPLICIT type" / "not a member" errors under gfortran >= 12.
+# This wraps the single offending line with continuations (<=132 chars,
+# fully f2018-conformant). Idempotent: a no-op once wrapped or if upstream
+# fixes it. Mirror this fix upstream in Open-Quantum-Platform/tagarray.
+import sys, pathlib
+
+src = pathlib.Path(sys.argv[1]) / "source" / "API" / "Fortran" / "container.f90"
+if not src.is_file():
+    print(f"[OpenQP] tagarray patch: {src} not found, skipping")
+    sys.exit(0)
+
+text = src.read_text()
+long_line = ("  use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t, "
+             "c_float, c_double, c_double_complex, c_ptr, c_f_pointer, "
+             "c_null_ptr, c_associated")
+wrapped = ("  use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t, c_float, &\n"
+           "                                         c_double, c_double_complex, c_ptr, &\n"
+           "                                         c_f_pointer, c_null_ptr, c_associated")
+
+if long_line in text:
+    src.write_text(text.replace(long_line, wrapped))
+    print("[OpenQP] tagarray patch: wrapped container.f90 iso_c_binding line")
+else:
+    print("[OpenQP] tagarray patch: already conformant, no change")

--- a/include/oqp.h
+++ b/include/oqp.h
@@ -160,6 +160,14 @@ struct control_parameters {
     bool      sd_scf;
     bool      pcm_enabled;
     double    pcm_epsilon;
+    /* Performance knobs -- keep in sync with control_parameters in source/types.F90 */
+    int64_t   xc_c2f;
+    int64_t   xc_phi_cache;
+    int64_t   xc_incdft;
+    double    grad_cutoff;
+    double    mrsf_resp_cutoff;
+    int64_t   mrsf_fp32;
+    int64_t   mrsf_zv_warmstart;
 };
 
 struct mpi_communicator {

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -1442,6 +1442,7 @@ class Molecule:
         """
         self.mpi_manager.set_mpi_comm(self.data)
         self.config = self.get_config(input_source)
+        self._resolve_perf(input_source)
         self.data.apply_config(self.config)
         self.data['usempi'] = int(self.usempi)
         self.xyz = self.data._data.xyz
@@ -1451,6 +1452,17 @@ class Molecule:
         self.initialize_symmetry_metadata()
 
         return self
+
+    def _resolve_perf(self, input_source):
+        """Apply the `perf` preset to self.config before it is pushed to the control
+        struct: fill the performance input keys left at the sentinel 'auto' (an explicit
+        value always wins). Env-var free. Stores the resolution report for logging."""
+        from oqp.utils import perf_levels
+        self.perf_level = self.config.get("input", {}).get("perf", perf_levels.UNSET)
+        self.perf_report, self.perf_warns = perf_levels.apply(
+            self.config, self.perf_level,
+            scf_conv=self.config.get("scf", {}).get("conv"),
+            zv_conv=self.config.get("tdhf", {}).get("zvconv"))
 
     @mpi_dump
     def write_molden(self, filename):

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -64,6 +64,22 @@ def path(strng):
     return Path(strng)
 
 
+def _perf_parse_bool(v):
+    """Parse a perf input-key boolean; return None for 'auto'/empty (= leave default)."""
+    s = str(v).strip().lower()
+    if s in ("", "auto"):
+        return None
+    return s in ("1", "y", "yes", "t", "true", "on")
+
+
+def _perf_parse_float(v):
+    """Parse a perf input-key float (Fortran 'd' exponents ok); None for 'auto'/empty."""
+    s = str(v).strip().lower()
+    if s in ("", "auto"):
+        return None
+    return float(s.replace("d", "e"))
+
+
 OQP_CONFIG_SCHEMA = {
     'input': {
         'charge': {'type': int, 'default': '0'},
@@ -72,6 +88,11 @@ OQP_CONFIG_SCHEMA = {
         'functional': {'type': string, 'default': ''},
         'method': {'type': string, 'default': 'hf'},
         'runtype': {'type': string, 'default': 'energy'},
+        # perf: performance preset, default 1 (recommended production; exact). 0..3
+        # resolve to a validated bundle of the performance input keys in
+        # utils/perf_levels.py; explicit input keys override the preset. Set perf=-1
+        # to disable the preset entirely (leave every knob at its control default).
+        'perf': {'type': int, 'default': '1'},
         'system': {'type': str, 'default': ''},
         'system2': {'type': str, 'default': ''},
         'ispher': {'type': ispher_mode, 'default': 'auto'},
@@ -142,6 +163,12 @@ OQP_CONFIG_SCHEMA = {
         'pscreen_xc_aocut': {'type': float, 'default': '0.0'},
         'pscreen_grid_rad': {'type': int, 'default': '0'},
         'pscreen_grid_ang': {'type': int, 'default': '0'},
+        # performance knobs (see utils/perf_levels.py). 'auto' defers to the [input]
+        # perf preset; an explicit value overrides it. Translated to OQP_* env vars.
+        'xc_c2f': {'type': string, 'default': 'auto'},
+        'xc_phi_cache': {'type': string, 'default': 'auto'},
+        'xc_incdft': {'type': string, 'default': 'auto'},
+        'grad_cutoff': {'type': string, 'default': 'auto'},
         'init_scf': {'type':  string, 'default': 'no'},
         'init_basis': {'type': string, 'default': 'none'},
         'init_library': {'type': string, 'default': ''},
@@ -206,6 +233,11 @@ OQP_CONFIG_SCHEMA = {
         'ixcore': {'type': string, 'default': '-1'},
         'z_solver': {'type': int, 'default': '0'},  # 0: CG, 1: GMRES (legacy), 2: MINRES, 3: AUTO
         'gmres_dim': {'type': int, 'default': '50'},  # Dimension for GMRES during Z-vector
+        # MRSF performance knobs (see utils/perf_levels.py). 'auto' defers to the
+        # [input] perf preset; an explicit value overrides it.
+        'resp_cutoff': {'type': string, 'default': 'auto'},
+        'fp32': {'type': string, 'default': 'auto'},
+        'zv_warmstart': {'type': string, 'default': 'auto'},
     },
     'ekt': {
         'ip': {'type': bool, 'default': 'True'},
@@ -375,6 +407,10 @@ class OQPData:
             "pscreen_xc_aocut": "set_scf_pscreen_xc_aocut",
             "pscreen_grid_rad": "set_scf_pscreen_grid_rad",
             "pscreen_grid_ang": "set_scf_pscreen_grid_ang",
+            "xc_c2f": "set_scf_xc_c2f",
+            "xc_phi_cache": "set_scf_xc_phi_cache",
+            "xc_incdft": "set_scf_xc_incdft",
+            "grad_cutoff": "set_scf_grad_cutoff",
             "active_basis": "set_scf_active_basis",
             "rstctmo": "set_scf_rstctmo",
             "scal_rel": "set_scf_scal_rel",
@@ -429,6 +465,9 @@ class OQPData:
             "ixcore": "set_tdhf_ixcore",
             "z_solver": "set_tdhf_z_solver",
             "gmres_dim": "set_tdhf_gmres_dim",
+            "resp_cutoff": "set_tdhf_resp_cutoff",
+            "fp32": "set_tdhf_fp32",
+            "zv_warmstart": "set_tdhf_zv_warmstart",
         },
     }
     _typemap = [np.void,
@@ -690,6 +729,50 @@ class OQPData:
     def set_scf_pscreen_grid_ang(self, n):
         """Progressive XC: coarse angular (Lebedev) grid points during the SCF descent (0=off)"""
         self._data.control.pscreen_grid_ang = n
+
+    # --- Performance knobs (input keys; 'auto' defers to the perf preset / leaves
+    #     the control default untouched). See utils/perf_levels.py. ---
+    def set_scf_xc_c2f(self, v):
+        """Coarse-to-fine XC grid during SCF descent (on/off/auto)."""
+        b = _perf_parse_bool(v)
+        if b is not None:
+            self._data.control.xc_c2f = 1 if b else 0
+
+    def set_scf_xc_phi_cache(self, v):
+        """Cache collocation Phi across SCF iterations (on/off/auto)."""
+        b = _perf_parse_bool(v)
+        if b is not None:
+            self._data.control.xc_phi_cache = 1 if b else 0
+
+    def set_scf_xc_incdft(self, v):
+        """Incremental DFT (experimental; on/off/auto)."""
+        b = _perf_parse_bool(v)
+        if b is not None:
+            self._data.control.xc_incdft = 1 if b else 0
+
+    def set_scf_grad_cutoff(self, v):
+        """Schwarz cutoff for the 2e-derivative gradient build (number or auto)."""
+        f = _perf_parse_float(v)
+        if f is not None:
+            self._data.control.grad_cutoff = f
+
+    def set_tdhf_resp_cutoff(self, v):
+        """MRSF response 2e-integral cutoff (number or auto)."""
+        f = _perf_parse_float(v)
+        if f is not None:
+            self._data.control.mrsf_resp_cutoff = f
+
+    def set_tdhf_fp32(self, v):
+        """FP32 MRSF response digestion (on/off/auto)."""
+        b = _perf_parse_bool(v)
+        if b is not None:
+            self._data.control.mrsf_fp32 = 1 if b else 0
+
+    def set_tdhf_zv_warmstart(self, v):
+        """MRSF z-vector warm-start across geometry steps (on/off/auto)."""
+        b = _perf_parse_bool(v)
+        if b is not None:
+            self._data.control.mrsf_zv_warmstart = 1 if b else 0
 
     def set_scf_converger_type(self, converger_type):
         """Set SCF solver for SCF convergence:

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -219,6 +219,9 @@ class Runner:
         else:
             self.mol.load_config(input_file)
 
+        # (The `perf` preset is resolved inside mol.load_config, before the config is
+        #  pushed to the control struct; mol.perf_report holds the resolution for logging.)
+
         # Apply the parsed `omp_threads` at runtime. The pre-import hook only sees
         # a CLI flag or an input *file*, so this also covers the programmatic
         # Runner(input_dict=...) path. omp_set_num_threads takes effect for the
@@ -249,6 +252,26 @@ class Runner:
         dump_log(self.mol, title='', section='start',
                  info={"build": _openqp_build_label()})
         dump_log(self.mol, title='PyOQP: Symmetry metadata', section='symmetry')
+        self._log_perf_settings()
+
+    def _log_perf_settings(self):
+        """Append the resolved performance settings + warnings to the log."""
+        report = getattr(self.mol, "perf_report", None)
+        if not report:
+            return
+        from oqp.utils import perf_levels
+        block = perf_levels.format_report(getattr(self.mol, "perf_level", perf_levels.UNSET),
+                                          report, getattr(self.mol, "perf_warns", []))
+        if not block:
+            return
+        if getattr(self.mol, "log", None):
+            try:
+                with open(self.mol.log, 'a', encoding='utf-8') as fout:
+                    fout.write(block + "\n")
+            except OSError:
+                pass
+        if not getattr(self.mol, "silent", False):
+            print(block)
 
     def run(self, test_mod=False):
         """

--- a/pyoqp/oqp/utils/perf_levels.py
+++ b/pyoqp/oqp/utils/perf_levels.py
@@ -1,0 +1,123 @@
+"""
+Centralised resolver for OpenQP's performance options and the ``perf`` preset.
+
+Each performance knob is an ordinary **input key** (e.g. ``[scf] xc_c2f``,
+``[tdhf] resp_cutoff``) backed by a field on the shared ``control`` struct -- there are
+no environment variables involved. ``[input] perf = 0|1|2|3`` is a preset that fills in
+those input keys (the ones the user left at the sentinel ``auto``) before the config is
+pushed to the native library. An explicit input key always overrides the preset.
+
+  perf = 0  strict reference / reproducible  -- every accelerator off, tightest cutoffs.
+  perf = 1  recommended production (exact)   -- only exact, proven-helpful knobs:
+                                                MRSF response cutoff 1e-8, z-vector
+                                                warm-start (+ the always-on Fock digest).
+  perf = 2  faster, tiny degradation         -- + coarse-to-fine XC grid + grad Schwarz
+                                                cutoff 1e-8 (<=5e-7 a.u. on gradients).
+  perf = 3  aggressive, degradation allowed  -- looser cutoffs traded for speed: grad
+                                                1e-7 (~1e-5 a.u.), response 1e-6 (~few ueV).
+
+The accelerators that the CPU benchmark found net-negative or experimental -- Phi-cache,
+IncDFT, FP32 and progressive screening (pscreen) -- are NOT enabled by any preset (they
+stay available as explicit input keys, e.g. for GPU XC or regimes not covered here).
+
+Precedence (low -> high): control-struct default  <  perf preset  <  explicit input key.
+An input key set to ``auto`` (its default) defers to the preset; any other value overrides
+it. ``perf`` unset (-1) leaves every key at its default -> identical to legacy behaviour.
+"""
+
+UNSET = -1
+
+# Per-knob preset table.  Columns: section, input-key, [value@0, @1, @2, @3].
+# Every key here is a sentinel-'auto' string input key: 'auto'/'' means "defer to the
+# preset"; any other value is an explicit override (parsed by the setter in oqpdata.py).
+KNOBS = [
+    ("scf",  "xc_c2f",        ["off", "off", "on",  "on" ]),
+    ("scf",  "xc_phi_cache",  ["off", "off", "off", "off"]),
+    ("scf",  "xc_incdft",     ["off", "off", "off", "off"]),
+    ("scf",  "grad_cutoff",   ["1.0d-10", "1.0d-10", "1.0d-8", "1.0d-7"]),
+    ("tdhf", "resp_cutoff",   ["5e-11", "1e-8", "1e-8", "1e-6"]),
+    ("tdhf", "fp32",          ["off", "off", "off", "off"]),
+    ("tdhf", "zv_warmstart",  ["off", "on",  "on",  "on" ]),
+]
+
+# Input keys this module introduces (added to OQP_CONFIG_SCHEMA as sentinel 'auto' strings).
+NEW_INPUT_KEYS = {
+    "scf":  ["xc_c2f", "xc_phi_cache", "xc_incdft", "grad_cutoff"],
+    "tdhf": ["resp_cutoff", "fp32", "zv_warmstart"],
+}
+
+
+def _truthy(v):
+    return str(v).strip().lower() in ("1", "y", "yes", "t", "true", "on")
+
+
+def _is_auto(v):
+    return v is None or str(v).strip().lower() in ("", "auto")
+
+
+def resolve(config, perf):
+    """Fill the perf input keys in ``config`` from the preset (in place).
+
+    A key is filled from the preset only when its value is the sentinel ``auto`` -- so an
+    explicit value (from the input file or a caller-supplied dict, even a fully
+    default-expanded one) always wins. Returns a list of (label, shown_value, source) with
+    source in {"input", "perf"}. ``perf`` unset -> no change, empty report.
+    """
+    if perf is None or perf == UNSET:
+        return []
+    if perf not in (0, 1, 2, 3):
+        raise ValueError("perf=%r is invalid; choose 0, 1, 2 or 3" % perf)
+    report = []
+    for sec, key, vals in KNOBS:
+        cfg_val = config.get(sec, {}).get(key)
+        if not _is_auto(cfg_val):                         # explicit value wins
+            report.append(("%s.%s" % (sec, key), cfg_val, "input"))
+            continue
+        config.setdefault(sec, {})[key] = vals[perf]      # else apply the preset
+        report.append(("%s.%s" % (sec, key), vals[perf], "perf"))
+    return report
+
+
+def validate(config, scf_conv=None, zv_conv=None):
+    """Warnings for risky resolved settings (reads the post-resolution config)."""
+    warns = []
+    scf = config.get("scf", {})
+    tdhf = config.get("tdhf", {})
+    if _truthy(scf.get("xc_incdft")):
+        warns.append("xc_incdft is experimental and usually *slows* SCF convergence.")
+    if _truthy(scf.get("pscreen")):
+        cap = scf.get("pscreen_cap")
+        try:
+            if cap is not None and float(str(cap).replace("d", "e")) > 1e-8:
+                warns.append("pscreen_cap looser than 1e-8 risks a spurious SCF state.")
+        except ValueError:
+            pass
+    if _truthy(tdhf.get("fp32")):
+        warns.append("fp32 is non-reproducible, can flip near-degenerate states, and was "
+                     "net-slower than fp64 on CPU in the perf benchmark.")
+        for label, c in (("scf.conv", scf_conv), ("tdhf.zvconv", zv_conv)):
+            if c is not None and c < 1e-9:
+                warns.append("fp32 with a tight %s (%g) may stall before convergence." % (label, c))
+    return warns
+
+
+def format_report(perf, report, warns):
+    if not report:
+        return ""
+    head = "perf = %s" % ("unset" if perf in (None, UNSET) else perf)
+    lines = ["", "   Performance settings (%s)" % head]
+    w = max(len(lbl) for lbl, _, _ in report)
+    src = {"input": "(input)", "perf": "(preset)"}
+    for lbl, val, s in report:
+        lines.append("     %-*s = %-9s %s" % (w, lbl, val, src.get(s, "")))
+    for warn in warns:
+        lines.append("     WARNING: " + warn)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def apply(config, perf, scf_conv=None, zv_conv=None):
+    """Resolve into ``config`` (in place) + validate; return (report, warns)."""
+    report = resolve(config, perf)
+    warns = validate(config, scf_conv=scf_conv, zv_conv=zv_conv) if report else []
+    return report, warns

--- a/source/dftlib/dft.F90
+++ b/source/dftlib/dft.F90
@@ -540,17 +540,11 @@ contains
       rad = ps_grid_rad; ang = ps_grid_ang
       requested = .true.
     else
-      ! --- coarse-to-fine, ON by default (opt out with OQP_XC_C2F=0) ---
-      c2f_off = .false.
-      call get_environment_variable("OQP_XC_C2F", ev, el)
-      if (el > 0) c2f_off = (ev(1:1)=='0' .or. ev(1:1)=='n' .or. ev(1:1)=='N' &
-                             .or. ev(1:1)=='f' .or. ev(1:1)=='F')
+      ! --- coarse-to-fine, controlled by [scf] xc_c2f (infos%control%xc_c2f,
+      !     1=on default; opt out with xc_c2f=off). Coarse grid fixed at 50x110. ---
+      c2f_off = (infos%control%xc_c2f == 0)
       if (.not. c2f_off .and. c2f_grid_eligible(infos)) then
         rad = 50; ang = 110
-        call get_environment_variable("OQP_XC_C2F_RAD", ev, el)
-        if (el > 0) read(ev,*,iostat=el) rad
-        call get_environment_variable("OQP_XC_C2F_ANG", ev, el)
-        if (el > 0) read(ev,*,iostat=el) ang
         requested = (rad > 0 .and. ang > 0)
       end if
     end if

--- a/source/dftlib/dft_gridint.F90
+++ b/source/dftlib/dft_gridint.F90
@@ -10,7 +10,7 @@ module mod_dft_gridint
   use oqp_linalg
   use blas_wrap, only: oqp_ddot => oqp_ddot_i64
   use parallel, only: par_env_t
-  use mod_dft_gridint_phi_cache, only: g_phi_cache, phi_cache_geom_hash, phi_cache_env_enabled
+  use mod_dft_gridint_phi_cache, only: g_phi_cache, phi_cache_geom_hash
   implicit none
 
 !###############################################################################
@@ -2406,7 +2406,7 @@ contains
     nAODer_c = xc_opts%nDer
     if (xc_opts%isGGA .or. xc_opts%needTau) nAODer_c = nAODer_c + 1
     numAOVecs_c = nAOVecs_tbl(nAODer_c)
-    cache_on = xc_opts%use_phi_cache .and. phi_cache_env_enabled()
+    cache_on = xc_opts%use_phi_cache
     ghash = 0_i8b
     if (cache_on) ghash = phi_cache_geom_hash(basis%atoms%xyz)
     call g_phi_cache%begin_run(cache_on, xc_opts%molGrid%nSlices, &

--- a/source/dftlib/dft_gridint_energy.F90
+++ b/source/dftlib/dft_gridint_energy.F90
@@ -469,9 +469,9 @@ contains
     xc_opts%ao_sparsity_ratio = 0.0_fp
 
     ! Opt 1: the SCF Fock build reaches the grid through this density-driven path
-    ! (calc_fock passes the packed density as dens_in). Opt in to the
-    ! cross-iteration Phi cache (further gated by env OQP_XC_PHI_CACHE).
-    xc_opts%use_phi_cache = .true.
+    ! (calc_fock passes the packed density as dens_in). Enable the cross-iteration
+    ! Phi cache from [scf] xc_phi_cache (infos%control%xc_phi_cache).
+    xc_opts%use_phi_cache = (infos%control%xc_phi_cache /= 0)
 
     call dat%pe%init(infos%mpiinfo%comm, infos%mpiinfo%usempi)
     call run_xc(xc_opts, dat, basis)

--- a/source/integrals/grd2.F90
+++ b/source/integrals/grd2.F90
@@ -173,10 +173,8 @@ contains
 
     real(kind=dp) :: rtol, dtol
 
-    integer :: itmp
     character(len=64) :: sval
     integer :: ln
-    real(kind=dp) :: cutval
     logical :: lstats
 
     type(grd2_int_data_t) :: gdat
@@ -209,12 +207,10 @@ contains
 !                       it to larger sizes).  Looser still is unsafe: derivative
 !                       integrals amplify the dropped contributions.  See
 !                       GRAD_SCREENING_NOTES.md for the per-size/method table.
-    cutoff = 1.0d-10
-    call get_environment_variable("OQP_GRAD_CUTOFF", sval, ln)
-    if (ln > 0) then
-      read(sval,*,iostat=itmp) cutval
-      if (itmp == 0 .and. cutval > 0.0_dp) cutoff = cutval
-    end if
+    ! Schwarz block cutoff for the 2e-derivative build, from [scf] grad_cutoff
+    ! (infos%control%grad_cutoff; default 1.0d-10 = historic exact baseline).
+    cutoff = infos%control%grad_cutoff
+    if (cutoff <= 0.0_dp) cutoff = 1.0d-10
     cutoff2 = cutoff/2.0d+00
 
     zbig = maxval(basis%ex)

--- a/source/modules/tdhf_mrsf_energy.F90
+++ b/source/modules/tdhf_mrsf_energy.F90
@@ -84,7 +84,7 @@ contains
     use tdhf_mrsf_lib, only: &
       mrinivec, mrsfcbc, umrsfcbc, mrsfmntoia, umrsfmntoia, mrsfesum, &
       mrsfqroesum, get_mrsf_transitions, &
-      get_mrsf_transition_density, get_jacobi, umrsfssqu
+      get_mrsf_transition_density, get_jacobi, umrsfssqu, mrsf_set_fp32
     use mathlib, only: orthogonal_transform, orthogonal_transform_sym, &
       unpack_matrix
     use oqp_linalg
@@ -132,7 +132,6 @@ contains
     integer :: ierr
     logical :: converged
     real(kind=dp) :: rc_save, rc_new
-    character(len=64) :: rc_env
     real(kind=dp) :: mxerr, cnvtol, scale_exch
     real(kind=dp) :: spc_scale_coco, spc_scale_ovov, spc_scale_coov
     integer :: maxvec, mrst, nstates, target_state
@@ -404,11 +403,16 @@ contains
     ! the SCF cutoff (5e-11) to recover the previous exact-tight behavior.
     ! max(SCF cutoff, requested) never goes tighter than the SCF integrals.
     ! Restored after the response so SCF / later steps are unaffected.
+    ! Response 2e cutoff from [tdhf] resp_cutoff (infos%control%mrsf_resp_cutoff,
+    ! default 1e-8). max(SCF cutoff, requested) never goes tighter than SCF.
     rc_save = infos%control%int2e_cutoff
-    rc_new = 1.0e-8_dp
-    call get_environment_variable('OQP_MRSF_RESP_CUTOFF', rc_env)
-    if (len_trim(rc_env) > 0) read(rc_env,*) rc_new
+    rc_new = infos%control%mrsf_resp_cutoff
+    if (rc_new <= 0.0_dp) rc_new = 1.0e-8_dp
     infos%control%int2e_cutoff = max(rc_save, rc_new)
+
+    ! FP32 response digestion from [tdhf] fp32 (infos%control%mrsf_fp32). Also
+    ! reaches the z-vector gradient, which reuses the same process-global flag.
+    call mrsf_set_fp32(int(infos%control%mrsf_fp32))
 
     ! Initialize ERI (Electron Repulsion Integrals) calculations
     call int2_driver%init(basis, infos)

--- a/source/modules/tdhf_mrsf_z_vector.F90
+++ b/source/modules/tdhf_mrsf_z_vector.F90
@@ -145,18 +145,20 @@ contains
     call flush(log_unit)
   end subroutine zv_timers_report
 
-  !> Read the z-vector opt-in environment variables once.
-  subroutine zv_read_config()
+  !> Read the z-vector config once: warm-start from the control struct ([tdhf]
+  !> zv_warmstart); the remaining opt-in levers from their env vars (advanced).
+  subroutine zv_read_config(infos)
+    use types, only: information
+    type(information), intent(in) :: infos
     character(len=32) :: e_
     integer :: ios
+    ! Warm-start is control-backed ([tdhf] zv_warmstart): refresh it on EVERY call so a
+    ! per-calculation override applies in long-lived (e.g. Python) workflows. It is
+    ! result-neutral (a CG initial guess only; the solve still converges to the same
+    ! tolerance), so it cannot change a converged single-point gradient.
+    zv_warm_on = (infos%control%mrsf_zv_warmstart /= 0)
+    ! The remaining levers are env-only and read once.
     if (zv_cfg_init) return
-    ! Warm-start DEFAULT ON: it is result-neutral (a CG initial guess only; the
-    ! solve still converges to the same tolerance), so it cannot change a
-    ! converged single-point gradient. Disable with OQP_MRSF_ZV_WARMSTART=0.
-    call get_environment_variable('OQP_MRSF_ZV_WARMSTART', e_)
-    zv_warm_on = .true.
-    if (len_trim(e_) > 0) zv_warm_on = .not. (e_(1:1)=='0' .or. e_(1:1)=='n' .or. &
-        e_(1:1)=='N' .or. e_(1:1)=='f' .or. e_(1:1)=='F')
     call get_environment_variable('OQP_MRSF_ZV_CONV', e_)
     if (len_trim(e_) > 0) then
       read(e_,*,iostat=ios) zv_conv_user
@@ -1174,8 +1176,8 @@ contains
 
   ! Optional per-iteration profiler (env OQP_MRSF_ZV_TIMERS; default off)
     call zv_timers_begin()
-  ! Optional performance opt-ins (env-gated; default off)
-    call zv_read_config()
+  ! Warm-start from [tdhf] zv_warmstart; remaining levers env-gated (advanced)
+    call zv_read_config(infos)
 
   ! Files open
   ! 3. LOG: Write: Main output file

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -64,7 +64,7 @@ contains
     use scf_converger, only: scf_conv_result, scf_conv, &
                              conv_cdiis, conv_ediis, conv_soscf, &
                              conv_trah
-    use mod_dft_incdft, only: incdft_env_enabled, incdft_should_reuse, incdft_reset
+    use mod_dft_incdft, only: incdft_should_reuse, incdft_reset
     use scf_addons, only: pfon_t, apply_mom, level_shift_fock, calc_fock, &
                           scf_energy_t, scf_rhf, scf_uhf, scf_rohf, get_scf_name, &
                           scf_diis, scf_bfgs, scf_trah, get_solver_name
@@ -351,7 +351,8 @@ contains
     end if
 
     ! Opt 2 (IncDFT): start each SCF with a clean XC reference store.
-    use_incdft = is_dft .and. incdft_env_enabled()
+    ! Controlled by [scf] xc_incdft (infos%control%xc_incdft).
+    use_incdft = is_dft .and. (infos%control%xc_incdft /= 0)
     if (use_incdft) call incdft_reset()
 
     !==============================================================================
@@ -579,12 +580,10 @@ contains
     ! coarse grid was provided.
     ps_grid_on = present(coarseGrid)
     ! When the grid ramp runs without integral screening, it still needs a pin
-    ! threshold: use the coarse-to-fine switch threshold (OQP_XC_C2F_SWITCH,
-    ! default 1e-2). With integral screening on, ps_tight (above) governs both.
+    ! threshold: the coarse-to-fine switch threshold (fixed 1e-2, floored at
+    ! 10*conv). With integral screening on, ps_tight (above) governs both.
     if (ps_grid_on .and. .not. ps_on) then
       ps_tight = 1.0e-2_dp
-      call get_environment_variable("OQP_XC_C2F_SWITCH", ps_env, ps_ln)
-      if (ps_ln > 0) read(ps_env,*,iostat=ps_ln) ps_tight
       ps_tight = max(ps_tight, 10.0_dp * infos%control%conv)
     end if
     ps_cur_grid => molGrid

--- a/source/scf_addons.F90
+++ b/source/scf_addons.F90
@@ -1640,7 +1640,7 @@ contains
     use mod_dft_molgrid, only : dft_grid_t
     use mathlib,          only : traceprod_sym_packed
     use solvent_pcm,      only : add_pcm_reaction_field
-    use mod_dft_incdft,  only : g_xc_ref, incdft_store, incdft_env_enabled
+    use mod_dft_incdft,  only : g_xc_ref, incdft_store
     implicit none
 
     type(basis_set),   intent(in)    :: basis
@@ -1766,7 +1766,7 @@ contains
         call calc_dft_xc(infos, basis, molgrid, pfxc, E%eexc, E%totele, E%totkin, mo_a, mo_b)
       end if
       ! Refresh the IncDFT reference from this full build (only when IncDFT is on).
-      if (incdft_env_enabled()) call incdft_store(pfxc, E%eexc, E%totele, E%totkin)
+      if (infos%control%xc_incdft /= 0) call incdft_store(pfxc, E%eexc, E%totele, E%totkin)
     end if
 
     if (do_t) then

--- a/source/tdhf_mrsf_lib.F90
+++ b/source/tdhf_mrsf_lib.F90
@@ -42,15 +42,15 @@ contains
   !> cc-pVDZ; excitation energies perturbed at the ~few-ueV level, Davidson
   !> convergence unchanged). Default off = exact FP64.
   subroutine ensure_mrsf_fp32()
-    character(len=8) :: e_
-    if (g_mrsf_fp32 < 0) then
-      call get_environment_variable('OQP_MRSF_FP32', e_)
-      if (len_trim(e_) > 0) then
-        read(e_,*) g_mrsf_fp32
-      else
-        g_mrsf_fp32 = 0
-      end if
-    end if
+    ! g_mrsf_fp32 is set from [tdhf] fp32 via mrsf_set_fp32() before the response;
+    ! default to off (0) if it was never set.
+    if (g_mrsf_fp32 < 0) g_mrsf_fp32 = 0
+  end subroutine
+
+  !> Set the FP32 response-digestion flag from the control struct ([tdhf] fp32).
+  subroutine mrsf_set_fp32(v)
+    integer, intent(in) :: v
+    g_mrsf_fp32 = v
   end subroutine
 
 !###############################################################################

--- a/source/types.F90
+++ b/source/types.F90
@@ -175,6 +175,16 @@ module types
     ! PCM implicit solvent (energy-only, ddX backend; off by default)
     logical(c_bool) :: pcm_enabled = .false.     !< Enable PCM reaction-field contribution to SCF
     real(c_double)  :: pcm_epsilon = 78.3553_dp  !< Solvent dielectric constant (water default)
+    ! Performance knobs -- set from input keys via the control struct (see
+    ! pyoqp utils/perf_levels.py and the `perf` preset). Defaults reproduce the
+    ! historic behaviour. Kept in sync with struct control_parameters in include/oqp.h.
+    integer(c_int64_t) :: xc_c2f            = 1         !< coarse-to-fine XC grid (1=on, default)
+    integer(c_int64_t) :: xc_phi_cache      = 0         !< cache collocation Phi across SCF iters
+    integer(c_int64_t) :: xc_incdft         = 0         !< incremental DFT (experimental)
+    real(c_double)     :: grad_cutoff       = 1.0d-10   !< 2e-derivative Schwarz cutoff (gradient)
+    real(c_double)     :: mrsf_resp_cutoff  = 1.0d-8    !< MRSF response 2e cutoff
+    integer(c_int64_t) :: mrsf_fp32         = 0         !< FP32 MRSF response digestion
+    integer(c_int64_t) :: mrsf_zv_warmstart = 1         !< MRSF z-vector warm-start (1=on, default)
   end type control_parameters
 
   type, public, bind(c) :: tddft_parameters

--- a/tests/test_perf_levels.py
+++ b/tests/test_perf_levels.py
@@ -1,0 +1,98 @@
+"""Unit tests for the perf-preset resolver (utils/perf_levels). Pure Python; no liboqp.
+
+The resolver fills the performance input keys (sentinel 'auto') in the parsed config from
+the `perf` preset; an explicit value always wins. Env-var free.
+"""
+import os, importlib.util
+_p = os.path.join(os.path.dirname(__file__), "..", "pyoqp", "oqp", "utils", "perf_levels.py")
+_spec = importlib.util.spec_from_file_location("perf_levels", _p)
+P = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(P)
+
+
+def _auto_cfg():
+    """A fully default-expanded config: every perf key present at the 'auto' sentinel
+    (mirrors the OQPConfigParser-validated dict the scripting API passes)."""
+    return {
+        "input": {"perf": 1},
+        "scf": {"xc_c2f": "auto", "xc_phi_cache": "auto", "xc_incdft": "auto",
+                "grad_cutoff": "auto"},
+        "tdhf": {"resp_cutoff": "auto", "fp32": "auto", "zv_warmstart": "auto"},
+    }
+
+
+def test_unset_changes_nothing():
+    cfg = _auto_cfg()
+    report = P.resolve(cfg, P.UNSET)
+    assert report == []
+    assert cfg["scf"]["xc_c2f"] == "auto" and cfg["tdhf"]["resp_cutoff"] == "auto"
+
+
+def test_levels_fill_config_even_from_expanded_dict():
+    # Regression for the codex review: a fully default-expanded config (all keys present
+    # at 'auto') must still receive the preset -- 'auto' must NOT count as an override.
+    want = {
+        0: dict(xc_c2f="off", grad_cutoff="1.0d-10", resp_cutoff="5e-11", zv_warmstart="off", fp32="off"),
+        1: dict(xc_c2f="off", grad_cutoff="1.0d-10", resp_cutoff="1e-8",  zv_warmstart="on",  fp32="off"),
+        2: dict(xc_c2f="on",  grad_cutoff="1.0d-8",  resp_cutoff="1e-8",  zv_warmstart="on",  fp32="off"),
+        3: dict(xc_c2f="on",  grad_cutoff="1.0d-7",  resp_cutoff="1e-6",  zv_warmstart="on",  fp32="off"),
+    }
+    for lvl, w in want.items():
+        cfg = _auto_cfg()
+        report = P.resolve(cfg, lvl)
+        assert cfg["scf"]["xc_c2f"] == w["xc_c2f"], (lvl, cfg["scf"]["xc_c2f"])
+        assert cfg["scf"]["grad_cutoff"] == w["grad_cutoff"]
+        assert cfg["tdhf"]["resp_cutoff"] == w["resp_cutoff"]
+        assert cfg["tdhf"]["zv_warmstart"] == w["zv_warmstart"]
+        assert cfg["tdhf"]["fp32"] == w["fp32"]
+        assert all(s == "perf" for _, _, s in report)     # every key came from the preset
+
+
+def test_explicit_value_overrides_preset():
+    cfg = _auto_cfg()
+    cfg["scf"]["xc_c2f"] = "off"            # explicit, at perf=2 the preset wants 'on'
+    cfg["tdhf"]["resp_cutoff"] = "5e-11"    # explicit
+    report = P.resolve(cfg, 2)
+    assert cfg["scf"]["xc_c2f"] == "off"
+    assert cfg["tdhf"]["resp_cutoff"] == "5e-11"
+    assert ("scf.xc_c2f", "off", "input") in report
+    assert ("tdhf.resp_cutoff", "5e-11", "input") in report
+    # a still-auto key is filled by the preset
+    assert cfg["scf"]["grad_cutoff"] == "1.0d-8"
+
+
+def test_invalid_perf_raises():
+    try:
+        P.resolve(_auto_cfg(), 7)
+    except ValueError:
+        return
+    assert False, "perf=7 should raise"
+
+
+def test_validator_flags_fp32_and_incdft():
+    cfg = {"scf": {"xc_incdft": "on"}, "tdhf": {"fp32": "on"}}
+    w = P.validate(cfg, scf_conv=1e-6, zv_conv=1e-10)
+    joined = " ".join(w)
+    assert "fp32" in joined and "incdft" in joined
+    assert any("stall" in x for x in w)                  # zvconv 1e-10 < 1e-9
+
+
+def test_validator_pscreen_cap_loose():
+    cfg = {"scf": {"pscreen": True, "pscreen_cap": "1e-6"}}
+    w = P.validate(cfg)
+    assert any("pscreen_cap" in x for x in w)
+
+
+def test_report_format():
+    cfg = _auto_cfg(); cfg["scf"]["grad_cutoff"] = "1.0d-9"
+    report = P.resolve(cfg, 1)
+    block = P.format_report(1, report, [])
+    assert "perf = 1" in block and "grad_cutoff" in block
+    assert "(input)" in block and "(preset)" in block
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn(); print("ok", fn.__name__)
+    print("ALL %d PASSED" % len(fns))


### PR DESCRIPTION
## Summary

Adds a user-facing performance preset **`[input] perf = 0|1|2|3` (default `1`)** that bundles
OpenQP's performance knobs into one accuracy↔speed dial, plus the per-knob **input keys** behind
it — all routed through the shared `control` struct, **with no environment variables**. Also fixes
a build break on `main` under gfortran ≥ 12 (separate first commit, cherry-pickable).

Outcome of an audit + CPU benchmark of the recent perf machinery (C2F XC grid, Φ-cache, progressive
screening, gradient/response cutoffs, MRSF FP32, z-vector warm-start).

## Commits
1. **`fix(build)`: tagarray v1.0.0 under gfortran ≥ 12.** A 144-char `iso_c_binding` USE line in
   `container.f90` is truncated by tagarray's own `-std=f2018` → `pip install .` of `main` fails on
   GCC ≥ 12. Fixed with an idempotent `PATCH_COMMAND` (mirror upstream in `Open-Quantum-Platform/tagarray`).
2. **`feat(perf)`: the `perf` preset + input keys (control-struct, no env vars).**

## Design
Each knob is a `control_parameters` field (`source/types.F90` + the C mirror in `include/oqp.h`),
set from Python via the existing setter dispatch, and read directly from `infos%control` in Fortran —
the previous `get_environment_variable("OQP_*")` reads for these knobs are removed.

New input keys (sentinel default `auto` = defer to the preset; any explicit value overrides it):

| section | keys |
|---|---|
| `[scf]` | `xc_c2f`, `xc_phi_cache`, `xc_incdft`, `grad_cutoff` |
| `[tdhf]` | `resp_cutoff`, `fp32`, `zv_warmstart` |

Resolved in `mol.load_config`, filling only keys still at `auto`. Precedence:
**control default < `perf` preset < explicit input key**. Set `perf=-1` to disable the preset.

## The levels (CPU-calibrated: MKL + Apple Accelerate)

| `perf` | meaning | speed | accuracy |
|---|---|---|---|
| 0 | strict reference / reproducible | baseline | bit-reference (fixed thread count) |
| **1 (default)** | recommended production — exact wins only (resp 1e-8, z-vector warm-start, + Fock digest) | ~6% faster | energies/VEEs **exact** |
| 2 | faster, tiny degradation — + C2F grid + grad cutoff 1e-8 | — | gradients ≤ 5e-7 a.u. |
| 3 | aggressive, degradation allowed — grad 1e-7, response 1e-6 | **~17% faster** (MRSF energy) | ~6 µeV on VEEs |

Φ-cache, IncDFT, FP32 and progressive screening were **net-negative/experimental on CPU** (FP32 ~2×
slower under MKL) and are enabled by **no preset** — kept as explicit input keys for other regimes (GPU XC).

## Benchmark highlights (chc4 Xeon 8368 / MKL; cross-checked on M3 Ultra / Accelerate)
- All settings reproduce reference energies/VEEs to printed precision (C20H42 = -786.7633652204).
- "Enable everything" is net-slower for single points (C2F × pscreen adds 3–10 SCF iterations);
  Φ-cache −8%, FP32 ~2× slower — hence excluded from presets.
- `perf=3` thymine MRSF energy: **37.5 s → 31.1 s (1.21×)** for ~6 µeV.

## Review feedback addressed
- **`auto` is no longer treated as an override** — the preset is applied even when a fully
  default-expanded config dict is passed (value-based resolution; regression test added).
- **z-vector warm-start is refreshed every call**, so a per-calculation override applies in
  long-lived (Python) workflows.

## Tests / verification
- `tests/test_perf_levels.py` — 7 cases (level mapping incl. expanded-dict, override precedence,
  validation). ALL PASS.
- Clean-checkout build on chc4 (no-libint, MKL ILP64, OpenMP): builds, imports, `perf=0..3` exact/
  controlled, explicit keys override the preset, **no `OQP_*` env var governs the path**, `perf=1`
  is the default. CI: gcc-build, sdist, and Linux wheel-smoke all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
