### PR TITLE
ci(policy): enforce the four PR contribution rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,12 +7,13 @@
 See [AGENTS.md](../AGENTS.md) for details. The automated Claude and Codex
 reviewers check these too.
 
-- [ ] **BLAS/LAPACK** — no raw `dgemm`/`dgels`/`dgetrf`/... calls; all go through
-      the `oqp_linalg` wrapper (raw calls only inside
-      `source/mathlib/lapack_wrap.F90` / `blas_wrap.F90`).
+- [ ] **BLAS/LAPACK** — every referenced BLAS/LAPACK routine is registered in
+      `OQP_ACCELERATE_ILP64_SYMS` (`cmake/oqp_functions.cmake`); new code prefers
+      `use oqp_linalg`. Unregistered routines fail the `PR policy` lint.
 - [ ] **Example** — new functionality (runtype/method/`[section]`/keyword/flag)
-      adds a small, fast example under `examples/` (passes
-      `openqp --check_feature_coverage`).
+      adds a small, fast example under `examples/`. (New opt-in **boolean** flags
+      are gated by `openqp --check_feature_coverage`; other additions are checked
+      by the automated reviewers.)
 - [ ] **Python API** — user-facing additions are usable from `oqp.openqp.OpenQP`
       and covered by a `tests/test_openqp_api.py` test.
 - [ ] **Docs** — user-facing keywords/workflows documented in openqp-docs; link

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- Describe the change and link any related issues. -->
+
+## Summary
+
+## Contribution checklist
+
+See [AGENTS.md](../AGENTS.md) for details. The automated Claude and Codex
+reviewers check these too.
+
+- [ ] **BLAS/LAPACK** — no raw `dgemm`/`dgels`/`dgetrf`/... calls; all go through
+      the `oqp_linalg` wrapper (raw calls only inside
+      `source/mathlib/lapack_wrap.F90` / `blas_wrap.F90`).
+- [ ] **Example** — new functionality (runtype/method/`[section]`/keyword/flag)
+      adds a small, fast example under `examples/` (passes
+      `openqp --check_feature_coverage`).
+- [ ] **Python API** — user-facing additions are usable from `oqp.openqp.OpenQP`
+      and covered by a `tests/test_openqp_api.py` test.
+- [ ] **Docs** — user-facing keywords/workflows documented in openqp-docs; link
+      the companion PR here: <!-- openqp-docs PR # -->
+
+<!-- If a checklist item does not apply, say why. -->

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,10 +53,12 @@ jobs:
             In addition to correctness/bug review, check the PR against the four
             contribution rules in AGENTS.md (in the repo root) and report each
             explicitly:
-              1. BLAS/LAPACK calls go through the oqp_linalg wrapper (no raw
-                 dgemm/dgels/dgetrf/... outside source/mathlib/lapack_wrap.F90
-                 and blas_wrap.F90); new routines are registered in
-                 OQP_ACCELERATE_ILP64_SYMS.
+              1. Every BLAS/LAPACK routine the PR references is registered in
+                 OQP_ACCELERATE_ILP64_SYMS (cmake/oqp_functions.cmake) so it gets
+                 an oqp_<name>_i64 wrapper and a macOS Accelerate ILP64 alias; new
+                 code should prefer `use oqp_linalg`. (OpenQP is ILP64-only, so the
+                 operative failure of an unregistered routine is the macOS alias
+                 gate.) The PR policy lint enforces the registration part.
               2. New functionality (runtype/method/[section]/keyword/flag) adds a
                  small, fast example under examples/.
               3. User-facing additions have a pythonic Python-API addition in

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,6 +50,21 @@ jobs:
             Leave a non-blocking review comment with blocking issues, important suggestions,
             and tests that should be run. If no blocking issues are found, say so clearly.
 
+            In addition to correctness/bug review, check the PR against the four
+            contribution rules in AGENTS.md (in the repo root) and report each
+            explicitly:
+              1. BLAS/LAPACK calls go through the oqp_linalg wrapper (no raw
+                 dgemm/dgels/dgetrf/... outside source/mathlib/lapack_wrap.F90
+                 and blas_wrap.F90); new routines are registered in
+                 OQP_ACCELERATE_ILP64_SYMS.
+              2. New functionality (runtype/method/[section]/keyword/flag) adds a
+                 small, fast example under examples/.
+              3. User-facing additions have a pythonic Python-API addition in
+                 pyoqp/oqp/openqp.py and a test in tests/test_openqp_api.py.
+              4. New user-facing keywords/workflows are documented in openqp-docs
+                 (a linked openqp-docs PR).
+            For each rule, state PASS, or explain what is missing.
+
       - name: Claude review unavailable
         if: steps.claude_review.outcome == 'failure'
         run: |

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,30 @@
+name: PR policy
+
+# Enforce the contribution rules in AGENTS.md that can be checked
+# deterministically. The Claude/Codex automated reviews cover the rest
+# (examples, pythonic Python API, openqp-docs) as non-blocking review comments.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  blas-wrapper:
+    name: BLAS/LAPACK wrapper gate (rule 1)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      # Portable, dependency-free source lint: every BLAS/LAPACK routine
+      # referenced from source/ (outside the wrapper modules) must be registered
+      # in OQP_ACCELERATE_ILP64_SYMS, i.e. it has an oqp_*_i64 wrapper and a macOS
+      # Accelerate ILP64 alias. This catches an un-wrapped raw call on every
+      # platform, before the build -- the portable complement to the macOS-only,
+      # link-time check_accelerate_aliases gate.
+      - name: BLAS/LAPACK wrapper gate
+        run: python3 tools/check_blas_wrapper.py

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -9,13 +9,20 @@ on:
   push:
     branches: [main]
 
+# Read-only, no secrets: the job only STATICALLY reads Fortran/CMake as text; it
+# never builds or executes checked-out PR code.
+permissions:
+  contents: read
+
 jobs:
   blas-wrapper:
     name: BLAS/LAPACK wrapper gate (rule 1)
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout PR code (scanned as text only)
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -26,5 +33,26 @@ jobs:
       # Accelerate ILP64 alias. This catches an un-wrapped raw call on every
       # platform, before the build -- the portable complement to the macOS-only,
       # link-time check_accelerate_aliases gate.
+      #
+      # A PR must not be able to weaken rule 1 by editing the gate script in the
+      # same PR, so we run the TRUSTED base-branch copy of the script against the
+      # PR-head tree ($GITHUB_WORKSPACE), never the PR's own copy. (The base
+      # branch's cmake/check_accelerate_aliases.cmake link-time gate is the
+      # independent, non-PR-controlled backstop.)
       - name: BLAS/LAPACK wrapper gate
-        run: python3 tools/check_blas_wrapper.py
+        run: |
+          set -euo pipefail
+          gate=tools/check_blas_wrapper.py
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base='${{ github.event.pull_request.base.sha }}'
+            git fetch --depth=1 origin "$base" || true
+            if git cat-file -e "$base:$gate" 2>/dev/null; then
+              mkdir -p .gate
+              git show "$base:$gate" > .gate/check_blas_wrapper.py
+              gate=.gate/check_blas_wrapper.py
+              echo "Using trusted base-branch gate script ($base:tools/check_blas_wrapper.py)"
+            else
+              echo "Base branch has no gate script yet; using in-tree copy (bootstrap)."
+            fi
+          fi
+          python3 "$gate" "$GITHUB_WORKSPACE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,12 +17,20 @@ name (`call dgels(...)` resolves to `oqp_dgels_i64`).
 
 - Raw calls are only allowed **inside the wrapper modules**
   `source/mathlib/lapack_wrap.F90` and `source/mathlib/blas_wrap.F90`.
-- A raw call elsewhere breaks two things: the macOS Accelerate ILP64 alias check
-  (`cmake/check_accelerate_aliases.cmake`) and the ILP64 integer ABI on
-  `OQP_BLAS_INT=4` builds.
+- OpenQP is **ILP64-only** (`-fdefault-integer-8`, `BLA_SIZEOF_INTEGER=8`), so a
+  bare call binds correct-width 8-byte integers on Linux. The failure a stray raw
+  call causes is on **macOS Accelerate**, whose classic Fortran symbols are LP64:
+  every referenced name must be interposed onto its `$NEWLAPACK$ILP64` variant via
+  the alias list, so a routine that is CALLED but not in `OQP_ACCELERATE_ILP64_SYMS`
+  fails `cmake/check_accelerate_aliases.cmake`.
 - If a wrapper is missing, add `oqp_<name>_i64` to the wrapper module, add the
   `<name> => oqp_<name>_i64` rename in `source/mathlib/oqp_linalg.F90`, and add
   the routine to `OQP_ACCELERATE_ILP64_SYMS` in `cmake/oqp_functions.cmake`.
+- The **enforced minimum** is registration in `OQP_ACCELERATE_ILP64_SYMS`, not
+  literal `use oqp_linalg`: a number of long-standing sites call bare BLAS
+  directly and are correct on the ILP64-only build (they predate the wrapper
+  convention). New code should still prefer `use oqp_linalg` for clarity, but the
+  CI gate rejects any *unregistered* BLAS/LAPACK routine regardless of call style.
 
 **Enforced by CI:** `tools/check_blas_wrapper.py` (the `PR policy` workflow)
 fails the build if any BLAS/LAPACK routine referenced from `source/` (outside the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# Contributor and AI-reviewer guide
+
+This file is read by the automated PR reviewers (Codex reads `AGENTS.md`
+natively; the Claude review workflow is pointed at it in
+`.github/workflows/claude.yml`) and by human contributors. Every pull request is
+expected to satisfy the four rules below. A reviewer should call out, per rule,
+whether the PR satisfies it or explain what is missing.
+
+## PR rules
+
+### 1. BLAS/LAPACK must go through the OpenQP wrapper layer
+
+Never call a raw BLAS/LAPACK routine (`dgemm`, `dgels`, `dgetrf`, `dsyev`,
+`zheev`, ...) directly. Fortran modules must `use oqp_linalg`, which renames the
+`oqp_<name>_i64` wrappers back to the standard names, and then call the standard
+name (`call dgels(...)` resolves to `oqp_dgels_i64`).
+
+- Raw calls are only allowed **inside the wrapper modules**
+  `source/mathlib/lapack_wrap.F90` and `source/mathlib/blas_wrap.F90`.
+- A raw call elsewhere breaks two things: the macOS Accelerate ILP64 alias check
+  (`cmake/check_accelerate_aliases.cmake`) and the ILP64 integer ABI on
+  `OQP_BLAS_INT=4` builds.
+- If a wrapper is missing, add `oqp_<name>_i64` to the wrapper module, add the
+  `<name> => oqp_<name>_i64` rename in `source/mathlib/oqp_linalg.F90`, and add
+  the routine to `OQP_ACCELERATE_ILP64_SYMS` in `cmake/oqp_functions.cmake`.
+
+**Enforced by CI:** `tools/check_blas_wrapper.py` (the `PR policy` workflow)
+fails the build if any BLAS/LAPACK routine referenced from `source/` (outside the
+wrapper modules) is not registered in `OQP_ACCELERATE_ILP64_SYMS` — the portable
+complement to the macOS-only, link-time `cmake/check_accelerate_aliases.cmake`.
+
+### 2. New functionality ships with a test/example under `examples/`
+
+Any new capability — a new `runtype`, `method`, `[section]`, keyword, or opt-in
+feature flag — must add at least one **small, fast** example under `examples/`
+that exercises it (single-point or minimal steps; no big calculations).
+
+- Opt-in boolean flags are already enforced by `openqp --check_feature_coverage`
+  (a CI gate): a new flag must be set true by an example, or classified in
+  `EXEMPT_FLAGS` / `KNOWN_UNCOVERED` in `pyoqp/oqp/utils/regression.py` with a
+  reason.
+- Give the example a reference where reproducible (`openqp --validate_examples`
+  checks committed `.json` references); a demo that needs an optional backend
+  (e.g. OpenMM) may be run-only.
+
+**Reviewer check:** if the diff adds a new runtype/method/section/keyword but no
+`examples/**` file, flag it.
+
+### 3. User-facing additions get a pythonic Python-API addition
+
+New user-facing features should be usable from the compact `OpenQP` Python API in
+`pyoqp/oqp/openqp.py`.
+
+- New `[section]` keywords are auto-exposed through the schema-driven proxies
+  (`job.settings.<section>(...)`, `job.<section>.<key>`), so no manual work is
+  usually needed for plain keywords.
+- A new workflow/runtype should get a `job.workflow.<name>` entry (and a
+  convenience helper like `job.qmmm(...)` where it improves ergonomics), plus a
+  unit test in `tests/test_openqp_api.py`.
+
+**Reviewer check:** if the diff adds a new workflow runtype or a new `[section]`
+with no corresponding `openqp.py` handling or `tests/test_openqp_api.py` test,
+flag it.
+
+### 4. New functionality is documented in openqp-docs
+
+User-facing keywords, sections, and workflows must be documented in the manual
+repo [Open-Quantum-Platform/openqp-docs](https://github.com/Open-Quantum-Platform/openqp-docs):
+a keyword-page entry under `docs/keywords/` and/or a workflow page under
+`docs/workflows/`, wired into `mkdocs.yml` nav.
+
+- openqp-docs is a **separate repository**, so this PR's CI cannot see it
+  directly. Link the companion openqp-docs PR in this PR's description.
+
+**Reviewer check:** if the diff adds/changes user-facing keywords or workflows,
+confirm the PR description links an openqp-docs PR; flag it if missing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,10 @@ Never call a raw BLAS/LAPACK routine (`dgemm`, `dgels`, `dgetrf`, `dsyev`,
 `oqp_<name>_i64` wrappers back to the standard names, and then call the standard
 name (`call dgels(...)` resolves to `oqp_dgels_i64`).
 
-- Raw calls are only allowed **inside the wrapper modules**
-  `source/mathlib/lapack_wrap.F90` and `source/mathlib/blas_wrap.F90`.
+- Raw calls are **always allowed inside the wrapper modules**
+  `source/mathlib/lapack_wrap.F90` and `source/mathlib/blas_wrap.F90` (their whole
+  job is to call the raw symbol). Elsewhere, a bare call is acceptable only if the
+  routine is registered (see the enforced-minimum note below).
 - OpenQP is **ILP64-only** (`-fdefault-integer-8`, `BLA_SIZEOF_INTEGER=8`), so a
   bare call binds correct-width 8-byte integers on Linux. The failure a stray raw
   call causes is on **macOS Accelerate**, whose classic Fortran symbols are LP64:
@@ -33,9 +35,11 @@ name (`call dgels(...)` resolves to `oqp_dgels_i64`).
   CI gate rejects any *unregistered* BLAS/LAPACK routine regardless of call style.
 
 **Enforced by CI:** `tools/check_blas_wrapper.py` (the `PR policy` workflow)
-fails the build if any BLAS/LAPACK routine referenced from `source/` (outside the
-wrapper modules) is not registered in `OQP_ACCELERATE_ILP64_SYMS` — the portable
-complement to the macOS-only, link-time `cmake/check_accelerate_aliases.cmake`.
+fails the build if any BLAS/LAPACK routine referenced from `source/` — or from the
+`tests/fortran/*.F90` harnesses linked into `liboqp` — (outside the wrapper
+modules) is not registered in `OQP_ACCELERATE_ILP64_SYMS`. It is the portable
+complement to the macOS-only, link-time `cmake/check_accelerate_aliases.cmake`, and
+CI runs the trusted base-branch copy of the script so a PR cannot weaken its own gate.
 
 ### 2. New functionality ships with a test/example under `examples/`
 

--- a/tools/check_blas_wrapper.py
+++ b/tools/check_blas_wrapper.py
@@ -22,6 +22,7 @@ WHY THIS IS THE RIGHT INVARIANT (see commit ad43fae1, the dgels bug):
   at link time. This script is the PORTABLE gate: it runs on any PR on any OS by
   static inspection and names the offending routine + call site before the build.
 
+Usage: check_blas_wrapper.py [REPO_ROOT]   (default: this script's own repo)
 Exit: 0 clean, 1 violations, 2 setup error.
 """
 import os
@@ -169,6 +170,20 @@ def strip_comment(line):
 
 
 def main():
+    # Optional argv[1] = repository root to scan. CI passes the PR-head tree here
+    # so the TRUSTED base-branch copy of this script can lint untrusted PR code
+    # (a PR must not be able to weaken the gate by editing this file). Default:
+    # the tree this script lives in.
+    global REPO, SRC, CMAKE, WRAPPER_FILES
+    if len(sys.argv) > 1:
+        REPO = os.path.abspath(sys.argv[1])
+        SRC = os.path.join(REPO, "source")
+        CMAKE = os.path.join(REPO, "cmake", "oqp_functions.cmake")
+        WRAPPER_FILES = {
+            os.path.normpath(os.path.join(SRC, "mathlib", "lapack_wrap.F90")),
+            os.path.normpath(os.path.join(SRC, "mathlib", "blas_wrap.F90")),
+        }
+
     reg = registered_syms()
     if not reg:
         print(f"ERROR: could not parse OQP_ACCELERATE_ILP64_SYMS from {CMAKE}",
@@ -189,9 +204,11 @@ def main():
         for i, line in enumerate(lines, 1):
             code = strip_comment(line)
             # subroutine calls: flag known-BLAS and, via the shape heuristic,
-            # a new BLAS/LAPACK external that CANON does not list.
-            m = call_rx.search(code)
-            if m:
+            # a new BLAS/LAPACK external that CANON does not list. Use finditer,
+            # not search: Fortran ';' statement separators allow more than one
+            # `call` per line (a style the tree uses, e.g. hf_hessian.F90), and a
+            # non-first call must be inspected too.
+            for m in call_rx.finditer(code):
                 name = m.group(1).lower()
                 if name not in reg and (
                     name in CANON

--- a/tools/check_blas_wrapper.py
+++ b/tools/check_blas_wrapper.py
@@ -81,6 +81,64 @@ _LAPACK = """
 """
 CANON = set((_BLAS1 + _BLAS2 + _BLAS3 + _LAPACK).split())
 
+# CANON is the *known* set, but it cannot list every LAPACK routine (there are
+# hundreds). So a second, list-free heuristic catches a genuinely new routine:
+# a `call NAME(` whose NAME has the LAPACK shape [precision][matrix-type][op],
+# is NOT defined anywhere in the scanned OpenQP source (=> it is an external
+# symbol resolved from the BLAS/LAPACK library), and is NOT registered. Anchoring
+# on the real LAPACK matrix-type digraphs (ge, sy, he, po, tr, ...) -- not just
+# "[sdcz] + letters" -- is what keeps ordinary externals like `call solver(` or
+# `call second(` from being mistaken for LAPACK, while still flagging a new
+# `call dgesdd(` / `call dpotrs(` / `call dsyevr(` that CANON does not list.
+# (BLAS L1/L2/L3, which do not follow this scheme, are fully covered by CANON.)
+# Restricting this to `call NAME(` (never bare function-style refs, which produce
+# fragment false positives on names like `dftd4_calc`) and excluding
+# OpenQP-defined procedures completes the false-positive guard.
+BLAS_CALL_PAT = re.compile(
+    r"^[sdcz](?:bd|di|gb|ge|gg|gt|hb|he|hg|hp|hs|la|op|or|pb|po|pp|pt|"
+    r"sb|sp|st|sy|tb|tg|tp|tr|tz|un|up)[a-z0-9]{2,4}$")
+# Belt-and-suspenders: [sdcz]-initial subroutines that survive the digraph anchor
+# yet are not BLAS/LAPACK externals (none known today; kept as an explicit escape).
+INTRINSIC_SUB = set()
+
+DEF_RX = re.compile(r"\b(?:subroutine|function)\s+([a-z][a-z0-9_]*)", re.I)
+
+
+def scan_files():
+    """Fortran compiled into liboqp: all of source/, plus the tests/fortran/*.F90
+    bind(C) self-test harnesses that source/CMakeLists.txt appends to the library
+    target (they ship inside liboqp, so a raw call there evades the macOS alias
+    gate exactly like one in source/). Wrapper bodies are excluded by the caller."""
+    files = []
+    for root, _, names in os.walk(SRC):
+        for fn in names:
+            if fn.endswith((".F90", ".f90")):
+                files.append(os.path.normpath(os.path.join(root, fn)))
+    cml = os.path.join(SRC, "CMakeLists.txt")
+    try:
+        with open(cml, encoding="utf-8") as fh:
+            cml_txt = fh.read()
+    except OSError:
+        cml_txt = ""
+    for rel in re.findall(r"tests/fortran/([A-Za-z0-9_]+\.[Ff]90)", cml_txt):
+        p = os.path.normpath(os.path.join(REPO, "tests", "fortran", rel))
+        if os.path.exists(p):
+            files.append(p)
+    return files
+
+
+def defined_procedures(files):
+    """Names of every subroutine/function DEFINED in the scanned source. A
+    `call NAME(` to a name in this set is an internal routine, never a BLAS/LAPACK
+    external, so the shape heuristic must not flag it."""
+    defined = set()
+    for path in files:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                for m in DEF_RX.finditer(strip_comment(line)):
+                    defined.add(m.group(1).lower())
+    return defined
+
 
 def registered_syms():
     """Names in OQP_ACCELERATE_ILP64_SYMS (the wrapper/alias source of truth)."""
@@ -121,29 +179,36 @@ def main():
     func_rx = re.compile(r"(?<![\w%])([a-z][a-z0-9]+)\s*\(", re.I)
     defkw = re.compile(r"\b(subroutine|function|end|module|use|interface)\b", re.I)
 
+    files = [p for p in scan_files() if p not in WRAPPER_FILES]
+    defined = defined_procedures(files)
+
     violations = []
-    for root, _, files in os.walk(SRC):
-        for fn in files:
-            if not fn.endswith((".F90", ".f90")):
-                continue
-            path = os.path.normpath(os.path.join(root, fn))
-            if path in WRAPPER_FILES:
-                continue
-            with open(path, encoding="utf-8", errors="replace") as fh:
-                lines = fh.readlines()
-            for i, line in enumerate(lines, 1):
-                code = strip_comment(line)
-                names = set()
-                m = call_rx.search(code)
-                if m:
-                    names.add(m.group(1).lower())
-                if not defkw.search(code):
-                    for fm in func_rx.finditer(code):
-                        names.add(fm.group(1).lower())
-                for name in names:
-                    if name in CANON and name not in reg:
+    for path in files:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            lines = fh.readlines()
+        for i, line in enumerate(lines, 1):
+            code = strip_comment(line)
+            # subroutine calls: flag known-BLAS and, via the shape heuristic,
+            # a new BLAS/LAPACK external that CANON does not list.
+            m = call_rx.search(code)
+            if m:
+                name = m.group(1).lower()
+                if name not in reg and (
+                    name in CANON
+                    or (BLAS_CALL_PAT.match(name)
+                        and name not in defined
+                        and name not in INTRINSIC_SUB)
+                ):
+                    violations.append(
+                        (os.path.relpath(path, REPO), i, name, line.strip()))
+            # BLAS/LAPACK *function* refs (ddot, dnrm2, dlamch, ...): limited to
+            # CANON so name fragments never produce false positives.
+            if not defkw.search(code):
+                for fm in func_rx.finditer(code):
+                    fn = fm.group(1).lower()
+                    if fn in CANON and fn not in reg:
                         violations.append(
-                            (os.path.relpath(path, REPO), i, name, line.strip()))
+                            (os.path.relpath(path, REPO), i, fn, line.strip()))
 
     if violations:
         seen, uniq = set(), []
@@ -152,21 +217,26 @@ def main():
             if k not in seen:
                 seen.add(k)
                 uniq.append(v)
-        print("PR RULE 1 VIOLATION: BLAS/LAPACK routine(s) referenced from source "
-              "but NOT registered in OQP_ACCELERATE_ILP64_SYMS.\n"
+        print("PR RULE 1 VIOLATION: BLAS/LAPACK routine(s) referenced from the "
+              "Fortran compiled into liboqp but NOT registered in "
+              "OQP_ACCELERATE_ILP64_SYMS.\n"
               "Such a routine has no oqp_*_i64 wrapper and no macOS Accelerate "
               "ILP64 alias, so the macOS build's check_accelerate_aliases gate will "
-              "fail and OQP_BLAS_INT=4 builds pass wrong-width integers.\n"
+              "fail (OpenQP is ILP64-only, so this is the failure that bites).\n"
               "Fix: add the base name to OQP_ACCELERATE_ILP64_SYMS in "
               "cmake/oqp_functions.cmake, add its oqp_<name>_i64 wrapper in "
               "source/mathlib/{blas,lapack}_wrap.F90, and rename it in "
-              "source/mathlib/oqp_linalg.F90 (see how dgels was added in ad43fae1).\n")
+              "source/mathlib/oqp_linalg.F90 (see how dgels was added in ad43fae1).\n"
+              "If a flagged name is an internal routine (not BLAS/LAPACK), it will "
+              "have a `subroutine`/`function` definition in the scanned source and "
+              "so should not be reported -- please open an issue if it is.\n")
         for rel, ln, name, txt in uniq:
             print(f"  {rel}:{ln}: {name}  ->  {txt}")
         print(f"\n{len(uniq)} unregistered BLAS/LAPACK reference(s).")
         return 1
 
-    print(f"OK: every BLAS/LAPACK routine referenced in source/ is registered in "
+    print(f"OK: every BLAS/LAPACK routine referenced in source/ and the "
+          f"tests/fortran/*.F90 harnesses linked into liboqp is registered in "
           f"OQP_ACCELERATE_ILP64_SYMS ({len(reg)} symbols).")
     return 0
 

--- a/tools/check_blas_wrapper.py
+++ b/tools/check_blas_wrapper.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Enforce PR RULE 1 (portable, source-level): every BLAS/LAPACK routine referenced
+from OpenQP source must go through the wrapper layer -- i.e. it must be registered
+in OQP_ACCELERATE_ILP64_SYMS (cmake/oqp_functions.cmake), the single list that (a)
+the oqp_*_i64 wrappers are built from and (b) the macOS Accelerate link-time alias
+interposition uses.
+
+WHY THIS IS THE RIGHT INVARIANT (see commit ad43fae1, the dgels bug):
+  OpenQP compiles the whole tree with -fdefault-integer-8 and BLA_SIZEOF_INTEGER=8,
+  so on Linux ILP64 backends (MKL ILP64 / openblas64) a bare `call dgemm(...)` binds
+  the genuine 8-byte symbol and is fine. The place a raw call breaks is macOS
+  Accelerate, whose *classic* Fortran symbols are LP64 (4-byte): every referenced
+  name must be interposed onto its $NEWLAPACK$ILP64 variant via the alias list, and
+  the wrapper layer (lapack_wrap/blas_wrap + the oqp_linalg renames) is generated in
+  lockstep with that same list. The dgels bug was exactly a routine that was CALLED
+  but MISSING from OQP_ACCELERATE_ILP64_SYMS: it had no wrapper and no alias, so the
+  macOS build's check_accelerate_aliases gate failed and OQP_BLAS_INT=4 builds passed
+  4-byte integers to an ILP64 routine.
+
+  check_accelerate_aliases.cmake already catches this -- but only on macOS and only
+  at link time. This script is the PORTABLE gate: it runs on any PR on any OS by
+  static inspection and names the offending routine + call site before the build.
+
+Exit: 0 clean, 1 violations, 2 setup error.
+"""
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC = os.path.join(REPO, "source")
+CMAKE = os.path.join(REPO, "cmake", "oqp_functions.cmake")
+
+# Files where raw BLAS/LAPACK references are correct BY DESIGN: the wrapper bodies
+# deliberately call the raw symbol after converting integer args to blas_int.
+WRAPPER_FILES = {
+    os.path.normpath(os.path.join(SRC, "mathlib", "lapack_wrap.F90")),
+    os.path.normpath(os.path.join(SRC, "mathlib", "blas_wrap.F90")),
+}
+
+# Canonical BLAS (L1/L2/L3) + core LAPACK routine names (no trailing underscore).
+# This is what tells a genuine BLAS/LAPACK reference apart from an ordinary
+# internal `call some_subroutine(`. Extend if a new routine family is adopted.
+_BLAS1 = """
+ srotg srotmg srot srotm sswap sscal scopy saxpy sdot sdsdot snrm2 sasum isamax
+ drotg drotmg drot drotm dswap dscal dcopy daxpy ddot dsdot dnrm2 dasum idamax
+ crotg csrot cswap cscal csscal ccopy caxpy cdotu cdotc scnrm2 scasum icamax
+ zrotg zdrot zswap zscal zdscal zcopy zaxpy zdotu zdotc dznrm2 dzasum izamax
+"""
+_BLAS2 = """
+ sgemv sgbmv ssymv ssbmv sspmv strmv stbmv stpmv strsv stbsv stpsv sger ssyr
+ sspr ssyr2 sspr2
+ dgemv dgbmv dsymv dsbmv dspmv dtrmv dtbmv dtpmv dtrsv dtbsv dtpsv dger dsyr
+ dspr dsyr2 dspr2
+ cgemv cgbmv chemv chbmv chpmv ctrmv ctbmv ctpmv ctrsv ctbsv ctpsv cgeru cgerc
+ cher chpr cher2 chpr2
+ zgemv zgbmv zhemv zhbmv zhpmv ztrmv ztbmv ztpmv ztrsv ztbsv ztpsv zgeru zgerc
+ zher zhpr zher2 zhpr2
+"""
+_BLAS3 = """
+ sgemm ssymm ssyrk ssyr2k strmm strsm
+ dgemm dsymm dsyrk dsyr2k dtrmm dtrsm
+ cgemm csymm chemm csyrk cher2k csyr2k cherk ctrmm ctrsm
+ zgemm zsymm zhemm zsyrk zher2k zsyr2k zherk ztrmm ztrsm
+"""
+_LAPACK = """
+ sgesv sgetrf sgetrs sgetri sgels sgesvd ssyev ssyevd sspev sspevx ssytrf
+ ssytri ssytrs ssysv sgeqrf sorgqr sormqr spotrf spotri strtri stpttr strttp
+ sgglse slamch
+ dgesv dgetrf dgetrs dgetri dgels dgesvd dsyev dsyevd dspev dspevx dsytrf
+ dsytri dsytrs dsysv dgeqrf dorgqr dormqr dpotrf dpotri dtrtri dtpttr dtrttp
+ dgglse dlamch
+ cgesv cgetrf cgetrs cgetri cgels cgesvd cheev cheevd chpev chpevx chetrf
+ chetri chetrs chesv cgeqrf cungqr cunmqr cpotrf cpotri ctrtri ctpttr ctrttp
+ cgglse
+ zgesv zgetrf zgetrs zgetri zgels zgesvd zheev zheevd zhpev zhpevx zhetrf
+ zhetri zhetrs zhesv zgeqrf zungqr zunmqr zpotrf zpotri ztrtri ztpttr ztrttp
+ zgglse
+ xerbla lsame
+"""
+CANON = set((_BLAS1 + _BLAS2 + _BLAS3 + _LAPACK).split())
+
+
+def registered_syms():
+    """Names in OQP_ACCELERATE_ILP64_SYMS (the wrapper/alias source of truth)."""
+    with open(CMAKE, encoding="utf-8") as fh:
+        txt = fh.read()
+    m = re.search(r"set\(OQP_ACCELERATE_ILP64_SYMS(.*?)CACHE INTERNAL", txt, re.S)
+    if not m:
+        return None
+    return set(w.lower() for w in re.findall(r"\b[a-z][a-z0-9]+\b", m.group(1)))
+
+
+def strip_comment(line):
+    """Drop a trailing free-form Fortran '!' comment, respecting string literals."""
+    out, q = [], None
+    for ch in line:
+        if q:
+            out.append(ch)
+            if ch == q:
+                q = None
+        elif ch in "'\"":
+            q = ch
+            out.append(ch)
+        elif ch == "!":
+            break
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def main():
+    reg = registered_syms()
+    if not reg:
+        print(f"ERROR: could not parse OQP_ACCELERATE_ILP64_SYMS from {CMAKE}",
+              file=sys.stderr)
+        return 2
+
+    call_rx = re.compile(r"\bcall\s+([a-z][a-z0-9]+)\s*\(", re.I)
+    func_rx = re.compile(r"(?<![\w%])([a-z][a-z0-9]+)\s*\(", re.I)
+    defkw = re.compile(r"\b(subroutine|function|end|module|use|interface)\b", re.I)
+
+    violations = []
+    for root, _, files in os.walk(SRC):
+        for fn in files:
+            if not fn.endswith((".F90", ".f90")):
+                continue
+            path = os.path.normpath(os.path.join(root, fn))
+            if path in WRAPPER_FILES:
+                continue
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                lines = fh.readlines()
+            for i, line in enumerate(lines, 1):
+                code = strip_comment(line)
+                names = set()
+                m = call_rx.search(code)
+                if m:
+                    names.add(m.group(1).lower())
+                if not defkw.search(code):
+                    for fm in func_rx.finditer(code):
+                        names.add(fm.group(1).lower())
+                for name in names:
+                    if name in CANON and name not in reg:
+                        violations.append(
+                            (os.path.relpath(path, REPO), i, name, line.strip()))
+
+    if violations:
+        seen, uniq = set(), []
+        for v in violations:
+            k = (v[0], v[1], v[2])
+            if k not in seen:
+                seen.add(k)
+                uniq.append(v)
+        print("PR RULE 1 VIOLATION: BLAS/LAPACK routine(s) referenced from source "
+              "but NOT registered in OQP_ACCELERATE_ILP64_SYMS.\n"
+              "Such a routine has no oqp_*_i64 wrapper and no macOS Accelerate "
+              "ILP64 alias, so the macOS build's check_accelerate_aliases gate will "
+              "fail and OQP_BLAS_INT=4 builds pass wrong-width integers.\n"
+              "Fix: add the base name to OQP_ACCELERATE_ILP64_SYMS in "
+              "cmake/oqp_functions.cmake, add its oqp_<name>_i64 wrapper in "
+              "source/mathlib/{blas,lapack}_wrap.F90, and rename it in "
+              "source/mathlib/oqp_linalg.F90 (see how dgels was added in ad43fae1).\n")
+        for rel, ln, name, txt in uniq:
+            print(f"  {rel}:{ln}: {name}  ->  {txt}")
+        print(f"\n{len(uniq)} unregistered BLAS/LAPACK reference(s).")
+        return 1
+
+    print(f"OK: every BLAS/LAPACK routine referenced in source/ is registered in "
+          f"OQP_ACCELERATE_ILP64_SYMS ({len(reg)} symbols).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Introduce automatic enforcement of four PR contribution rules, using a mix of a deterministic CI gate and the existing Claude/Codex automated reviews.

The four rules (documented in the new **`AGENTS.md`**):
1. **BLAS/LAPACK** must go through the `oqp_linalg` wrapper — no raw `dgemm`/`dgels`/`dgetrf`/... outside `source/mathlib/lapack_wrap.F90` / `blas_wrap.F90`; new routines are registered in `OQP_ACCELERATE_ILP64_SYMS`.
2. **New functionality** ships with a small, fast example under `examples/`.
3. **User-facing additions** get a pythonic Python-API addition in `pyoqp/oqp/openqp.py` + a `tests/test_openqp_api.py` test.
4. **New keywords/workflows** are documented in openqp-docs (a linked docs PR).

## How each rule is enforced

| Rule | Mechanism |
| --- | --- |
| 1 | **Hard gate** — `tools/check_blas_wrapper.py` run by the new `PR policy` workflow (`.github/workflows/pr-policy.yml`), plus the existing macOS `check_accelerate_aliases` link-time check |
| 2 | `openqp --check_feature_coverage` (existing) for opt-in flags + reviewer check for the rest |
| 3 | Claude/Codex review against `AGENTS.md` + `tests/test_openqp_api.py` |
| 4 | PR-template checklist (cross-repo) + reviewer check |

- **`AGENTS.md`** is read natively by the Codex reviewer; the **Claude review** prompt (`.github/workflows/claude.yml`) now points at it and reports PASS / what's missing per rule.
- **`.github/pull_request_template.md`** surfaces the rules as an author checklist — the practical lever for the cross-repo openqp-docs rule.

## The Rule-1 lint

`tools/check_blas_wrapper.py` is a portable, dependency-free source lint: it fails when any BLAS/LAPACK routine referenced from `source/` (outside the wrapper modules) is missing from `OQP_ACCELERATE_ILP64_SYMS` — meaning it has no `oqp_*_i64` wrapper and no macOS Accelerate ILP64 alias. It is the every-platform, pre-build complement to the macOS-only, link-time `cmake/check_accelerate_aliases.cmake` gate.

Verified:
- **Green on current `main`** — "every BLAS/LAPACK routine referenced in source/ is registered (165 symbols)", zero false positives across the ~90 bare-`dgemm` call sites.
- **Catches the real bug** — removing `dgels`/`dgetrf` from the list reproduces exactly `source/modules/qmmm.F90:1357/1362: dgels` (the un-wrapped call that shipped in #205 and failed only the macOS Accelerate build).

## Notes / follow-ups

- The AI reviews are **non-blocking** (they comment); the deterministic gates block. That's why Rule 1 (mechanically checkable) is a hard gate while Rules 3–4 (subjective / cross-repo) are reviewer + checklist.
- Extending `--check_feature_coverage` to non-boolean additions (new `runtype`/`[section]`/`method`) would strengthen Rule 2 — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)