### PR TITLE
fix(qmmm): sort qm_atoms into topology order so QM forces scatter correctly

### DIFF
--- a/pyoqp/oqp/library/qmmm_driver.py
+++ b/pyoqp/oqp/library/qmmm_driver.py
@@ -459,7 +459,11 @@ class OpenQpQMMM:
         self.positions = positions
         self.topology = topology
         self.mm_systems = mm_systems
-        self.qm_atoms = qm_atoms
+        # Re-normalize to ascending (topology) order on every call: callers
+        # (e.g. QMMM_MD) pass their own config-order qm_atoms here, which would
+        # otherwise overwrite the sorted copy set in __init__ and reintroduce the
+        # force mis-scatter this fix prevents. See __init__ for the rationale.
+        self.qm_atoms = np.array(sorted(int(i) for i in qm_atoms), dtype=int)
 
         potmm = potqm = None
         if self.Embedding in ("electrostatic", "split") or self.espf_full:

--- a/pyoqp/oqp/library/qmmm_driver.py
+++ b/pyoqp/oqp/library/qmmm_driver.py
@@ -130,7 +130,17 @@ class OpenQpQMMM:
         self.positions = positions
         self.topology = topology
         self.forcefield = forcefield
-        self.qm_atoms = np.array(qm_atoms, dtype=int)
+        # Sort the QM selection into ascending (topology) order. The QM geometry
+        # handed to the engine is built by iterating self.topology.atoms() filtered
+        # by membership (i.e. topology order), so gqm / f_qm / pchg come back in
+        # topology order. The force-scatter loops in _assemble_force / _assemble_
+        # force_espf and the link-atom host_row projection index those arrays by
+        # position in self.qm_atoms; if qm_atoms were given out of order (e.g.
+        # "5,2,7") those positions would not match topology order and QM gradients,
+        # coupling forces, and link-atom projections would land on the wrong atoms.
+        # Sorting makes input order == topology order without changing the QM
+        # calculation (the engine already sees the atoms in topology order).
+        self.qm_atoms = np.array(sorted(int(i) for i in qm_atoms), dtype=int)
         self.Cutoff = Cutoff
         self.Embedding = Embedding
 

--- a/tests/test_qmmm_qm_atoms_order.py
+++ b/tests/test_qmmm_qm_atoms_order.py
@@ -1,0 +1,48 @@
+"""Regression test: the QM/MM driver normalizes qm_atoms into topology order.
+
+The QM geometry handed to the engine is built in topology (ascending atom.index)
+order, so the returned QM gradient / coupling force / ESP charges are in that
+order. The force-scatter loops and the link-atom host_row projection index those
+arrays by position in self.qm_atoms, so qm_atoms must be sorted ascending or the
+QM forces land on the wrong atoms. The driver sorts qm_atoms at construction;
+this test pins that invariant.
+
+Requires OpenMM and the compiled OpenQP backend (the driver imports it at module
+load), so it is skipped in environments without them.
+"""
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+try:
+    import openmm.app as app
+    from oqp.library.qmmm_driver import OpenQpQMMM
+    _HAVE = True
+except Exception:  # pragma: no cover - optional deps / uncompiled backend
+    _HAVE = False
+
+
+@unittest.skipUnless(_HAVE, "OpenMM or compiled OpenQP backend unavailable")
+class TestQMAtomsOrder(unittest.TestCase):
+    def test_qm_atoms_sorted_into_topology_order(self):
+        pdb_path = ROOT / "examples" / "QMMM" / "ala.pdb"
+        if not pdb_path.exists():
+            self.skipTest("examples/QMMM/ala.pdb missing")
+        pdb = app.PDBFile(str(pdb_path))
+        try:
+            ff = app.ForceField("amber14-all.xml")
+        except Exception as err:  # pragma: no cover
+            self.skipTest(f"amber14-all.xml unavailable: {err}")
+        # deliberately shuffled selection (amide atoms, out of order)
+        shuffled = [16, 8, 18, 9, 17]
+        drv = OpenQpQMMM(
+            pdb.positions, pdb.topology, ff, shuffled, oqp_cfg={},
+            Cutoff=app.NoCutoff, Embedding="electrostatic",
+        )
+        self.assertEqual(list(drv.qm_atoms), sorted(shuffled))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The QM/MM driver builds the QM geometry by iterating `topology.atoms()` filtered
by membership — i.e. in **topology order** (ascending `atom.index`). So the QM
gradient, coupling force, and ESP charges returned by the engine are in topology
order.

But the force-scatter loops (`_assemble_force`, `_assemble_force_espf`) and the
link-atom `host_row` projection index those arrays **by position in
`self.qm_atoms`**. If `qm_atoms` is supplied out of ascending order (e.g.
`qm_atoms = "5,2,7"`), those positions don't match topology order, so the QM
gradient / coupling force / link-atom projection land on the **wrong atoms** —
a silent wrong-number (no crash).

This is pre-existing (independent of, and predating, the frontier-charge work in
#258, which inherits the same scatter).

## Fix

Sort `qm_atoms` into ascending (topology) order at construction. This does **not**
change the QM calculation — the engine already sees the atoms in topology order —
it only realigns the force scatter. A shuffled selection now normalizes to
ascending order.

Regression test in `tests/test_qmmm_qm_atoms_order.py` (OpenMM/backend-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)