### PR TITLE
Native-BLAS platform policy: uniform ILP64 on all platforms, deterministic selection, integer-ABI fixes

### DIFF
--- a/.github/scripts/wheel_smoke_test.py
+++ b/.github/scripts/wheel_smoke_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Numerical smoke test run against every built wheel (CIBW_TEST_COMMAND).
+
+Goes beyond the old import/file-exists check: runs a real RHF/STO-3G
+calculation and asserts the energy AND the raw basis-metadata integer ABI.
+These are exactly the two failure classes that previously shipped in wheels
+while ``import oqp`` still succeeded:
+  * a wrong/slow BLAS selection (silent NetLib fallback) -- caught here by
+    requiring the calculation to complete with the reference energy;
+  * the LP64 integer-ABI misread (oqp_get_basis exporting build-width
+    integers read as int64 by Python), which corrupted basis metadata
+    (centers [0,1] -> [8589934592, -1]) and crashed the molden writer.
+
+Usage: wheel_smoke_test.py <project-dir>
+"""
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+EREF = -1.1167593075  # RHF/STO-3G h2 at 0.74 A (examples/QUANTUM/h2.inp)
+
+project = sys.argv[1]
+src = os.path.join(project, "examples", "QUANTUM", "h2.inp")
+tmp = tempfile.mkdtemp(prefix="oqp_wheel_test_")
+inp = os.path.join(tmp, "h2.inp")
+shutil.copy(src, inp)
+
+# 1. Full end-to-end run through the console entry point.
+r = subprocess.run(["openqp", "h2.inp"], cwd=tmp, capture_output=True,
+                   text=True, timeout=900)
+log_path = os.path.join(tmp, "h2.log")
+log = open(log_path).read() if os.path.exists(log_path) else ""
+assert r.returncode == 0, (
+    f"openqp h2.inp failed rc={r.returncode}\n--- stdout ---\n{r.stdout[-2000:]}"
+    f"\n--- stderr ---\n{r.stderr[-2000:]}\n--- log tail ---\n{log[-2000:]}")
+
+m = re.search(r"Final RHF energy is\s+(-?\d+\.\d+)", log)
+assert m, f"no 'Final RHF energy is' line in h2.log\n{log[-2000:]}"
+energy = float(m.group(1))
+assert abs(energy - EREF) < 1e-6, f"energy {energy} != reference {EREF}"
+
+# 2. The molden writer must have produced output (end-to-end guard for the
+#    basis-export path; scf.save_molden defaults to True).
+assert any(f.endswith(".molden") for f in os.listdir(tmp)), (
+    f"no .molden file written; dir: {os.listdir(tmp)}")
+
+# 3. Raw basis-metadata ABI check: the integer arrays crossing the
+#    Fortran->C->Python boundary must be exact small integers.
+os.chdir(tmp)
+from oqp.pyoqp import Runner  # noqa: E402  (import after wheel install)
+run = Runner(project="abi_probe", input_file=inp,
+             log=os.path.join(tmp, "probe.log"), silent=1)
+run.run(test_mod=True)
+basis = run.mol.data.get_basis()
+got = {k: list(map(int, basis[k])) for k in ("centers", "ncontr", "angs")}
+expect = {"centers": [0, 1], "ncontr": [3, 3], "angs": [0, 0]}
+assert got == expect, f"basis metadata ABI corrupt: {got} != {expect}"
+
+print(f"wheel smoke test OK: energy {energy} | basis metadata ABI clean")

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,12 @@ jobs:
             # (LINALG_LIB_INT64=ON), so LINALG_LIB=OpenBLAS resolves this system
             # library and OpenQP (and ddX) link it directly -- no reference LAPACK
             # is compiled from source.
+            #
+            # Test-what-ships: OpenBLAS ILP64 is exactly the BLAS the Linux PyPI
+            # wheels bundle (build_wheels.yml), so these legs validate the shipped
+            # configuration. The Linux x86_64 SOURCE-build mandate (LINALG_LIB=auto
+            # -> Intel MKL ILP64) is not exercised here -- installing oneAPI on
+            # runners is impractical; it is validated manually on MKL machines.
             sudo apt-get install libopenblas64-dev
          - name: Install MPI (ubuntu)
            if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -163,6 +169,91 @@ jobs:
               echo "::error::ddX-enabled build skipped a DDPCM example (OQP_ENABLE_DDX sentinel); ddX must be built and the PCM examples must run"
               exit 1
             fi
+
+   # macOS legs: build with PURE DEFAULTS (no LINALG flags) so CI exercises the
+   # native-BLAS platform policy exactly as users hit it: LINALG_LIB=auto must
+   # resolve to Apple Accelerate and LINALG_LIB_INT64 defaults ON -- the
+   # uniform 8-byte (ILP64) integer model on all platforms, on macOS via
+   # Accelerate's $NEWLAPACK$ILP64 interface with the post-build alias guard
+   # (cmake/check_accelerate_aliases.cmake) failing the build on any LP64
+   # symbol leak. The classic LP64 interface remains an explicit macOS-only
+   # opt-out (-DLINALG_LIB_INT64=OFF), validated manually, not in CI.
+   macos-build:
+      name: macOS Accelerate ILP64 (${{ matrix.os }})
+      runs-on: ${{ matrix.os }}
+      strategy:
+         fail-fast: false
+         matrix:
+            # macos-15 = arm64 (Apple Silicon), macos-15-intel = x86_64. Both
+            # matter: past integer-ABI bugs manifested differently per arch
+            # (Apple Silicon ran, Intel crashed on the same build).
+            os: [macos-15, macos-15-intel]
+      steps:
+         - name: Checkout code
+           uses: actions/checkout@v4
+         - name: Setup Python
+           uses: actions/setup-python@v5
+           with:
+            python-version: '3.12'
+         - name: Install GCC toolchain
+           run: brew install gcc@15
+         - name: Get toolchain version for the externals cache key
+           id: toolchain
+           run: echo "gcc=$(gfortran-15 -dumpfullversion)" >> "$GITHUB_OUTPUT"
+         - name: Cache bundled externals
+           uses: actions/cache@v4
+           with:
+            path: ~/Library/Caches/openqp/externals
+            key: oqp-externals-${{ matrix.os }}-gcc${{ steps.toolchain.outputs.gcc }}-accelerate-lp64-${{ hashFiles('external/CMakeLists.txt') }}
+            restore-keys: |
+               oqp-externals-${{ matrix.os }}-gcc${{ steps.toolchain.outputs.gcc }}-accelerate-lp64-
+         - name: Build & install OpenQP (pure defaults -> Accelerate ILP64)
+           env:
+            CC: gcc-15
+            CXX: g++-15
+            FC: gfortran-15
+           run: |
+            # No LINALG_LIB / LINALG_LIB_INT64: the platform policy must resolve
+            # them (macOS -> Apple Accelerate ILP64). Retry loop as in the Linux
+            # job: external deps are fetched via ExternalProject and upstream
+            # hosts intermittently 504; the externals cache persists across
+            # retries.
+            n=0
+            until pip install -v . \
+                --config-settings=cmake.define.CMAKE_C_COMPILER=gcc-15 \
+                --config-settings=cmake.define.CMAKE_CXX_COMPILER=g++-15 \
+                --config-settings=cmake.define.CMAKE_Fortran_COMPILER=gfortran-15; do
+              n=$((n + 1))
+              if [ "$n" -ge 3 ]; then
+                echo "::error::build failed after $n attempts"
+                exit 1
+              fi
+              echo "::warning::build attempt $n failed (likely a transient dependency download); retrying in 30s"
+              sleep 30
+            done
+         - name: Assert Accelerate is the linked BLAS
+           run: |
+            # The policy's whole point: a defaults build on macOS must link the
+            # system Accelerate framework -- not NetLib, not anything else.
+            # (import oqp prints a benign mpi4py warning line; take the last
+            # stdout line as the path.)
+            LIB=$(python -c "import glob, os, oqp; print(glob.glob(os.path.join(os.path.dirname(oqp.__file__), 'lib', 'liboqp*.dylib'))[0])" | tail -1)
+            echo "liboqp: $LIB"
+            otool -L "$LIB" | grep -q "Accelerate.framework" || {
+              echo "::error::liboqp does not link Accelerate.framework:"; otool -L "$LIB"; exit 1;
+            }
+         - name: Run example test suite
+           env:
+            OQP_TEST_OMP_THREADS: 1
+           run: |
+            # pipefail so a failing suite cannot be masked by tee (see the Linux
+            # job comment). This suite includes the PBE EDIIS/ADIIS examples that
+            # exercise the NLOpt handle path and the molden/basis-export examples
+            # that exercise the oqp_get_basis integer ABI -- the integer-width
+            # regressions this leg exists to catch, now under the ILP64
+            # interposition.
+            set -o pipefail
+            openqp --run_tests all | tee run_tests.out
 
 # NOTE: the two DDPCM smoke examples (examples/PCM/*.inp) run at conv=1e-6 -- see
 # the inline comment in each input. The energy-only ddPCM Fock coupling is

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,10 +47,9 @@ jobs:
          - name: Install OpenBLAS (ubuntu-latest)
            if: ${{ matrix.os == 'ubuntu-latest' || contains(matrix.os, 'ubuntu-24.04') }}
            run: |
-            # ILP64 OpenBLAS (provides openblas64.pc). The build requests ILP64
-            # (LINALG_LIB_INT64=ON), so LINALG_LIB=OpenBLAS resolves this system
-            # library and OpenQP (and ddX) link it directly -- no reference LAPACK
-            # is compiled from source.
+            # ILP64 OpenBLAS (provides openblas64.pc). OpenQP is ILP64-only, so
+            # LINALG_LIB=OpenBLAS resolves this system library and OpenQP (and
+            # ddX) link it directly -- no reference LAPACK is compiled from source.
             #
             # Test-what-ships: OpenBLAS ILP64 is exactly the BLAS the Linux PyPI
             # wheels bundle (build_wheels.yml), so these legs validate the shipped
@@ -75,9 +74,9 @@ jobs:
             # native library, header and share/ data into the installed package,
             # so "openqp" self-locates via resolve_oqp_root() with no extra wiring
             # and runtime deps (numpy/scipy/geometric/...) come from pyproject.
-            # USE_LIBINT/ENABLE_OPENMP/LINALG_LIB_INT64 are pyproject defaults; CI
-            # overrides the build type, the MPI matrix leg, ENABLE_DDX, and the
-            # BLAS/LAPACK choice.
+            # USE_LIBINT/ENABLE_OPENMP are pyproject defaults (ILP64 is
+            # unconditional); CI overrides the build type, the MPI matrix leg,
+            # ENABLE_DDX, and the BLAS/LAPACK choice.
             #
             # LINALG_LIB=OpenBLAS links the system ILP64 OpenBLAS installed above
             # (it bundles LAPACK), so neither OpenQP nor ddX compiles the reference
@@ -172,12 +171,11 @@ jobs:
 
    # macOS legs: build with PURE DEFAULTS (no LINALG flags) so CI exercises the
    # native-BLAS platform policy exactly as users hit it: LINALG_LIB=auto must
-   # resolve to Apple Accelerate and LINALG_LIB_INT64 defaults ON -- the
-   # uniform 8-byte (ILP64) integer model on all platforms, on macOS via
-   # Accelerate's $NEWLAPACK$ILP64 interface with the post-build alias guard
+   # resolve to Apple Accelerate ILP64 -- OpenQP is ILP64-only, one uniform
+   # 8-byte integer model on all platforms, on macOS via Accelerate's
+   # $NEWLAPACK$ILP64 interface with the post-build alias guard
    # (cmake/check_accelerate_aliases.cmake) failing the build on any LP64
-   # symbol leak. The classic LP64 interface remains an explicit macOS-only
-   # opt-out (-DLINALG_LIB_INT64=OFF), validated manually, not in CI.
+   # symbol leak.
    macos-build:
       name: macOS Accelerate ILP64 (${{ matrix.os }})
       runs-on: ${{ matrix.os }}
@@ -213,8 +211,8 @@ jobs:
             CXX: g++-15
             FC: gfortran-15
            run: |
-            # No LINALG_LIB / LINALG_LIB_INT64: the platform policy must resolve
-            # them (macOS -> Apple Accelerate ILP64). Retry loop as in the Linux
+            # No LINALG_LIB: the platform policy must resolve it
+            # (macOS -> Apple Accelerate ILP64). Retry loop as in the Linux
             # job: external deps are fetched via ExternalProject and upstream
             # hosts intermittently 504; the externals cache persists across
             # retries.

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -114,25 +114,36 @@ jobs:
           CIBW_SKIP: "*-musllinux_* pp*"
           CIBW_CONTAINER_ENGINE: >-
             docker; create_args: --volume ${{ github.workspace }}/.cache:/host-cache
-          # No yum install: the manylinux image already ships gcc-toolset
-          # (gfortran included), which the build uses. Installing the AlmaLinux 8
-          # base gcc-gfortran (8.5) just refreshes ~120 MB of repo metadata and
-          # an unused old compiler.
+          # Native-BLAS policy for Linux wheels: bundle an ILP64 OpenBLAS built
+          # here (plain Fortran symbols, INTERFACE64=1, DYNAMIC_ARCH for runtime
+          # CPU dispatch -- the scipy/numpy approach). MKL is the source-build
+          # mandate on Linux x86_64 but cannot ship in PyPI wheels (libmkl_core
+          # alone exceeds PyPI's per-file size limit), so wheels pin OpenBLAS
+          # ILP64 explicitly -- deterministic, and exactly what CI tests.
+          # Installed under the bind-mounted externals cache so actions/cache
+          # persists it; rebuilt only when absent. gcc-toolset (gfortran) already
+          # ships in the manylinux image.
+          CIBW_BEFORE_ALL: |
+            set -e
+            P=/host-cache/openqp/externals/openblas64
+            if [ ! -e "$P/lib/libopenblas.so" ]; then
+              git clone --depth 1 --branch v0.3.30 https://github.com/OpenMathLib/OpenBLAS.git /tmp/OpenBLAS
+              make -C /tmp/OpenBLAS -j"$(nproc)" INTERFACE64=1 USE_OPENMP=1 DYNAMIC_ARCH=1 NO_STATIC=1 libs netlib shared
+              make -C /tmp/OpenBLAS PREFIX="$P" INTERFACE64=1 USE_OPENMP=1 DYNAMIC_ARCH=1 NO_STATIC=1 install
+            fi
           CIBW_ENVIRONMENT: >-
             XDG_CACHE_HOME=/host-cache
+            PKG_CONFIG_PATH=/host-cache/openqp/externals/openblas64/lib/pkgconfig
             CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
-            -DLINALG_LIB=auto
+            -DLINALG_LIB=OpenBLAS
             -DLINALG_LIB_INT64=ON"
           CIBW_REPAIR_WHEEL_COMMAND: >-
-            LD_LIBRARY_PATH="oqp/lib:$LD_LIBRARY_PATH"
+            LD_LIBRARY_PATH="oqp/lib:/host-cache/openqp/externals/openblas64/lib:$LD_LIBRARY_PATH"
             auditwheel repair -w {dest_dir} {wheel}
+          # Real numerical test: RHF/STO-3G h2 with energy + basis-metadata ABI
+          # asserts (see the script header for the failure classes this guards).
           CIBW_TEST_COMMAND: >-
-            python -c "import oqp, pathlib;
-            root = pathlib.Path(oqp.oqp_root);
-            assert (root / 'include' / 'oqp.h').exists();
-            assert any((root / 'lib').glob('liboqp.*'));
-            assert (root / 'share' / 'basis_sets').exists();
-            print('OpenQP runtime root:', root)"
+            python {project}/.github/scripts/wheel_smoke_test.py {project}
         run: python -m cibuildwheel --output-dir dist
 
       - uses: actions/upload-artifact@v4
@@ -156,6 +167,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux wheels bundle an ILP64 OpenBLAS built in CIBW_BEFORE_ALL
+          # (plain Fortran symbols, DYNAMIC_ARCH runtime CPU dispatch; the
+          # scipy/numpy approach), installed under the bind-mounted externals
+          # cache so it persists across runs. MKL is the source-build mandate on
+          # Linux x86_64 but cannot ship in PyPI wheels (libmkl_core alone
+          # exceeds PyPI's per-file size limit), so wheels pin OpenBLAS ILP64
+          # explicitly -- deterministic, and exactly the BLAS that CI tests.
           - name: linux-x86_64
             os: ubuntu-24.04
             platform: linux
@@ -165,14 +183,22 @@ jobs:
             # built inside it persist for actions/cache (see smoke job comment).
             container_engine: >-
               docker; create_args: --volume ${{ github.workspace }}/.cache:/host-cache
-            before_all: ""   # manylinux gcc-toolset already provides gfortran
+            before_all: |
+              set -e
+              P=/host-cache/openqp/externals/openblas64
+              if [ ! -e "$P/lib/libopenblas.so" ]; then
+                git clone --depth 1 --branch v0.3.30 https://github.com/OpenMathLib/OpenBLAS.git /tmp/OpenBLAS
+                make -C /tmp/OpenBLAS -j"$(nproc)" INTERFACE64=1 USE_OPENMP=1 DYNAMIC_ARCH=1 NO_STATIC=1 libs netlib shared
+                make -C /tmp/OpenBLAS PREFIX="$P" INTERFACE64=1 USE_OPENMP=1 DYNAMIC_ARCH=1 NO_STATIC=1 install
+              fi
             environment: >-
               XDG_CACHE_HOME=/host-cache
+              PKG_CONFIG_PATH=/host-cache/openqp/externals/openblas64/lib/pkgconfig
               CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
-              -DLINALG_LIB=auto
+              -DLINALG_LIB=OpenBLAS
               -DLINALG_LIB_INT64=ON"
             repair: >-
-              LD_LIBRARY_PATH="oqp/lib:$LD_LIBRARY_PATH"
+              LD_LIBRARY_PATH="oqp/lib:/host-cache/openqp/externals/openblas64/lib:$LD_LIBRARY_PATH"
               auditwheel repair -w {dest_dir} {wheel}
 
           - name: linux-aarch64
@@ -182,16 +208,32 @@ jobs:
             cache_path: .cache/openqp/externals
             container_engine: >-
               docker; create_args: --volume ${{ github.workspace }}/.cache:/host-cache
-            before_all: ""   # manylinux gcc-toolset already provides gfortran
+            before_all: |
+              set -e
+              P=/host-cache/openqp/externals/openblas64
+              if [ ! -e "$P/lib/libopenblas.so" ]; then
+                git clone --depth 1 --branch v0.3.30 https://github.com/OpenMathLib/OpenBLAS.git /tmp/OpenBLAS
+                make -C /tmp/OpenBLAS -j"$(nproc)" INTERFACE64=1 USE_OPENMP=1 DYNAMIC_ARCH=1 NO_STATIC=1 libs netlib shared
+                make -C /tmp/OpenBLAS PREFIX="$P" INTERFACE64=1 USE_OPENMP=1 DYNAMIC_ARCH=1 NO_STATIC=1 install
+              fi
             environment: >-
               XDG_CACHE_HOME=/host-cache
+              PKG_CONFIG_PATH=/host-cache/openqp/externals/openblas64/lib/pkgconfig
               CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
-              -DLINALG_LIB=auto
+              -DLINALG_LIB=OpenBLAS
               -DLINALG_LIB_INT64=ON"
             repair: >-
-              LD_LIBRARY_PATH="oqp/lib:$LD_LIBRARY_PATH"
+              LD_LIBRARY_PATH="oqp/lib:/host-cache/openqp/externals/openblas64/lib:$LD_LIBRARY_PATH"
               auditwheel repair -w {dest_dir} {wheel}
 
+          # macOS wheels use the native-BLAS policy backend: Apple Accelerate's
+          # modern ILP64 interface ($NEWLAPACK$ILP64 symbol interposition) --
+          # the same 8-byte integer model as the Linux wheels, no LP64 special
+          # case. Accelerate is a system framework, so delocate does not bundle
+          # any BLAS and the wheels stay small; the ILP64 interface needs
+          # macOS >= 13.3, well below the 15.0 deployment target. LINALG_LIB
+          # and INT64 are what defaults resolve to on macOS; pinned explicitly
+          # so the shipped artifact never depends on resolution logic.
           - name: macos-x86_64
             os: macos-15-intel
             platform: macos
@@ -204,8 +246,8 @@ jobs:
               CMAKE_ARGS="-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15
-              -DLINALG_LIB=auto
-              -DLINALG_LIB_INT64=OFF"
+              -DLINALG_LIB=Apple
+              -DLINALG_LIB_INT64=ON"
             repair: >-
               delocate-wheel --require-archs {delocate_archs}
               -w {dest_dir} -v {wheel}
@@ -222,8 +264,8 @@ jobs:
               CMAKE_ARGS="-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15
-              -DLINALG_LIB=auto
-              -DLINALG_LIB_INT64=OFF"
+              -DLINALG_LIB=Apple
+              -DLINALG_LIB_INT64=ON"
             repair: >-
               delocate-wheel --require-archs {delocate_archs}
               -w {dest_dir} -v {wheel}
@@ -262,13 +304,12 @@ jobs:
           CIBW_BEFORE_ALL: ${{ matrix.before_all }}
           CIBW_ENVIRONMENT: ${{ matrix.environment }}
           CIBW_REPAIR_WHEEL_COMMAND: ${{ matrix.repair }}
+          # Real numerical test on every wheel: RHF/STO-3G h2 with energy and
+          # basis-metadata integer-ABI asserts (see the script header for the
+          # two failure classes this guards -- both previously shipped in wheels
+          # while a bare `import oqp` still succeeded).
           CIBW_TEST_COMMAND: >-
-            python -c "import oqp, pathlib;
-            root = pathlib.Path(oqp.oqp_root);
-            assert (root / 'include' / 'oqp.h').exists();
-            assert any((root / 'lib').glob('liboqp.*'));
-            assert (root / 'share' / 'basis_sets').exists();
-            print('OpenQP runtime root:', root)"
+            python {project}/.github/scripts/wheel_smoke_test.py {project}
         run: python -m cibuildwheel --output-dir dist
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -135,8 +135,7 @@ jobs:
             XDG_CACHE_HOME=/host-cache
             PKG_CONFIG_PATH=/host-cache/openqp/externals/openblas64/lib/pkgconfig
             CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
-            -DLINALG_LIB=OpenBLAS
-            -DLINALG_LIB_INT64=ON"
+            -DLINALG_LIB=OpenBLAS"
           CIBW_REPAIR_WHEEL_COMMAND: >-
             LD_LIBRARY_PATH="oqp/lib:/host-cache/openqp/externals/openblas64/lib:$LD_LIBRARY_PATH"
             auditwheel repair -w {dest_dir} {wheel}
@@ -195,8 +194,7 @@ jobs:
               XDG_CACHE_HOME=/host-cache
               PKG_CONFIG_PATH=/host-cache/openqp/externals/openblas64/lib/pkgconfig
               CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
-              -DLINALG_LIB=OpenBLAS
-              -DLINALG_LIB_INT64=ON"
+              -DLINALG_LIB=OpenBLAS"
             repair: >-
               LD_LIBRARY_PATH="oqp/lib:/host-cache/openqp/externals/openblas64/lib:$LD_LIBRARY_PATH"
               auditwheel repair -w {dest_dir} {wheel}
@@ -220,20 +218,19 @@ jobs:
               XDG_CACHE_HOME=/host-cache
               PKG_CONFIG_PATH=/host-cache/openqp/externals/openblas64/lib/pkgconfig
               CMAKE_ARGS="-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
-              -DLINALG_LIB=OpenBLAS
-              -DLINALG_LIB_INT64=ON"
+              -DLINALG_LIB=OpenBLAS"
             repair: >-
               LD_LIBRARY_PATH="oqp/lib:/host-cache/openqp/externals/openblas64/lib:$LD_LIBRARY_PATH"
               auditwheel repair -w {dest_dir} {wheel}
 
           # macOS wheels use the native-BLAS policy backend: Apple Accelerate's
           # modern ILP64 interface ($NEWLAPACK$ILP64 symbol interposition) --
-          # the same 8-byte integer model as the Linux wheels, no LP64 special
-          # case. Accelerate is a system framework, so delocate does not bundle
-          # any BLAS and the wheels stay small; the ILP64 interface needs
+          # OpenQP is ILP64-only, one 8-byte integer model everywhere.
+          # Accelerate is a system framework, so delocate does not bundle any
+          # BLAS and the wheels stay small; the ILP64 interface needs
           # macOS >= 13.3, well below the 15.0 deployment target. LINALG_LIB
-          # and INT64 are what defaults resolve to on macOS; pinned explicitly
-          # so the shipped artifact never depends on resolution logic.
+          # is what defaults resolve to on macOS; pinned explicitly so the
+          # shipped artifact never depends on resolution logic.
           - name: macos-x86_64
             os: macos-15-intel
             platform: macos
@@ -246,8 +243,7 @@ jobs:
               CMAKE_ARGS="-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15
-              -DLINALG_LIB=Apple
-              -DLINALG_LIB_INT64=ON"
+              -DLINALG_LIB=Apple"
             repair: >-
               delocate-wheel --require-archs {delocate_archs}
               -w {dest_dir} -v {wheel}
@@ -264,8 +260,7 @@ jobs:
               CMAKE_ARGS="-DCMAKE_C_COMPILER=gcc-15
               -DCMAKE_CXX_COMPILER=g++-15
               -DCMAKE_Fortran_COMPILER=gfortran-15
-              -DLINALG_LIB=Apple
-              -DLINALG_LIB_INT64=ON"
+              -DLINALG_LIB=Apple"
             repair: >-
               delocate-wheel --require-archs {delocate_archs}
               -w {dest_dir} -v {wheel}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ build:
       - external/fprettify
       - objdir/external
   script:
-    - cmake -G Ninja -Bobjdir -DCMAKE_BUILD_TYPE=Release -DLINALG_LIB_INT64=ON -DUSE_LIBINT=OFF -DENABLE_ASAN=OFF -DENABLE_LSAN=OFF -DENABLE_UBSAN=OFF -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=$CI_PROJECT_DIR
+    - cmake -G Ninja -Bobjdir -DCMAKE_BUILD_TYPE=Release -DUSE_LIBINT=OFF -DENABLE_ASAN=OFF -DENABLE_LSAN=OFF -DENABLE_UBSAN=OFF -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=$CI_PROJECT_DIR
     - cmake --build objdir --parallel 4 --target install
 
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,14 @@ build:
       - external/fprettify
       - objdir/external
   script:
-    - cmake -G Ninja -Bobjdir -DCMAKE_BUILD_TYPE=Release -DUSE_LIBINT=OFF -DENABLE_ASAN=OFF -DENABLE_LSAN=OFF -DENABLE_UBSAN=OFF -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=$CI_PROJECT_DIR
+    # LINALG_LIB=netlib pins the bundled reference BLAS explicitly: this job's
+    # image provides no MKL/OpenBLAS, and since the native-BLAS platform policy
+    # landed, LINALG_LIB=auto on Linux x86_64 mandates Intel MKL and FAILS the
+    # configure when it is missing (no more silent NetLib fallback). Pinning
+    # netlib reproduces this job's previous effective behavior, explicitly.
+    # Upgrade path: install an ILP64 OpenBLAS in the CI image and switch to
+    # -DLINALG_LIB=OpenBLAS (what GitHub CI tests and the Linux wheels bundle).
+    - cmake -G Ninja -Bobjdir -DCMAKE_BUILD_TYPE=Release -DLINALG_LIB=netlib -DUSE_LIBINT=OFF -DENABLE_ASAN=OFF -DENABLE_LSAN=OFF -DENABLE_UBSAN=OFF -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=$CI_PROJECT_DIR
     - cmake --build objdir --parallel 4 --target install
 
   artifacts:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,68 @@
 cmake_minimum_required(VERSION 3.25)
 
+# macOS: a bare configure picks Apple clang for C/C++ while Fortran must be
+# GNU gfortran (Apple ships no Fortran compiler). Mixing the toolchains links
+# BOTH OpenMP runtimes (clang's libomp + gfortran's libgomp) -- crashes and
+# thread oversubscription -- and the validated macOS configuration is all-GNU
+# (Homebrew gcc). When the user chose no compilers, auto-select the newest
+# COMPLETE Homebrew GCC toolchain so a plain `pip install .` gets the
+# supported compilers. The trio is picked as a matched set -- never a
+# mixed-version gcc/gfortran pair.
+#
+# Two traps encoded here:
+#  * this must run BEFORE project() (compilers are locked in there), and the
+#    APPLE variable is only set BY project() -- pre-project() code must test
+#    CMAKE_HOST_APPLE instead;
+#  * pip's build frontend on macOS INJECTS CC=clang / CXX=clang++ into the
+#    build environment. A bare unversioned default (clang/clang++/cc/c++) is
+#    toolchain noise, not a user choice, so it does not suppress the
+#    auto-selection. Real intent still always wins: any -DCMAKE_*_COMPILER,
+#    any FC, or any non-default CC/CXX (e.g. CC=gcc-14 or an absolute path).
+set(_oqp_env_cc  "$ENV{CC}")
+set(_oqp_env_cxx "$ENV{CXX}")
+if(CMAKE_HOST_APPLE AND _oqp_env_cc MATCHES "^(clang|cc)$")
+  set(_oqp_env_cc "")
+endif()
+if(CMAKE_HOST_APPLE AND _oqp_env_cxx MATCHES "^(clang\\+\\+|c\\+\\+)$")
+  set(_oqp_env_cxx "")
+endif()
+if(CMAKE_HOST_APPLE
+   AND NOT DEFINED CMAKE_C_COMPILER
+   AND NOT DEFINED CMAKE_CXX_COMPILER
+   AND NOT DEFINED CMAKE_Fortran_COMPILER
+   AND "${_oqp_env_cc}" STREQUAL ""
+   AND "${_oqp_env_cxx}" STREQUAL ""
+   AND "$ENV{FC}" STREQUAL "")
+  foreach(_oqp_gcc_ver 16 15 14 13)
+    find_program(_oqp_mac_gcc "gcc-${_oqp_gcc_ver}")
+    find_program(_oqp_mac_gxx "g++-${_oqp_gcc_ver}")
+    find_program(_oqp_mac_gfc "gfortran-${_oqp_gcc_ver}")
+    if(_oqp_mac_gcc AND _oqp_mac_gxx AND _oqp_mac_gfc)
+      set(CMAKE_C_COMPILER       "${_oqp_mac_gcc}")
+      set(CMAKE_CXX_COMPILER     "${_oqp_mac_gxx}")
+      set(CMAKE_Fortran_COMPILER "${_oqp_mac_gfc}")
+      message(STATUS "macOS: auto-selected Homebrew GCC ${_oqp_gcc_ver} toolchain "
+                     "(${_oqp_mac_gcc}); set CC/CXX/FC or -DCMAKE_*_COMPILER to override")
+      break()
+    endif()
+    unset(_oqp_mac_gcc CACHE)
+    unset(_oqp_mac_gxx CACHE)
+    unset(_oqp_mac_gfc CACHE)
+  endforeach()
+  if(NOT CMAKE_C_COMPILER)
+    message(WARNING
+      "macOS: no complete Homebrew GCC toolchain (gcc-NN + g++-NN + gfortran-NN) "
+      "was found; falling back to the system default compilers. A mixed "
+      "Clang/gfortran build with OpenMP is unsupported (two OpenMP runtimes) -- "
+      "install a full toolchain with `brew install gcc`.")
+  endif()
+  unset(_oqp_mac_gcc CACHE)
+  unset(_oqp_mac_gxx CACHE)
+  unset(_oqp_mac_gfc CACHE)
+endif()
+unset(_oqp_env_cc)
+unset(_oqp_env_cxx)
+
 project(Open-Quantum-Package
   VERSION 1.2.0
   LANGUAGES C CXX Fortran)
@@ -71,19 +134,20 @@ if(NOT LINALG_LIB IN_LIST linalg_lib_options)
     message(FATAL_ERROR "LINALG_LIB must be one of ${linalg_lib_options}")
 endif()
 
-# BLAS/LAPACK integer width: ILP64 (8-byte) by default on EVERY platform --
-# one uniform integer model across all hardware. On macOS this uses
-# Accelerate's modern $NEWLAPACK$ILP64 interface via symbol interposition
-# (requires macOS >= 13.3; see findAccelerateILP64 in cmake/oqp_functions.cmake).
-# The classic LP64 Accelerate interface remains available as a macOS-only
-# explicit opt-out: -DLINALG_LIB_INT64=OFF.
-option(LINALG_LIB_INT64  "Use 64-bit integer interface to BLAS/LAPACK" ON)
-if(NOT LINALG_LIB_INT64 AND NOT APPLE)
+# OpenQP is ILP64-only: 8-byte BLAS/LAPACK integers AND 8-byte default
+# Fortran integers on EVERY platform -- one uniform integer model across all
+# hardware. macOS uses Accelerate's modern $NEWLAPACK$ILP64 interface via
+# symbol interposition (requires macOS >= 13.3; see findAccelerateILP64 in
+# cmake/oqp_functions.cmake); Linux uses MKL / OpenBLAS ILP64.
+# LP64 (4-byte BLAS integer) support has been REMOVED: the flag below is a
+# tombstone so a stale CMake cache or an old build script cannot silently
+# produce a mixed-width build.
+if(DEFINED LINALG_LIB_INT64 AND NOT LINALG_LIB_INT64)
     message(FATAL_ERROR
-      "LP64 BLAS/LAPACK is supported only on macOS, primarily for native "
-      "Accelerate builds. Other platforms require ILP64 BLAS/LAPACK with "
-      "OQP_BLAS_INT=8."
-    )
+      "LINALG_LIB_INT64=OFF: LP64 (4-byte BLAS integer) support has been "
+      "removed -- OpenQP is ILP64-only on all platforms (macOS >= 13.3 uses "
+      "Accelerate's \$NEWLAPACK\$ILP64 interface). Remove the flag and clear "
+      "any stale CMake cache.")
 endif()
 
 # Escape hatch for the no-silent-NetLib policy in findLinearAlgebra(): when ON,
@@ -161,19 +225,15 @@ if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
       )
   endif()
 endif()
-if(LINALG_LIB_INT64)
-    set(BLA_SIZEOF_INTEGER 8)
-    set(OTR_SUFFIX "_64")
-    set(OTR_DEFS "-DUSE_ILP64")
-    if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Flang")
-        add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-fdefault-integer-8>)
-    elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "IntelLLVM")
-        add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-i8>)
-    endif()
-else()
-    set(BLA_SIZEOF_INTEGER 4)
-    set(OTR_SUFFIX "_32")
-    set(OTR_DEFS "")
+# ILP64 everywhere (unconditional): 8-byte BLAS integers and 8-byte default
+# Fortran integers. See the LINALG_LIB_INT64 tombstone above.
+set(BLA_SIZEOF_INTEGER 8)
+set(OTR_SUFFIX "_64")
+set(OTR_DEFS "-DUSE_ILP64")
+if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Flang")
+    add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-fdefault-integer-8>)
+elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "IntelLLVM")
+    add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-i8>)
 endif()
 
 # Build and link the external OpenTrustRegion (OpenTRAH) SCF solver. When OFF the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,10 @@ option(USE_LIBINT        "Use Libint two-electron code"      ON)
 set(LINALG_LIB auto CACHE STRING "Select BLAS & LAPACK Library")
 # See BLA_VENDOR in FindBLAS documentation
 set(linalg_lib_options none auto netlib
+    Apple
 #    Generic
 #    ACML ACML_MP ACML_GPU
-#    Apple NAS
+#    NAS
 #    Arm Arm_mp Arm_ilp64 Arm_ilp64_mp
 #    ATLAS
 #    CXML DXML
@@ -70,7 +71,18 @@ if(NOT LINALG_LIB IN_LIST linalg_lib_options)
     message(FATAL_ERROR "LINALG_LIB must be one of ${linalg_lib_options}")
 endif()
 
-option(LINALG_LIB_INT64  "Use 64-bit integer interface to BLAS/LAPACK" ON)
+# BLAS/LAPACK integer width. Default follows the native-BLAS platform policy:
+# macOS defaults to LP64 because the mandated backend (Apple Accelerate) only
+# provides an LP64 (4-byte integer) interface; everywhere else ILP64 (8-byte).
+# Both remain explicitly overridable, e.g. -DLINALG_LIB=OpenBLAS
+# -DLINALG_LIB_INT64=ON for an ILP64 build on macOS.
+if(APPLE)
+    set(_oqp_linalg_int64_default OFF)
+else()
+    set(_oqp_linalg_int64_default ON)
+endif()
+option(LINALG_LIB_INT64  "Use 64-bit integer interface to BLAS/LAPACK" ${_oqp_linalg_int64_default})
+unset(_oqp_linalg_int64_default)
 if(NOT LINALG_LIB_INT64 AND NOT APPLE)
     message(FATAL_ERROR
       "LP64 BLAS/LAPACK is supported only on macOS, primarily for native "
@@ -78,6 +90,11 @@ if(NOT LINALG_LIB_INT64 AND NOT APPLE)
       "OQP_BLAS_INT=8."
     )
 endif()
+
+# Escape hatch for the no-silent-NetLib policy in findLinearAlgebra(): when ON,
+# a missing mandated/requested BLAS backend falls back to the bundled NetLib
+# reference BLAS with a WARNING instead of failing the configuration.
+option(OQP_ALLOW_REFERENCE_BLAS "Allow fallback to the slow bundled NetLib reference BLAS when the requested backend is missing" OFF)
 
 option(ENABLE_OPENMP     "Enable OpenMP parallelization"     OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,18 +71,13 @@ if(NOT LINALG_LIB IN_LIST linalg_lib_options)
     message(FATAL_ERROR "LINALG_LIB must be one of ${linalg_lib_options}")
 endif()
 
-# BLAS/LAPACK integer width. Default follows the native-BLAS platform policy:
-# macOS defaults to LP64 because the mandated backend (Apple Accelerate) only
-# provides an LP64 (4-byte integer) interface; everywhere else ILP64 (8-byte).
-# Both remain explicitly overridable, e.g. -DLINALG_LIB=OpenBLAS
-# -DLINALG_LIB_INT64=ON for an ILP64 build on macOS.
-if(APPLE)
-    set(_oqp_linalg_int64_default OFF)
-else()
-    set(_oqp_linalg_int64_default ON)
-endif()
-option(LINALG_LIB_INT64  "Use 64-bit integer interface to BLAS/LAPACK" ${_oqp_linalg_int64_default})
-unset(_oqp_linalg_int64_default)
+# BLAS/LAPACK integer width: ILP64 (8-byte) by default on EVERY platform --
+# one uniform integer model across all hardware. On macOS this uses
+# Accelerate's modern $NEWLAPACK$ILP64 interface via symbol interposition
+# (requires macOS >= 13.3; see findAccelerateILP64 in cmake/oqp_functions.cmake).
+# The classic LP64 Accelerate interface remains available as a macOS-only
+# explicit opt-out: -DLINALG_LIB_INT64=OFF.
+option(LINALG_LIB_INT64  "Use 64-bit integer interface to BLAS/LAPACK" ON)
 if(NOT LINALG_LIB_INT64 AND NOT APPLE)
     message(FATAL_ERROR
       "LP64 BLAS/LAPACK is supported only on macOS, primarily for native "

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ PY
 
 # Copy and install the checked-out OpenQP source.  GitHub Actions has already
 # checked out the branch/PR being tested, so do not clone main again here.
-# USE_LIBINT=OFF, ENABLE_OPENMP=ON, and LINALG_LIB_INT64=ON are the pyproject
+# USE_LIBINT=OFF and ENABLE_OPENMP=ON are the pyproject
 # defaults; CC/CXX/FC select the gcc-14 toolchain and CMAKE_ARGS points the
 # ILP64 BLAS/LAPACK search at the OpenBLAS in the build environment (LAPACK is
 # bundled in libopenblas).  OPENQP_ROOT is intentionally not set: the

--- a/cmake/check_accelerate_aliases.cmake
+++ b/cmake/check_accelerate_aliases.cmake
@@ -1,6 +1,6 @@
 # check_accelerate_aliases.cmake
 # ---------------------------------------------------------------------------
-# POST-BUILD guard for the Accelerate-ILP64 backend (macOS, LINALG_LIB_INT64=ON).
+# POST-BUILD guard for the Accelerate-ILP64 backend (macOS; OpenQP is ILP64-only).
 #
 # Fails the build if liboqp still references any *classic* (LP64, 4-byte
 # integer) Accelerate BLAS/LAPACK symbol that was NOT interposed onto its

--- a/cmake/check_accelerate_aliases.cmake
+++ b/cmake/check_accelerate_aliases.cmake
@@ -1,0 +1,76 @@
+# check_accelerate_aliases.cmake
+# ---------------------------------------------------------------------------
+# POST-BUILD guard for the Accelerate-ILP64 backend (macOS, LINALG_LIB_INT64=ON).
+#
+# Fails the build if liboqp still references any *classic* (LP64, 4-byte
+# integer) Accelerate BLAS/LAPACK symbol that was NOT interposed onto its
+# modern 8-byte `<name>$NEWLAPACK$ILP64` variant. An un-aliased classic symbol
+# would execute a 4-byte-integer routine while OpenQP passes 8-byte integers
+# => silent numerical corruption. This is what keeps the curated symbol list
+# in oqp_functions.cmake honest: adding a new BLAS/LAPACK call without adding
+# it to OQP_ACCELERATE_ILP64_SYMS breaks the build here, loudly, with the
+# missing name -- instead of shipping corrupted numerics.
+#
+# Invoked from the Apple-ILP64 link step in findLinearAlgebra():
+#     add_custom_command(TARGET oqp POST_BUILD
+#       COMMAND ${CMAKE_COMMAND} -DLIB=$<TARGET_FILE:oqp>
+#               -P ${CMAKE_SOURCE_DIR}/cmake/check_accelerate_aliases.cmake)
+#
+# nm -m annotations this relies on (verified on macOS 15/26, Xcode ld):
+#   correctly interposed classic symbol:
+#       (indirect) external _dgesvd_ (for _dgesvd$NEWLAPACK$ILP64)
+#   its ILP64 target (expected, OK):
+#       (undefined) external _dgesvd$NEWLAPACK$ILP64 (from Accelerate)
+#   a LEAK (classic symbol still bound to legacy LP64 Accelerate):
+#       (undefined) external _dgesvd_ (from Accelerate)
+#
+# The pattern matches ANY lowercase Fortran-style symbol resolved from
+# Accelerate (not just [sdcz]-prefixed): integer-returning routines (idamax,
+# isamax, ...) and auxiliaries (lsame, xerbla, dlamch) are BLAS/LAPACK too,
+# and a leak in any of them is just as corrupting.
+# ---------------------------------------------------------------------------
+
+if(NOT DEFINED LIB OR NOT EXISTS "${LIB}")
+  message(FATAL_ERROR "check_accelerate_aliases: LIB not set or missing: '${LIB}'")
+endif()
+
+find_program(NM_EXE nm)
+if(NOT NM_EXE)
+  message(FATAL_ERROR "check_accelerate_aliases: 'nm' not found in PATH")
+endif()
+
+execute_process(COMMAND "${NM_EXE}" -m "${LIB}"
+                OUTPUT_VARIABLE _nm
+                RESULT_VARIABLE _rc)
+if(NOT _rc EQUAL 0)
+  message(FATAL_ERROR "check_accelerate_aliases: 'nm -m ${LIB}' failed (rc=${_rc})")
+endif()
+
+# The trailing "_ " (underscore then space) excludes the $NEWLAPACK$ILP64
+# targets themselves (they end in a digit) and C/CBLAS names (no trailing
+# underscore before the annotation).
+string(REGEX MATCHALL
+       "\\(undefined\\) external _[a-z][a-z0-9]+_ \\(from Accelerate\\)"
+       _leak_lines "${_nm}")
+
+set(_bad "")
+foreach(_line IN LISTS _leak_lines)
+  string(REGEX MATCH "_[a-z][a-z0-9]+_" _sym "${_line}")
+  list(APPEND _bad "${_sym}")
+endforeach()
+
+if(_bad)
+  list(REMOVE_DUPLICATES _bad)
+  list(SORT _bad)
+  string(REPLACE ";" " " _badstr "${_bad}")
+  message(FATAL_ERROR
+    "Accelerate ILP64 alias check FAILED for:\n  ${LIB}\n"
+    "These classic LP64 BLAS/LAPACK symbols are NOT routed to \$NEWLAPACK\$ILP64:\n"
+    "    ${_badstr}\n"
+    "Add each (base name, without the leading '_' / trailing '_') to "
+    "OQP_ACCELERATE_ILP64_SYMS in cmake/oqp_functions.cmake and rebuild.\n"
+    "Rationale: an un-aliased LP64 symbol executes a 4-byte-integer BLAS/LAPACK "
+    "routine while OpenQP passes 8-byte integers => silent numerical corruption.")
+endif()
+
+message(STATUS "Accelerate ILP64 alias check OK: no LP64 BLAS/LAPACK leaks in ${LIB}")

--- a/cmake/oqp_functions.cmake
+++ b/cmake/oqp_functions.cmake
@@ -345,15 +345,19 @@ macro(findLinearAlgebra)
       # macOS: Accelerate's modern ILP64 interface via symbol interposition
       # (see findAccelerateILP64 above; OpenQP is ILP64-only).
       # FATALs internally if the SDK lacks $NEWLAPACK$ILP64 (macOS < 13.3).
-      # Externals that link BLAS themselves are not wired for the alias list
-      # yet -- refuse the combination rather than let them bind the classic
-      # LP64 symbols and corrupt (they are OFF by default).
-      if(ENABLE_DDX OR ENABLE_OPENTRAH)
+      # OpenTrustRegion is a STATIC library absorbed into liboqp, so its
+      # BLAS/LAPACK references resolve at the liboqp link where the alias list
+      # applies -- the interposition covers it, and the POST_BUILD guard fails
+      # the build naming any of its symbols missing from the alias list.
+      # ddX however builds a SHARED libddx that links BLAS itself and is NOT
+      # wired for the interposition yet: refuse it (OFF by default) rather
+      # than let it bind the classic LP64 symbols and silently corrupt.
+      if(ENABLE_DDX)
         message(FATAL_ERROR
-            "ENABLE_DDX/ENABLE_OPENTRAH link BLAS/LAPACK directly and are not "
-            "yet wired for the Accelerate ILP64 alias interposition. Build them "
-            "with an ILP64 library instead (-DLINALG_LIB=OpenBLAS) or disable "
-            "the feature on macOS.")
+            "ENABLE_DDX builds a shared libddx that links BLAS/LAPACK directly "
+            "and is not yet wired for the Accelerate ILP64 alias interposition. "
+            "Build it with an ILP64 library instead (-DLINALG_LIB=OpenBLAS) or "
+            "disable ddX on macOS.")
       endif()
       findAccelerateILP64()
 

--- a/cmake/oqp_functions.cmake
+++ b/cmake/oqp_functions.cmake
@@ -119,6 +119,78 @@ macro(findOpenBLASConfig)
     unset(_openblas_library)
 endmacro()
 
+# Validate the ILP64/LP64 integer width of an OpenBLAS selected through
+# pkg-config, reading openblas_config.h straight from the pkg-config include dir.
+#
+# Regression note: CMake's FindBLAS.cmake takes an early return out of its
+# pkg-config branch (Modules/FindBLAS.cmake) the moment pkg_check_modules()
+# reports the requested module (e.g. openblas64) as found -- it sets BLAS_FOUND
+# and BLAS_LIBRARIES and return()s WITHOUT ever setting BLAS_SIZEOF_INTEGER.
+# Because of that, the BLAS_SIZEOF_INTEGER consistency gate in findBlasLapack()
+# is silently skipped on the pkg-config happy path, and findOpenBLASConfig() is
+# only reached on find_package() FAILURE. A hand-rolled/vendored openblas64.pc
+# that actually points at an LP64 build would therefore link cleanly (the symbol
+# names match) yet every BLAS call would read an 8-byte dimension/leading-dim as
+# two 4-byte ints => silent numerical corruption on ILP64 builds. So we must NOT
+# depend on BLAS_SIZEOF_INTEGER here: re-query pkg-config ourselves and assert
+# OPENBLAS_USE64BITINT is present iff LINALG_LIB_INT64 is ON.
+macro(validateOpenBLASPkgConfigInt64 _pc_module)
+    if(NOT "${_pc_module}" STREQUAL "")
+        find_package(PkgConfig QUIET)
+        if(PKG_CONFIG_FOUND)
+            pkg_check_modules(_OQP_OPENBLAS QUIET "${_pc_module}")
+            if(_OQP_OPENBLAS_FOUND)
+                set(_oqp_openblas_config_h)
+                foreach(_oqp_inc IN LISTS _OQP_OPENBLAS_INCLUDE_DIRS)
+                    if(EXISTS "${_oqp_inc}/openblas_config.h")
+                        set(_oqp_openblas_config_h "${_oqp_inc}/openblas_config.h")
+                        break()
+                    endif()
+                endforeach()
+                # Only assert when we can actually read the header; a missing
+                # header means we cannot prove a mismatch, and failing hard there
+                # would break otherwise-valid setups that ship the .pc but no dev
+                # headers. This mirrors findOpenBLASConfig()'s guarded check.
+                if(_oqp_openblas_config_h)
+                    file(READ "${_oqp_openblas_config_h}" _oqp_openblas_config)
+                    if(LINALG_LIB_INT64 AND NOT _oqp_openblas_config MATCHES "#define[ \t]+OPENBLAS_USE64BITINT")
+                        message(FATAL_ERROR "OpenBLAS pkg-config module '${_pc_module}' resolves to an LP64 build (${_oqp_openblas_config_h} does not define OPENBLAS_USE64BITINT), but OpenQP is configured for 8-byte BLAS integers (LINALG_LIB_INT64=ON). Point pkg-config at a genuine ILP64 OpenBLAS (openblas64) or set LINALG_LIB_INT64=OFF.")
+                    elseif(NOT LINALG_LIB_INT64 AND _oqp_openblas_config MATCHES "#define[ \t]+OPENBLAS_USE64BITINT")
+                        message(FATAL_ERROR "OpenBLAS pkg-config module '${_pc_module}' resolves to an ILP64 build (${_oqp_openblas_config_h} defines OPENBLAS_USE64BITINT), but OpenQP is configured for 4-byte BLAS integers (LINALG_LIB_INT64=OFF). Point pkg-config at an LP64 OpenBLAS (openblas) or set LINALG_LIB_INT64=ON.")
+                    endif()
+                    unset(_oqp_openblas_config)
+                endif()
+                unset(_oqp_openblas_config_h)
+                unset(_oqp_inc)
+            endif()
+        endif()
+    endif()
+endmacro()
+
+# Handle "the required BLAS/LAPACK backend was not found".
+# Policy: NEVER fall back to the bundled NetLib reference BLAS silently -- that
+# is how unoptimized wheels shipped and how CI ended up testing a different
+# BLAS than users ran. Configuration FAILS with instructions instead. The
+# reference build remains available, but only as an explicit choice:
+# -DLINALG_LIB=netlib, or -DOQP_ALLOW_REFERENCE_BLAS=ON to accept the fallback.
+macro(oqpLinalgNotFound _backend _hint)
+    if(OQP_ALLOW_REFERENCE_BLAS)
+        message(WARNING
+            "BLAS/LAPACK backend '${_backend}' was not found. Falling back to "
+            "the bundled NetLib reference BLAS because OQP_ALLOW_REFERENCE_BLAS=ON. "
+            "This build will be SLOW (typically 1.5-2x on BLAS-bound jobs).")
+        cleanBlasVars()
+        set(linalg_lib netlib)
+    else()
+        message(FATAL_ERROR
+            "Required BLAS/LAPACK backend '${_backend}' was not found.\n"
+            "${_hint}\n"
+            "Alternatively: pick another backend explicitly with -DLINALG_LIB=<vendor>, "
+            "or accept the slow bundled reference BLAS with -DLINALG_LIB=netlib "
+            "(or -DOQP_ALLOW_REFERENCE_BLAS=ON).")
+    endif()
+endmacro()
+
 macro(findBlasLapack)
     cleanBlasVars()
     find_package(BLAS)
@@ -135,19 +207,61 @@ macro(findLinearAlgebra)
 
     set(linalg_lib "${LINALG_LIB}")
 
-    if(${linalg_lib} STREQUAL auto)
+    # =================================================================
+    # Deterministic native-BLAS platform policy.
+    # 'auto' resolves to the mandated native backend per OS/arch instead of
+    # probing whatever BLAS happens to be installed. Environment probing made
+    # the selected BLAS differ between wheels, CI, and user machines (and
+    # shipped NetLib reference BLAS in the PyPI Linux wheels); the mandate
+    # makes every build path pick the same backend on the same hardware:
+    #     macOS (arm64 and x86_64)  -> Apple Accelerate (LP64)
+    #     Linux x86_64              -> Intel MKL (ILP64)
+    #     Linux aarch64             -> OpenBLAS (ILP64)
+    # Platforms outside this table keep the legacy environment probe.
+    # There is no silent fallback to the bundled NetLib reference BLAS --
+    # see oqpLinalgNotFound() for the explicit escape hatches.
+    # =================================================================
+    if(linalg_lib STREQUAL auto)
+      set(_oqp_linalg_mandated FALSE)
+      if(APPLE)
+        set(linalg_lib Apple)
+        set(_oqp_linalg_mandated TRUE)
+      elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+        set(linalg_lib Intel10_64ilp)
+        set(_oqp_linalg_mandated TRUE)
+      elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
+        set(linalg_lib OpenBLAS)
+        set(_oqp_linalg_mandated TRUE)
+      endif()
+      if(_oqp_linalg_mandated)
+        message(STATUS "LINALG_LIB=auto resolved to '${linalg_lib}' for "
+                       "${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR} (native-BLAS platform policy)")
+      endif()
+      unset(_oqp_linalg_mandated)
+    endif()
+
+    if(linalg_lib STREQUAL auto)
+      # Platform without a mandated backend: legacy environment probe,
+      # but a missing BLAS is an explicit failure, not a silent NetLib build.
       findBlasLapack()
-      if(NOT ${LAPACK_FOUND} OR NOT ${BLAS_FOUND})
-          # Fall back to netlib if nothing have been found
-          cleanBlasVars()
-          set(linalg_lib netlib)
+      if(NOT LAPACK_FOUND OR NOT BLAS_FOUND)
+          oqpLinalgNotFound(auto "CMake's FindBLAS found no BLAS/LAPACK on this platform.")
       endif()
 
-    elseif(${linalg_lib} STREQUAL netlib)
-        # do nothing
+    elseif(linalg_lib STREQUAL netlib)
+        # Explicit user choice of the bundled reference BLAS: do nothing.
 
     else()
-      if(${linalg_lib} STREQUAL OpenBLAS)
+      if(linalg_lib STREQUAL Apple AND LINALG_LIB_INT64)
+        # Accelerate's classic (Fortran-symbol) interface is LP64-only.
+        message(FATAL_ERROR
+            "LINALG_LIB resolves to Apple Accelerate, which only provides an "
+            "LP64 (4-byte integer) BLAS/LAPACK interface, but LINALG_LIB_INT64=ON "
+            "requests 8-byte BLAS integers. Configure with -DLINALG_LIB_INT64=OFF "
+            "(the macOS default) or pick an ILP64 backend explicitly, e.g. "
+            "-DLINALG_LIB=OpenBLAS.")
+      endif()
+      if(linalg_lib STREQUAL OpenBLAS)
         set(BLA_PREFER_PKGCONFIG ON)
         if(LINALG_LIB_INT64)
           set(BLA_PKGCONFIG_BLAS openblas64)
@@ -159,23 +273,50 @@ macro(findLinearAlgebra)
       endif()
       set(BLA_VENDOR ${linalg_lib})
       findBlasLapack()
-      if(NOT ${LAPACK_FOUND} OR NOT ${BLAS_FOUND})
-          if(${linalg_lib} STREQUAL OpenBLAS)
+      if(BLAS_FOUND AND LAPACK_FOUND AND linalg_lib STREQUAL OpenBLAS)
+          # FindBLAS's pkg-config branch returns early without setting
+          # BLAS_SIZEOF_INTEGER, so the width gate inside findBlasLapack() never
+          # fired for this configuration. Re-validate the ILP64/LP64 width from
+          # openblas_config.h so a mislabeled openblas64.pc cannot deliver a
+          # silently-truncating 4-byte BLAS (see validateOpenBLASPkgConfigInt64).
+          validateOpenBLASPkgConfigInt64("${BLA_PKGCONFIG_BLAS}")
+      endif()
+      if(NOT LAPACK_FOUND OR NOT BLAS_FOUND)
+          if(linalg_lib STREQUAL OpenBLAS)
               cleanBlasVars()
               findOpenBLASConfig()
           endif()
       endif()
-      if(NOT ${LAPACK_FOUND} OR NOT ${BLAS_FOUND})
-          # If nothing was found, try to find any other
-          # linear algebra library in system
-          unset(BLA_VENDOR)
-          set(linalg_lib auto)
-          findBlasLapack()
-          if(NOT ${LAPACK_FOUND} OR NOT ${BLAS_FOUND})
-              # Fall back to netlib if nothing have been found
-              cleanBlasVars()
-              set(linalg_lib netlib)
+      if(NOT LAPACK_FOUND OR NOT BLAS_FOUND)
+          # No silent re-probe or NetLib fallback: fail with instructions.
+          if(linalg_lib STREQUAL Apple)
+            oqpLinalgNotFound(Apple "Apple Accelerate was not found; it ships with macOS -- check the Xcode Command Line Tools / SDK installation.")
+          elseif(linalg_lib MATCHES "^Intel10_64ilp")
+            oqpLinalgNotFound("${linalg_lib}" "Install Intel MKL (oneAPI) and load its environment (source setvars.sh, or 'module load imkl') so MKLROOT is set before configuring.")
+          elseif(linalg_lib STREQUAL OpenBLAS)
+            oqpLinalgNotFound(OpenBLAS "Install an ILP64 OpenBLAS so that 'pkg-config --exists openblas64' succeeds (e.g. libopenblas64-dev / openblas built with INTERFACE64=1), or an LP64 one when LINALG_LIB_INT64=OFF.")
+          else()
+            oqpLinalgNotFound("${linalg_lib}" "The requested BLA_VENDOR '${linalg_lib}' was not found by CMake's FindBLAS.")
           endif()
+      endif()
+      # Record the integer width as a *fact of the selected backend* on paths
+      # where FindBLAS does not report BLAS_SIZEOF_INTEGER, so the width gate
+      # can never be skipped (Accelerate classic = LP64 by definition; the
+      # Intel10_64ilp* vendor names mandate ILP64 by definition).
+      if(NOT linalg_lib STREQUAL netlib AND BLAS_FOUND)
+        if(NOT DEFINED BLAS_SIZEOF_INTEGER)
+          if(linalg_lib STREQUAL Apple)
+            set(BLAS_SIZEOF_INTEGER 4)
+          elseif(linalg_lib MATCHES "^Intel10_64ilp")
+            set(BLAS_SIZEOF_INTEGER 8)
+          endif()
+        endif()
+        if(DEFINED BLAS_SIZEOF_INTEGER AND NOT BLAS_SIZEOF_INTEGER EQUAL ${BLA_SIZEOF_INTEGER})
+          message(FATAL_ERROR
+              "Selected BLAS ('${linalg_lib}') has ${BLAS_SIZEOF_INTEGER}-byte "
+              "integers; OpenQP is configured for ${BLA_SIZEOF_INTEGER}-byte "
+              "BLAS integers (LINALG_LIB_INT64=${LINALG_LIB_INT64}).")
+        endif()
       endif()
     endif()
 

--- a/cmake/oqp_functions.cmake
+++ b/cmake/oqp_functions.cmake
@@ -167,6 +167,98 @@ macro(validateOpenBLASPkgConfigInt64 _pc_module)
     endif()
 endmacro()
 
+# =================================================================
+# Accelerate ILP64 backend (macOS, LINALG_LIB_INT64=ON).
+#
+# Accelerate's classic Fortran symbols (dgemm_, dgesvd_, ...) are LP64
+# (4-byte integers) only. Since macOS 13.3 Accelerate ALSO ships a genuine
+# ILP64 (8-byte integer) BLAS/LAPACK behind suffixed symbols
+# (`dgemm$NEWLAPACK$ILP64`, ...). We interpose every classic name OpenQP
+# references onto its ILP64 variant with an ld alias-list FILE, so macOS
+# builds run 8-byte integers end-to-end exactly like MKL/OpenBLAS ILP64 on
+# Linux -- uniform integer model on all platforms, no LP64 special case, and
+# still zero bundled BLAS (Accelerate is a system framework).
+#
+# Two ld gotchas are baked in here (both verified the hard way):
+#   * use an alias-list FILE (-Wl,-alias_list,<file>), never inline
+#     -Wl,-alias,... -- the `$` in the symbol name gets shell-expanded to
+#     nothing by the sh that drives the link, silently aliasing to `_dgemm`;
+#   * the file format is "<real_symbol> <alias_name>" per line, i.e. the
+#     ILP64 symbol FIRST and the classic name as its alias.
+#
+# The symbol list below was generated from the real liboqp:
+#   nm -u liboqp.dylib | grep -E '^_[a-z][a-z0-9]+_$'
+# with every candidate link-probed against Accelerate for a
+# $NEWLAPACK$ILP64 variant (163/163 routable). If OpenQP gains a new
+# BLAS/LAPACK call that is missing here, the POST_BUILD guard
+# (cmake/check_accelerate_aliases.cmake) FAILS the build naming the symbol --
+# a stale list cannot silently ship a 4-byte routine into an 8-byte build.
+# =================================================================
+set(OQP_ACCELERATE_ILP64_SYMS
+    caxpy ccopy cdotc cdotu cgbmv cgemm cgemv cgerc cgeru chbmv chemm chemv
+    cher cher2 cher2k cherk chpmv chpr chpr2 cscal csrot csscal cswap csymm
+    csyr2k csyrk ctbmv ctbsv ctpmv ctpsv ctrmm ctrmv ctrsm ctrsv
+    dasum daxpy dcopy ddot dgbmv dgemm dgemv dgeqrf dger dgesv dgesvd dgetri
+    dgglse dlamch dnrm2 dorgqr dormqr drot drotm dsbmv dscal dsdot dspev
+    dspevx dspmv dspr dspr2 dswap dsyev dsyevd dsymm dsymv dsyr dsyr2 dsyr2k
+    dsyrk dsysv dsytrf dsytri dsytrs dtbmv dtbsv dtpmv dtpsv dtpttr dtrmm
+    dtrmv dtrsm dtrsv dtrttp dzasum dznrm2
+    icamax idamax isamax izamax
+    sasum saxpy scasum scnrm2 scopy sdot sdsdot sgbmv sgemm sgemv sger snrm2
+    srot srotm ssbmv sscal sspmv sspr sspr2 sswap ssymm ssymv ssyr ssyr2
+    ssyr2k ssyrk ssytrf ssytri ssytrs stbmv stbsv stpmv stpsv strmm strmv
+    strsm strsv
+    xerbla
+    zaxpy zcopy zdotc zdotu zdrot zdscal zgbmv zgemm zgemv zgerc zgeru zhbmv
+    zheev zhemm zhemv zher zher2 zher2k zherk zhpmv zhpr zhpr2 zscal zswap
+    zsymm zsyr2k zsyrk ztbmv ztbsv ztpmv ztpsv ztrmm ztrmv ztrsm ztrsv
+    CACHE INTERNAL "BLAS/LAPACK routines interposed onto Accelerate ILP64")
+
+function(oqp_accelerate_alias_file out_path)
+    set(_txt "")
+    foreach(_s IN LISTS OQP_ACCELERATE_ILP64_SYMS)
+        # "$" is literal in CMake strings; the line format is
+        # "<real symbol> <alias>": the ILP64 symbol is real, classic name aliases it.
+        string(APPEND _txt "_${_s}$NEWLAPACK$ILP64 _${_s}_\n")
+    endforeach()
+    file(WRITE "${out_path}" "${_txt}")
+endfunction()
+
+macro(findAccelerateILP64)
+    cleanBlasVars()
+    # Probe: link a stub with the FULL alias list. This validates at configure
+    # time that every symbol in OQP_ACCELERATE_ILP64_SYMS has a $NEWLAPACK$ILP64
+    # variant in this SDK's Accelerate (needs macOS >= 13.3) -- a missing one
+    # fails here with a clear story instead of at the liboqp link.
+    oqp_accelerate_alias_file("${CMAKE_BINARY_DIR}/_oqp_accel_ilp64_probe.alias")
+    file(WRITE "${CMAKE_BINARY_DIR}/_oqp_accel_ilp64_probe.f90" "program p\nend program\n")
+    try_compile(_OQP_ACC_ILP64_OK "${CMAKE_BINARY_DIR}/_oqp_accel_ilp64_probe_dir"
+        SOURCES "${CMAKE_BINARY_DIR}/_oqp_accel_ilp64_probe.f90"
+        LINK_LIBRARIES "-framework Accelerate"
+        LINK_OPTIONS "-Wl,-alias_list,${CMAKE_BINARY_DIR}/_oqp_accel_ilp64_probe.alias")
+    if(NOT _OQP_ACC_ILP64_OK)
+        message(FATAL_ERROR
+            "Accelerate's ILP64 interface (\$NEWLAPACK\$ILP64 symbols) is not "
+            "available from this SDK -- it requires macOS >= 13.3. Either update "
+            "macOS/Xcode, use the classic LP64 Accelerate interface with "
+            "-DLINALG_LIB_INT64=OFF, or pick an ILP64 backend explicitly, e.g. "
+            "-DLINALG_LIB=OpenBLAS.")
+    endif()
+    oqp_accelerate_alias_file("${CMAKE_BINARY_DIR}/accelerate_ilp64.alias")
+    set(OQP_ACC_ALIAS "${CMAKE_BINARY_DIR}/accelerate_ilp64.alias"
+        CACHE INTERNAL "Accelerate ILP64 alias list")
+    set(BLAS_FOUND   TRUE)
+    set(LAPACK_FOUND TRUE)
+    set(BLAS_LIBRARIES   "-framework Accelerate")
+    set(LAPACK_LIBRARIES "-framework Accelerate")
+    # ILP64: 8-byte integers on both sides, recorded as facts so the width
+    # gate holds on this path too.
+    set(BLAS_SIZEOF_INTEGER   8)
+    set(LAPACK_SIZEOF_INTEGER 8)
+    message(STATUS "BLAS/LAPACK: Apple Accelerate ILP64 (\$NEWLAPACK\$ILP64 interposition, "
+                   "${CMAKE_BINARY_DIR}/accelerate_ilp64.alias)")
+endmacro()
+
 # Handle "the required BLAS/LAPACK backend was not found".
 # Policy: NEVER fall back to the bundled NetLib reference BLAS silently -- that
 # is how unoptimized wheels shipped and how CI ended up testing a different
@@ -213,8 +305,12 @@ macro(findLinearAlgebra)
     # probing whatever BLAS happens to be installed. Environment probing made
     # the selected BLAS differ between wheels, CI, and user machines (and
     # shipped NetLib reference BLAS in the PyPI Linux wheels); the mandate
-    # makes every build path pick the same backend on the same hardware:
-    #     macOS (arm64 and x86_64)  -> Apple Accelerate (LP64)
+    # makes every build path pick the same backend on the same hardware,
+    # ALL with the uniform 8-byte (ILP64) integer model by default:
+    #     macOS (arm64 and x86_64)  -> Apple Accelerate ILP64
+    #                                  ($NEWLAPACK$ILP64 interposition; the
+    #                                  classic LP64 interface remains available
+    #                                  with -DLINALG_LIB_INT64=OFF)
     #     Linux x86_64              -> Intel MKL (ILP64)
     #     Linux aarch64             -> OpenBLAS (ILP64)
     # Platforms outside this table keep the legacy environment probe.
@@ -251,16 +347,23 @@ macro(findLinearAlgebra)
     elseif(linalg_lib STREQUAL netlib)
         # Explicit user choice of the bundled reference BLAS: do nothing.
 
-    else()
-      if(linalg_lib STREQUAL Apple AND LINALG_LIB_INT64)
-        # Accelerate's classic (Fortran-symbol) interface is LP64-only.
+    elseif(linalg_lib STREQUAL Apple AND LINALG_LIB_INT64)
+      # macOS with the default 8-byte integers: Accelerate's modern ILP64
+      # interface via symbol interposition (see findAccelerateILP64 above).
+      # FATALs internally if the SDK lacks $NEWLAPACK$ILP64 (macOS < 13.3).
+      # Externals that link BLAS themselves are not wired for the alias list
+      # yet -- refuse the combination rather than let them bind the classic
+      # LP64 symbols and corrupt (they are OFF by default).
+      if(ENABLE_DDX OR ENABLE_OPENTRAH)
         message(FATAL_ERROR
-            "LINALG_LIB resolves to Apple Accelerate, which only provides an "
-            "LP64 (4-byte integer) BLAS/LAPACK interface, but LINALG_LIB_INT64=ON "
-            "requests 8-byte BLAS integers. Configure with -DLINALG_LIB_INT64=OFF "
-            "(the macOS default) or pick an ILP64 backend explicitly, e.g. "
-            "-DLINALG_LIB=OpenBLAS.")
+            "ENABLE_DDX/ENABLE_OPENTRAH link BLAS/LAPACK directly and are not "
+            "yet wired for the Accelerate ILP64 alias interposition. Build them "
+            "with an ILP64 library instead (-DLINALG_LIB=OpenBLAS "
+            "-DLINALG_LIB_INT64=ON) or disable the feature on macOS.")
       endif()
+      findAccelerateILP64()
+
+    else()
       if(linalg_lib STREQUAL OpenBLAS)
         set(BLA_PREFER_PKGCONFIG ON)
         if(LINALG_LIB_INT64)
@@ -351,6 +454,19 @@ macro(findLinearAlgebra)
          set(_MKL_INTERFACE_LAYER "ILP64" CACHE INTERNAL "_MKL_INTERFACE_LAYER")
       else()
          set(_MKL_INTERFACE_LAYER "LP64" CACHE INTERNAL "_MKL_INTERFACE_LAYER")
+      endif()
+    elseif(linalg_lib STREQUAL Apple AND LINALG_LIB_INT64)
+      set(_LINALG_LIB_TYPE "Accelerate_ILP64" CACHE INTERNAL "_LIANLG_LIB_TYPE")
+      if(TARGET oqp)
+        target_link_libraries(oqp ${BLAS_LIBRARIES})
+        # Interpose every classic BLAS/LAPACK symbol onto its $NEWLAPACK$ILP64
+        # variant (see findAccelerateILP64), then verify at POST_BUILD that no
+        # classic LP64 symbol leaked through un-aliased -- a leak would run a
+        # 4-byte-integer routine inside this 8-byte build.
+        target_link_options(oqp PRIVATE "-Wl,-alias_list,${OQP_ACC_ALIAS}")
+        add_custom_command(TARGET oqp POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -DLIB=$<TARGET_FILE:oqp>
+                    -P ${CMAKE_SOURCE_DIR}/cmake/check_accelerate_aliases.cmake)
       endif()
     else()
       set(_LINALG_LIB_TYPE "other" CACHE INTERNAL "_LIANLG_LIB_TYPE")

--- a/cmake/oqp_functions.cmake
+++ b/cmake/oqp_functions.cmake
@@ -94,10 +94,9 @@ macro(findOpenBLASConfig)
         endif()
         if(_openblas_config_h AND EXISTS "${_openblas_config_h}")
             file(READ "${_openblas_config_h}" _openblas_config)
-            if(LINALG_LIB_INT64 AND NOT _openblas_config MATCHES "#define[ \t]+OPENBLAS_USE64BITINT")
-                message(FATAL_ERROR "OpenBLAS config at ${_openblas_config_h} is LP64, but OpenQP is configured for 8-byte BLAS integers.")
-            elseif(NOT LINALG_LIB_INT64 AND _openblas_config MATCHES "#define[ \t]+OPENBLAS_USE64BITINT")
-                message(FATAL_ERROR "OpenBLAS config at ${_openblas_config_h} is ILP64, but OpenQP is configured for 4-byte BLAS integers.")
+            # OpenQP is ILP64-only: the OpenBLAS build must be 8-byte.
+            if(NOT _openblas_config MATCHES "#define[ \t]+OPENBLAS_USE64BITINT")
+                message(FATAL_ERROR "OpenBLAS config at ${_openblas_config_h} is LP64, but OpenQP requires 8-byte (ILP64) BLAS integers.")
             endif()
         endif()
         set(BLAS_FOUND TRUE)
@@ -133,7 +132,7 @@ endmacro()
 # names match) yet every BLAS call would read an 8-byte dimension/leading-dim as
 # two 4-byte ints => silent numerical corruption on ILP64 builds. So we must NOT
 # depend on BLAS_SIZEOF_INTEGER here: re-query pkg-config ourselves and assert
-# OPENBLAS_USE64BITINT is present iff LINALG_LIB_INT64 is ON.
+# OPENBLAS_USE64BITINT is present (OpenQP is ILP64-only).
 macro(validateOpenBLASPkgConfigInt64 _pc_module)
     if(NOT "${_pc_module}" STREQUAL "")
         find_package(PkgConfig QUIET)
@@ -153,10 +152,8 @@ macro(validateOpenBLASPkgConfigInt64 _pc_module)
                 # headers. This mirrors findOpenBLASConfig()'s guarded check.
                 if(_oqp_openblas_config_h)
                     file(READ "${_oqp_openblas_config_h}" _oqp_openblas_config)
-                    if(LINALG_LIB_INT64 AND NOT _oqp_openblas_config MATCHES "#define[ \t]+OPENBLAS_USE64BITINT")
-                        message(FATAL_ERROR "OpenBLAS pkg-config module '${_pc_module}' resolves to an LP64 build (${_oqp_openblas_config_h} does not define OPENBLAS_USE64BITINT), but OpenQP is configured for 8-byte BLAS integers (LINALG_LIB_INT64=ON). Point pkg-config at a genuine ILP64 OpenBLAS (openblas64) or set LINALG_LIB_INT64=OFF.")
-                    elseif(NOT LINALG_LIB_INT64 AND _oqp_openblas_config MATCHES "#define[ \t]+OPENBLAS_USE64BITINT")
-                        message(FATAL_ERROR "OpenBLAS pkg-config module '${_pc_module}' resolves to an ILP64 build (${_oqp_openblas_config_h} defines OPENBLAS_USE64BITINT), but OpenQP is configured for 4-byte BLAS integers (LINALG_LIB_INT64=OFF). Point pkg-config at an LP64 OpenBLAS (openblas) or set LINALG_LIB_INT64=ON.")
+                    if(NOT _oqp_openblas_config MATCHES "#define[ \t]+OPENBLAS_USE64BITINT")
+                        message(FATAL_ERROR "OpenBLAS pkg-config module '${_pc_module}' resolves to an LP64 build (${_oqp_openblas_config_h} does not define OPENBLAS_USE64BITINT), but OpenQP requires 8-byte (ILP64) BLAS integers. Point pkg-config at a genuine ILP64 OpenBLAS (openblas64).")
                     endif()
                     unset(_oqp_openblas_config)
                 endif()
@@ -168,7 +165,7 @@ macro(validateOpenBLASPkgConfigInt64 _pc_module)
 endmacro()
 
 # =================================================================
-# Accelerate ILP64 backend (macOS, LINALG_LIB_INT64=ON).
+# Accelerate ILP64 backend (macOS; OpenQP is ILP64-only).
 #
 # Accelerate's classic Fortran symbols (dgemm_, dgesvd_, ...) are LP64
 # (4-byte integers) only. Since macOS 13.3 Accelerate ALSO ships a genuine
@@ -240,9 +237,8 @@ macro(findAccelerateILP64)
         message(FATAL_ERROR
             "Accelerate's ILP64 interface (\$NEWLAPACK\$ILP64 symbols) is not "
             "available from this SDK -- it requires macOS >= 13.3. Either update "
-            "macOS/Xcode, use the classic LP64 Accelerate interface with "
-            "-DLINALG_LIB_INT64=OFF, or pick an ILP64 backend explicitly, e.g. "
-            "-DLINALG_LIB=OpenBLAS.")
+            "macOS/Xcode or pick another ILP64 backend explicitly, e.g. "
+            "-DLINALG_LIB=OpenBLAS (OpenQP is ILP64-only; LP64 support was removed).")
     endif()
     oqp_accelerate_alias_file("${CMAKE_BINARY_DIR}/accelerate_ilp64.alias")
     set(OQP_ACC_ALIAS "${CMAKE_BINARY_DIR}/accelerate_ilp64.alias"
@@ -308,9 +304,7 @@ macro(findLinearAlgebra)
     # makes every build path pick the same backend on the same hardware,
     # ALL with the uniform 8-byte (ILP64) integer model by default:
     #     macOS (arm64 and x86_64)  -> Apple Accelerate ILP64
-    #                                  ($NEWLAPACK$ILP64 interposition; the
-    #                                  classic LP64 interface remains available
-    #                                  with -DLINALG_LIB_INT64=OFF)
+    #                                  ($NEWLAPACK$ILP64 interposition)
     #     Linux x86_64              -> Intel MKL (ILP64)
     #     Linux aarch64             -> OpenBLAS (ILP64)
     # Platforms outside this table keep the legacy environment probe.
@@ -347,9 +341,9 @@ macro(findLinearAlgebra)
     elseif(linalg_lib STREQUAL netlib)
         # Explicit user choice of the bundled reference BLAS: do nothing.
 
-    elseif(linalg_lib STREQUAL Apple AND LINALG_LIB_INT64)
-      # macOS with the default 8-byte integers: Accelerate's modern ILP64
-      # interface via symbol interposition (see findAccelerateILP64 above).
+    elseif(linalg_lib STREQUAL Apple)
+      # macOS: Accelerate's modern ILP64 interface via symbol interposition
+      # (see findAccelerateILP64 above; OpenQP is ILP64-only).
       # FATALs internally if the SDK lacks $NEWLAPACK$ILP64 (macOS < 13.3).
       # Externals that link BLAS themselves are not wired for the alias list
       # yet -- refuse the combination rather than let them bind the classic
@@ -358,21 +352,17 @@ macro(findLinearAlgebra)
         message(FATAL_ERROR
             "ENABLE_DDX/ENABLE_OPENTRAH link BLAS/LAPACK directly and are not "
             "yet wired for the Accelerate ILP64 alias interposition. Build them "
-            "with an ILP64 library instead (-DLINALG_LIB=OpenBLAS "
-            "-DLINALG_LIB_INT64=ON) or disable the feature on macOS.")
+            "with an ILP64 library instead (-DLINALG_LIB=OpenBLAS) or disable "
+            "the feature on macOS.")
       endif()
       findAccelerateILP64()
 
     else()
       if(linalg_lib STREQUAL OpenBLAS)
+        # ILP64-only: always the openblas64 pkg-config module.
         set(BLA_PREFER_PKGCONFIG ON)
-        if(LINALG_LIB_INT64)
-          set(BLA_PKGCONFIG_BLAS openblas64)
-          set(BLA_PKGCONFIG_LAPACK openblas64)
-        else()
-          set(BLA_PKGCONFIG_BLAS openblas)
-          set(BLA_PKGCONFIG_LAPACK openblas)
-        endif()
+        set(BLA_PKGCONFIG_BLAS openblas64)
+        set(BLA_PKGCONFIG_LAPACK openblas64)
       endif()
       set(BLA_VENDOR ${linalg_lib})
       findBlasLapack()
@@ -397,7 +387,7 @@ macro(findLinearAlgebra)
           elseif(linalg_lib MATCHES "^Intel10_64ilp")
             oqpLinalgNotFound("${linalg_lib}" "Install Intel MKL (oneAPI) and load its environment (source setvars.sh, or 'module load imkl') so MKLROOT is set before configuring.")
           elseif(linalg_lib STREQUAL OpenBLAS)
-            oqpLinalgNotFound(OpenBLAS "Install an ILP64 OpenBLAS so that 'pkg-config --exists openblas64' succeeds (e.g. libopenblas64-dev / openblas built with INTERFACE64=1), or an LP64 one when LINALG_LIB_INT64=OFF.")
+            oqpLinalgNotFound(OpenBLAS "Install an ILP64 OpenBLAS so that 'pkg-config --exists openblas64' succeeds (e.g. libopenblas64-dev / openblas built with INTERFACE64=1),.")
           else()
             oqpLinalgNotFound("${linalg_lib}" "The requested BLA_VENDOR '${linalg_lib}' was not found by CMake's FindBLAS.")
           endif()
@@ -417,8 +407,8 @@ macro(findLinearAlgebra)
         if(DEFINED BLAS_SIZEOF_INTEGER AND NOT BLAS_SIZEOF_INTEGER EQUAL ${BLA_SIZEOF_INTEGER})
           message(FATAL_ERROR
               "Selected BLAS ('${linalg_lib}') has ${BLAS_SIZEOF_INTEGER}-byte "
-              "integers; OpenQP is configured for ${BLA_SIZEOF_INTEGER}-byte "
-              "BLAS integers (LINALG_LIB_INT64=${LINALG_LIB_INT64}).")
+              "integers; OpenQP requires ${BLA_SIZEOF_INTEGER}-byte (ILP64) "
+              "BLAS integers.")
         endif()
       endif()
     endif()
@@ -450,12 +440,8 @@ macro(findLinearAlgebra)
       if(TARGET oqp)
         target_link_libraries(oqp ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
       endif()
-      if(LINALG_LIB_INT64)
-         set(_MKL_INTERFACE_LAYER "ILP64" CACHE INTERNAL "_MKL_INTERFACE_LAYER")
-      else()
-         set(_MKL_INTERFACE_LAYER "LP64" CACHE INTERNAL "_MKL_INTERFACE_LAYER")
-      endif()
-    elseif(linalg_lib STREQUAL Apple AND LINALG_LIB_INT64)
+      set(_MKL_INTERFACE_LAYER "ILP64" CACHE INTERNAL "_MKL_INTERFACE_LAYER")
+    elseif(linalg_lib STREQUAL Apple)
       set(_LINALG_LIB_TYPE "Accelerate_ILP64" CACHE INTERNAL "_LIANLG_LIB_TYPE")
       if(TARGET oqp)
         target_link_libraries(oqp ${BLAS_LIBRARIES})

--- a/docs/dft_xc_reuse.md
+++ b/docs/dft_xc_reuse.md
@@ -115,11 +115,11 @@ to make the negative result reproducible (`[SCFTIME] ... xc_reused=T/F`).
 ## Reproduce
 
 ```sh
-# build (note LP64 BLAS flag, required on macOS/Accelerate):
+# build (macOS resolves to Accelerate ILP64 automatically):
 cmake -G Ninja -B build -DCMAKE_C_COMPILER=gcc-15 -DCMAKE_CXX_COMPILER=g++-15 \
   -DCMAKE_Fortran_COMPILER=gfortran-15 -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=ON -DENABLE_OPENMP=ON -DENABLE_PYTHON=OFF -DUSE_LIBINT=OFF \
-  -DLINALG_LIB=auto -DLINALG_LIB_INT64=OFF
+  -DLINALG_LIB=auto
 ninja -C build oqp
 
 # run with timing, toggling the optimizations:

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -304,12 +304,11 @@ oqp_reuse_or_build(libtagarray
 # the kinds match (otherwise alloc_or_die / create(override=...) fail to resolve
 # in ILP64 builds).
 set(_TAGARRAY_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}")
-if(LINALG_LIB_INT64)
-  if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Flang")
-    string(APPEND _TAGARRAY_Fortran_FLAGS " -fdefault-integer-8")
-  elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "IntelLLVM")
-    string(APPEND _TAGARRAY_Fortran_FLAGS " -i8")
-  endif()
+# ILP64-only: default integers are always 8 bytes.
+if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Flang")
+  string(APPEND _TAGARRAY_Fortran_FLAGS " -fdefault-integer-8")
+elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "IntelLLVM")
+  string(APPEND _TAGARRAY_Fortran_FLAGS " -i8")
 endif()
 if(NOT TARGET libtagarray)
 ExternalProject_Add(libtagarray
@@ -373,11 +372,7 @@ ExternalProject_Add(libecpint
         )
 endif()
 if(_LINALG_LIB_TYPE STREQUAL NetLib)
-  if(LINALG_LIB_INT64)
-    set(BLA_LIB_SUFFIX "64")
-  else()
-    set(BLA_LIB_SUFFIX "")
-  endif()
+  set(BLA_LIB_SUFFIX "64")
   if(BUILD_SHARED_LIBS)
     set(la_fortran_flags "${CMAKE_Fortran_FLAGS} -fpic")
   else()
@@ -408,7 +403,7 @@ if(_LINALG_LIB_TYPE STREQUAL NetLib)
         UPDATE_COMMAND ""
         PATCH_COMMAND perl -0pi -e "s/cmake_minimum_required\\(VERSION 3\\.2\\)/cmake_minimum_required(VERSION 3.5)/g" <SOURCE_DIR>/CMakeLists.txt <SOURCE_DIR>/INSTALL/CMakeLists.txt
         INSTALL_COMMAND ""
-        CMAKE_ARGS -DBUILD_INDEX64=${LINALG_LIB_INT64}
+        CMAKE_ARGS -DBUILD_INDEX64=ON
                    -DBUILD_SINGLE=ON
                    -DBUILD_DOUBLE=ON
                    -DBUILD_COMPLEX=ON
@@ -432,15 +427,12 @@ oqp_set_external_paths(OPENTRUSTREGION opentrustregion
     "${CMAKE_BINARY_DIR}/external/opentrustregion/src/libopentrustregion-build-${CMAKE_Fortran_COMPILER_ID}"
     "${CMAKE_BINARY_DIR}/external/opentrustregion/src/libopentrustregion-stamp-${CMAKE_Fortran_COMPILER_ID}"
     "${CMAKE_BINARY_DIR}/external/install/opentrustregion")
+# ILP64-only: default integers are always 8 bytes.
 set(otr_integer_flags "")
-if(LINALG_LIB_INT64)
-    if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
-        set(otr_integer_flags "-fdefault-integer-8")
-    elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Flang")
-        set(otr_integer_flags "-fdefault-integer-8")
-    elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "IntelLLVM")
-        set(otr_integer_flags "-i8")
-    endif()
+if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Flang")
+    set(otr_integer_flags "-fdefault-integer-8")
+elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "IntelLLVM")
+    set(otr_integer_flags "-i8")
 endif()
 set(otr_fortran_flags "${CMAKE_Fortran_FLAGS} ${OTR_DEFS} ${otr_integer_flags}")
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 10.0)
@@ -598,13 +590,12 @@ if(ENABLE_DDX AND OQP_DDX_AUTOBUILD)
         CACHE INTERNAL "DDX_LIBRARY" FORCE)
 
     # Match OpenTrustRegion's BLAS integer flags.
+    # ILP64-only: default integers are always 8 bytes.
     set(ddx_integer_flags "")
-    if(LINALG_LIB_INT64)
-        if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Flang")
-            set(ddx_integer_flags "-fdefault-integer-8")
-        elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "IntelLLVM")
-            set(ddx_integer_flags "-i8")
-        endif()
+    if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Flang")
+        set(ddx_integer_flags "-fdefault-integer-8")
+    elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "IntelLLVM")
+        set(ddx_integer_flags "-i8")
     endif()
     set(ddx_fortran_flags "${CMAKE_Fortran_FLAGS} ${ddx_integer_flags}")
     if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 10.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,12 @@ wheel.packages = ["pyoqp/oqp"]
 USE_LIBINT = "OFF"
 ENABLE_OPENMP = "ON"
 ENABLE_OPENTRAH = "OFF"
-# LINALG_LIB / LINALG_LIB_INT64 are intentionally NOT pinned here: CMake's
-# native-BLAS platform policy resolves them per OS/arch, all ILP64 (8-byte
-# integers) by default -- macOS -> Accelerate ($NEWLAPACK$ILP64); Linux
-# x86_64 -> MKL; Linux aarch64 -> OpenBLAS -- so a plain `pip install .` is
-# deterministic per platform with one uniform integer model. Override
-# per-build if needed:
-#   pip install . -C cmake.define.LINALG_LIB=OpenBLAS -C cmake.define.LINALG_LIB_INT64=ON
+# LINALG_LIB is intentionally NOT pinned here: CMake's native-BLAS platform
+# policy resolves it per OS/arch -- macOS -> Accelerate ($NEWLAPACK$ILP64);
+# Linux x86_64 -> MKL; Linux aarch64 -> OpenBLAS -- so a plain `pip install .`
+# is deterministic per platform. OpenQP is ILP64-only (8-byte integers
+# everywhere, unconditional). Override the backend per-build if needed:
+#   pip install . -C cmake.define.LINALG_LIB=OpenBLAS
 CMAKE_INSTALL_PREFIX = "."
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,11 @@ USE_LIBINT = "OFF"
 ENABLE_OPENMP = "ON"
 ENABLE_OPENTRAH = "OFF"
 # LINALG_LIB / LINALG_LIB_INT64 are intentionally NOT pinned here: CMake's
-# native-BLAS platform policy resolves them per OS/arch (macOS -> Accelerate
-# LP64; Linux x86_64 -> MKL ILP64; Linux aarch64 -> OpenBLAS ILP64), so a plain
-# `pip install .` is deterministic per platform. Override per-build if needed:
+# native-BLAS platform policy resolves them per OS/arch, all ILP64 (8-byte
+# integers) by default -- macOS -> Accelerate ($NEWLAPACK$ILP64); Linux
+# x86_64 -> MKL; Linux aarch64 -> OpenBLAS -- so a plain `pip install .` is
+# deterministic per platform with one uniform integer model. Override
+# per-build if needed:
 #   pip install . -C cmake.define.LINALG_LIB=OpenBLAS -C cmake.define.LINALG_LIB_INT64=ON
 CMAKE_INSTALL_PREFIX = "."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ wheel.packages = ["pyoqp/oqp"]
 USE_LIBINT = "OFF"
 ENABLE_OPENMP = "ON"
 ENABLE_OPENTRAH = "OFF"
-LINALG_LIB_INT64 = "ON"
+# LINALG_LIB / LINALG_LIB_INT64 are intentionally NOT pinned here: CMake's
+# native-BLAS platform policy resolves them per OS/arch (macOS -> Accelerate
+# LP64; Linux x86_64 -> MKL ILP64; Linux aarch64 -> OpenBLAS ILP64), so a plain
+# `pip install .` is deterministic per platform. Override per-build if needed:
+#   pip install . -C cmake.define.LINALG_LIB=OpenBLAS -C cmake.define.LINALG_LIB_INT64=ON
 CMAKE_INSTALL_PREFIX = "."
 
 [tool.pytest.ini_options]

--- a/source/c_interop.F90
+++ b/source/c_interop.F90
@@ -36,6 +36,18 @@ module c_interop
     type(c_ptr) :: elshell
   end type
 
+  ! Export buffers for oqp_get_basis. The public C API is fixed at int64_t, but
+  ! basis_set%origin/am/ncontr are default Fortran integers, whose width follows
+  ! the build (4 bytes in LP64 builds, e.g. native macOS Accelerate). Returning
+  ! c_loc() of those internal arrays directly makes the Python side read pairs
+  ! of 32-bit values as single 64-bit integers => corrupted basis metadata
+  ! (e.g. centers [0,1] read back as [8589934592, -1]). Convert into these
+  ! int64 buffers and export their addresses instead. Contents stay valid until
+  ! the next oqp_get_basis call; callers (pyoqp get_basis) copy immediately.
+  integer(c_int64_t), allocatable, target :: basis_am_i64(:)
+  integer(c_int64_t), allocatable, target :: basis_origin_i64(:)
+  integer(c_int64_t), allocatable, target :: basis_ncontr_i64(:)
+
 contains
 
 !--------------------------------------------------------------------------------
@@ -246,10 +258,21 @@ contains
 #define ADDRESSOF(a,b) if(allocated(a))then;b=c_loc(a);else;return;endif
     ADDRESSOF(bas%ex,    ex)
     ADDRESSOF(bas%cc,    cc)
-    ADDRESSOF(bas%am, am)
-    ADDRESSOF(bas%origin, at)
-    ADDRESSOF(bas%ncontr,   cdeg)
 #undef ADDRESSOF
+
+    ! Integer arrays: do NOT export c_loc() of the internal default-integer
+    ! arrays -- their width follows the build (4 bytes in LP64 builds) while
+    ! the C API promises int64_t. Convert into the module-level int64 export
+    ! buffers and hand out those addresses (see declarations above).
+    if (.not. allocated(bas%am))     return
+    if (.not. allocated(bas%origin)) return
+    if (.not. allocated(bas%ncontr)) return
+    basis_am_i64     = int(bas%am,     c_int64_t)
+    basis_origin_i64 = int(bas%origin, c_int64_t)
+    basis_ncontr_i64 = int(bas%ncontr, c_int64_t)
+    am   = c_loc(basis_am_i64)
+    at   = c_loc(basis_origin_i64)
+    cdeg = c_loc(basis_ncontr_i64)
 
     ret = 0
 

--- a/source/scf_converger.F90
+++ b/source/scf_converger.F90
@@ -2049,7 +2049,13 @@ contains
     integer(kind=4) :: ires
     integer :: na, i, j, ifock
     logical :: is_a_repeat
-    integer :: opt_global, opt_lbfgs
+    ! NLOpt's f77-style API stores a C POINTER in the opt handle argument
+    ! (NLOpt documents it as integer*8), so the handles must be 8 bytes
+    ! REGARDLESS of the build's default integer width. With a default-width
+    ! declaration, LP64 builds (4-byte default integer, e.g. native macOS
+    ! Accelerate) let nlo_create() write an 8-byte pointer into 4-byte storage
+    ! => stack corruption => SIGSEGV (exit -11) in every EDIIS/ADIIS SCF.
+    integer(kind=8) :: opt_global, opt_lbfgs
     type(ediis_opt_data) :: t
 
     allocate(scf_conv_interp_result :: res)

--- a/tests/test_opentrustregion_linalg_config.py
+++ b/tests/test_opentrustregion_linalg_config.py
@@ -59,21 +59,22 @@ class OpenTrustRegionLinalgConfigTests(unittest.TestCase):
     def test_lp64_blas_is_macos_only(self):
         top_cmake = (ROOT / "CMakeLists.txt").read_text()
 
-        self.assertIn("if(NOT LINALG_LIB_INT64 AND NOT APPLE)", top_cmake)
-        self.assertIn("LP64 BLAS/LAPACK is supported only on macOS", top_cmake)
+        # ILP64-only: LP64 support was removed; the flag survives solely as a
+        # tombstone that fails a stale cache / old script loudly.
+        self.assertIn("if(DEFINED LINALG_LIB_INT64 AND NOT LINALG_LIB_INT64)", top_cmake)
+        self.assertIn("LP64 (4-byte BLAS integer) support has been", top_cmake)
 
-    def test_default_integer8_flags_are_gated_on_linalg_int64(self):
+    def test_default_integer8_flags_are_unconditional_ilp64(self):
         top_cmake = (ROOT / "CMakeLists.txt").read_text()
 
-        guard = top_cmake.index("if(LINALG_LIB_INT64)")
-        before_guard = top_cmake[:guard]
-        int64_guard_block = top_cmake[guard:top_cmake.index("if(ENABLE_OPENMP)")]
-
-        self.assertNotIn("fdefault-integer-8", before_guard)
-        self.assertNotIn(":-i8>", before_guard)
-        self.assertIn("fdefault-integer-8", int64_guard_block)
-        self.assertIn(":-i8>", int64_guard_block)
-        self.assertIn("set(BLA_SIZEOF_INTEGER 4)", int64_guard_block)
+        # OpenQP is ILP64-only: the 8-byte default-integer flags and the BLAS
+        # width are set unconditionally (no LP64 branch may reappear).
+        self.assertIn("set(BLA_SIZEOF_INTEGER 8)", top_cmake)
+        self.assertNotIn("set(BLA_SIZEOF_INTEGER 4)", top_cmake)
+        self.assertIn("fdefault-integer-8", top_cmake)
+        self.assertIn(":-i8>", top_cmake)
+        self.assertIn('set(OTR_DEFS "-DUSE_ILP64")', top_cmake)
+        self.assertNotIn('set(OTR_SUFFIX "_32")', top_cmake)
 
     def test_oqp_blas_integer_width_follows_linalg_configuration(self):
         source_cmake = (ROOT / "source" / "CMakeLists.txt").read_text()
@@ -222,7 +223,6 @@ class OpenTrustRegionLinalgConfigTests(unittest.TestCase):
                 project(openblas_config_probe NONE)
                 set(CMAKE_PREFIX_PATH [=[{package_root.as_posix()}]=])
                 set(BLA_SIZEOF_INTEGER 8)
-                set(LINALG_LIB_INT64 ON)
                 include([=[{(ROOT / "cmake" / "oqp_functions.cmake").as_posix()}]=])
                 findOpenBLASConfig()
                 if(NOT BLAS_FOUND OR NOT LAPACK_FOUND)

--- a/tests/test_runtime_root_resolution.py
+++ b/tests/test_runtime_root_resolution.py
@@ -132,12 +132,13 @@ class RuntimeRootResolutionTests(unittest.TestCase):
             self.assertEqual(lines[-2], str(package_root.resolve()))
             self.assertEqual(lines[-1], str(env_root))
 
-    def test_cmake_forces_ilp64_when_stale_cache_sets_lp64(self):
+    def test_cmake_rejects_lp64_from_stale_cache(self):
         source = (ROOT / "CMakeLists.txt").read_text()
 
-        self.assertIn("Forcing LINALG_LIB_INT64=ON", source)
-        self.assertIn("set(LINALG_LIB_INT64 ON CACHE BOOL", source)
-        self.assertIn("FORCE)", source)
+        # ILP64-only: a stale cache (or old script) carrying LINALG_LIB_INT64=OFF
+        # must fail the configure loudly instead of producing a mixed-width build.
+        self.assertIn("if(DEFINED LINALG_LIB_INT64 AND NOT LINALG_LIB_INT64)", source)
+        self.assertIn("LP64 (4-byte BLAS integer) support has been", source)
 
     def test_macos_cffi_extension_uses_package_local_liboqp(self):
         source = (ROOT / "pyoqp" / "CMakeLists.txt").read_text()
@@ -166,19 +167,18 @@ class RuntimeRootResolutionTests(unittest.TestCase):
         self.assertIn("types: [opened, synchronize, reopened, labeled, unlabeled]", source)
         self.assertIn("build_wheel_smoke:", source)
         self.assertIn(
-            "if: github.event_name == 'pull_request' && !contains("
-            "github.event.pull_request.labels.*.name, 'release')",
+            "!contains(github.event.pull_request.labels.*.name, 'release')",
             source,
         )
         self.assertNotIn("OQP_EXTERNALS_ROOT", source)
         self.assertIn("CIBW_BUILD: \"cp311-*\"", source)
         self.assertIn("path: .cache/openqp/externals", source)
-        self.assertIn("XDG_CACHE_HOME=\"$(pwd)/.cache\"", source)
+        self.assertIn("XDG_CACHE_HOME=/host-cache", source)
         self.assertIn("cache_path: ~/Library/Caches/openqp/externals", source)
         self.assertIn("build_wheels:", source)
+        self.assertIn("github.event_name == 'release'", source)
         self.assertIn(
-            "if: github.event_name != 'pull_request' || contains("
-            "github.event.pull_request.labels.*.name, 'release')",
+            "contains(github.event.pull_request.labels.*.name, 'release')",
             source,
         )
         self.assertIn("CIBW_BUILD: \"cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*\"", source)


### PR DESCRIPTION
## Summary

This PR makes OpenQP's BLAS/LAPACK selection **deterministic per platform** and its integer model **uniformly ILP64 (8-byte) on every platform**, fixing three classes of shipped breakage along the way. Three commits, reviewable independently:

### 1. `c1f8f4c` — Deterministic platform policy + integer-ABI fixes
- `LINALG_LIB=auto` now resolves to a **mandated native backend per OS/arch** (macOS → Apple Accelerate; Linux x86_64 → Intel MKL; Linux aarch64 → OpenBLAS) instead of probing whatever BLAS happens to be installed. Environment probing shipped NetLib reference BLAS in the PyPI Linux wheels and made CI test a different BLAS than users ran.
- **No silent NetLib fallback**: a missing backend fails the configure with instructions (`-DLINALG_LIB=netlib` / `-DOQP_ALLOW_REFERENCE_BLAS=ON` remain as explicit escape hatches).
- **`oqp_get_basis` integer-ABI fix**: the C API declares `int64_t**`, but the implementation exported `c_loc()` of internal default-width integer arrays. Python then read pairs of 32-bit values as single 64-bit integers — corrupted basis metadata (`centers [0,1]` came back as `[8589934592,-1]`) and an `IndexError` in the molden writer. Fixed on the Fortran side with int64 export buffers; the public API is width-stable.
- **NLOpt handle fix**: the f77-style opt handles were declared default `INTEGER`, but NLOpt stores a C pointer in them (documented `integer*8`). In 4-byte-integer builds `nlo_create()` wrote 8 bytes into 4-byte storage → stack corruption → "subprocess exit -11" in every PBE EDIIS/ADIIS test. Now `integer(kind=8)` regardless of build width.

### 2. `b24e98e` — Accelerate ILP64 backend + wheel/CI alignment
- macOS now uses **Accelerate's modern ILP64 interface** (macOS ≥ 13.3): all 163 BLAS/LAPACK symbols OpenQP references are interposed onto their `$NEWLAPACK$ILP64` variants via an ld alias-list at the liboqp link. Still zero bundled BLAS. A **post-build guard** (`cmake/check_accelerate_aliases.cmake`) fails the build naming any symbol that escaped interposition, so a future BLAS call missing from the list cannot silently run a 4-byte routine in an 8-byte build.
- **Linux wheels bundle an ILP64 OpenBLAS** (INTERFACE64=1, DYNAMIC_ARCH, built+cached in `CIBW_BEFORE_ALL`) instead of shipping NetLib. MKL cannot ship in PyPI wheels (size limits), so wheels pin OpenBLAS explicitly — exactly the BLAS CI tests.
- **Every wheel now runs a real numerical test** (`.github/scripts/wheel_smoke_test.py`): RHF/STO-3G h2 with exact-energy, molden-output, and basis-metadata-ABI asserts — the failure classes that previously shipped while `import oqp` still succeeded.
- **CI gains macOS coverage** (`macos-15` + `macos-15-intel`, previously none): pure-default builds so CI exercises the same resolution users hit, with an Accelerate-linkage assert and the full example suite.

### 3. `66d8a2a` — ILP64-only enforcement + macOS GCC auto-selection
- With uniform 8-byte verified everywhere, **all LP64 machinery is removed** (~a dozen conditionals across CMake, externals, workflows, docs). `LINALG_LIB_INT64` survives only as a **tombstone**: `=OFF` is a configure-time FATAL, so a stale CMake cache or old script cannot produce a mixed-width build. Genuine 32-bit C-ABI declarations (NLOpt return codes, tagarray metadata, ECP buffers) are deliberately kept — C `int` is 32-bit on every 64-bit platform; matching declared widths exactly is the correctness rule.
- **Bare `pip install .` on macOS now auto-selects the newest complete Homebrew GCC trio** (matched gcc/g++/gfortran versions). Previously pip's injected `CC=clang CXX=clang++` produced a mixed Clang/gfortran toolchain that links two OpenMP runtimes — and failed to configure. Explicit user choices (`-DCMAKE_*_COMPILER`, `FC`, versioned/absolute `CC`) always win.

## Verification

| Platform | Config (pure defaults) | Result |
|---|---|---|
| macOS arm64 (M3 Ultra) | Accelerate ILP64, GCC 15 auto-selected | 163/163 symbols interposed, 0 LP64 leaks; h2 energy `-1.1167593075` exact; **full suite 236: 234 passed, 0 failed, 0 errors** (was: 10 EDIIS/ADIIS crashes) |
| macOS x86_64 (Intel) | Accelerate ILP64 | interposition mechanism verified per-symbol on an Intel Mac; covered by the new `macos-15-intel` CI leg |
| Linux x86_64 | MKL ILP64 (`libmkl_gf_ilp64`) | h2 exact, molden clean |
| Linux x86_64/aarch64 CI | OpenBLAS ILP64 | existing legs, now exactly the BLAS the wheels bundle |

Ground-state SCF energy `-192.7715243456` Ha (methyloxirane/cc-pVTZ MRSF benchmark) identical across every machine and backend tested. Companion benchmark harness + per-host timing data (MKL 1.5×, Accelerate 1.66× vs NetLib): branch `blas-platform-autoselect`.

## Notes for reviewers

- The alias-list mechanism has two ld gotchas baked into comments: it must be a **file** (`-Wl,-alias_list`; inline `-Wl,-alias` gets the `$` shell-expanded away) and the format is `<real> <alias>` with the ILP64 symbol first.
- `ENABLE_DDX`/`ENABLE_OPENTRAH` link BLAS directly and are not yet wired for the interposition on macOS: the combination is refused at configure (both OFF by default) rather than allowed to bind LP64 symbols silently.
- Requires macOS ≥ 13.3 (`$NEWLAPACK$ILP64`); wheel deployment target is 15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
