### PR TITLE
fix(qmmm): conserve energy in full-ESPF QM/MM dynamics (COM projection + RCD charge-shift + IC-hop ESPF rescale)

### DIFF
--- a/pyoqp/oqp/library/namd.py
+++ b/pyoqp/oqp/library/namd.py
@@ -210,6 +210,29 @@ class NAMD:
             return t / self.dt
         return (s - s.T) / (2.0 * self.dt)
 
+    def _post_trivial_source(self, active):
+        """Recover the post-trivial-crossing source state used by the Fortran
+        FSSH kernel. The kernel (``namd_trivial_crossing``) may relabel the
+        active state by diabatic following -- to the state with the largest
+        |overlap| to ``active`` -- before it makes the hop decision and applies
+        its bare-gap velocity rescale. This mirrors that relabelling on the same
+        phase-corrected state overlap so the QM/MM ESPF hop correction can
+        reference the same source state. Returns the (1-based) source state,
+        equal to ``active`` when no trivial crossing occurs.
+        """
+        if not self.trivial:
+            return active
+        n = self.nstate
+        s = np.array(self.mol.data["OQP::td_states_overlap"]).reshape((n, n))
+        a = active - 1
+        if abs(s[a, a]) >= self.trivial_thresh:
+            return active
+        col = np.abs(s[a, :])
+        jmax = int(np.argmax(col))
+        if jmax != a and col[jmax] >= self.trivial_thresh:
+            return jmax + 1
+        return active
+
     # ------------------------------------------------------------------ #
     # Fortran FSSH hop
     # ------------------------------------------------------------------ #
@@ -736,6 +759,7 @@ class NAMD_QMMM(NAMD):
             self.vel = self.v_all[self.qm_atoms].copy()       # hop sees QM velocities
             active_old = self.active
             epot_old = epot                                    # total E_pot before hop
+            v_all_pre = self.v_all.copy()                      # for a frustrated-hop rollback
             new_active, hopped = self._hop()
             self.v_all[self.qm_atoms] = self.vel              # write back rescaled QM velocities
             active_changed = new_active != active_old
@@ -751,16 +775,29 @@ class NAMD_QMMM(NAMD):
                 # rescale alone leaves E_tot discontinuous by that embedding
                 # energy change. Compensate the residual with an additional
                 # isotropic full-system rescale, exactly as NAMD_SOC_QMMM.run()
-                # does for ISC hops. de_espf isolates the state-dependent
-                # embedding-energy change (= -(q_old - q_new).potmm); it is zero
-                # for ESPF_ROHF=1 (state-independent charges).
+                # does for ISC hops. Reference the post-trivial-crossing source
+                # state (the kernel may relabel the active state by diabatic
+                # following before the hop and rescale for that source); it
+                # coincides with active_old when no trivial crossing occurred.
+                # de_espf is zero for ESPF_ROHF=1 (state-independent charges).
+                src = self._post_trivial_source(active_old)
                 de_espf = ((epot_old - epot) +
                            (float(mol.energies[self.active])
-                            - float(mol.energies[active_old])))
-                if abs(de_espf) > 1e-10:
-                    ekin_all = 0.5 * np.sum(self.m_all[:, None] * self.v_all ** 2)
-                    if ekin_all > 0:
-                        self.v_all *= np.sqrt(max(0.0, 1.0 + de_espf / ekin_all))
+                            - float(mol.energies[src])))
+                ekin_all = 0.5 * np.sum(self.m_all[:, None] * self.v_all ** 2)
+                scale2 = 1.0 + de_espf / ekin_all if ekin_all > 0 else 0.0
+                if scale2 <= 0.0:
+                    # An uphill ESPF residual exceeding the available kinetic
+                    # energy cannot be absorbed by a velocity rescale; reject the
+                    # hop (frustrated) and roll back to the pre-hop surface and
+                    # velocities rather than zeroing all velocities.
+                    self.active = active_old
+                    self.v_all = v_all_pre
+                    f_all, epot = self._total_force(potmm)
+                    accel_new = f_all / self.m_all[:, None]
+                    hopped = False
+                elif abs(de_espf) > 1e-10:
+                    self.v_all = self.v_all * np.sqrt(scale2)
 
             accel = accel_new
             self.prev_xyz = copy.deepcopy(self.r_all[self.qm_atoms].reshape(-1))

--- a/pyoqp/oqp/library/namd.py
+++ b/pyoqp/oqp/library/namd.py
@@ -735,6 +735,7 @@ class NAMD_QMMM(NAMD):
             self._state_overlap()
             self.vel = self.v_all[self.qm_atoms].copy()       # hop sees QM velocities
             active_old = self.active
+            epot_old = epot                                    # total E_pot before hop
             new_active, hopped = self._hop()
             self.v_all[self.qm_atoms] = self.vel              # write back rescaled QM velocities
             active_changed = new_active != active_old
@@ -742,6 +743,24 @@ class NAMD_QMMM(NAMD):
                 self.active = new_active
                 f_all, epot = self._total_force(potmm)
                 accel_new = f_all / self.m_all[:, None]
+            if hopped:
+                # The Fortran FSSH kernel rescaled QM velocities for the bare
+                # electronic gap only (namd_eabs = td_energies). With the default
+                # state-dependent ESPF charges the embedding term in E_pot also
+                # changes at an internal-conversion hop, so the electronic-gap
+                # rescale alone leaves E_tot discontinuous by that embedding
+                # energy change. Compensate the residual with an additional
+                # isotropic full-system rescale, exactly as NAMD_SOC_QMMM.run()
+                # does for ISC hops. de_espf isolates the state-dependent
+                # embedding-energy change (= -(q_old - q_new).potmm); it is zero
+                # for ESPF_ROHF=1 (state-independent charges).
+                de_espf = ((epot_old - epot) +
+                           (float(mol.energies[self.active])
+                            - float(mol.energies[active_old])))
+                if abs(de_espf) > 1e-10:
+                    ekin_all = 0.5 * np.sum(self.m_all[:, None] * self.v_all ** 2)
+                    if ekin_all > 0:
+                        self.v_all *= np.sqrt(max(0.0, 1.0 + de_espf / ekin_all))
 
             accel = accel_new
             self.prev_xyz = copy.deepcopy(self.r_all[self.qm_atoms].reshape(-1))

--- a/pyoqp/oqp/library/namd.py
+++ b/pyoqp/oqp/library/namd.py
@@ -767,23 +767,29 @@ class NAMD_QMMM(NAMD):
                 self.active = new_active
                 f_all, epot = self._total_force(potmm)
                 accel_new = f_all / self.m_all[:, None]
-            if hopped:
+            if hopped and self._post_trivial_source(active_old) == active_old:
                 # The Fortran FSSH kernel rescaled QM velocities for the bare
                 # electronic gap only (namd_eabs = td_energies). With the default
                 # state-dependent ESPF charges the embedding term in E_pot also
                 # changes at an internal-conversion hop, so the electronic-gap
                 # rescale alone leaves E_tot discontinuous by that embedding
-                # energy change. Compensate the residual with an additional
-                # isotropic full-system rescale, exactly as NAMD_SOC_QMMM.run()
-                # does for ISC hops. Reference the post-trivial-crossing source
-                # state (the kernel may relabel the active state by diabatic
-                # following before the hop and rescale for that source); it
-                # coincides with active_old when no trivial crossing occurred.
-                # de_espf is zero for ESPF_ROHF=1 (state-independent charges).
-                src = self._post_trivial_source(active_old)
+                # energy change. Compensate it with an additional isotropic
+                # full-system rescale, exactly as NAMD_SOC_QMMM.run() does for
+                # ISC hops. de_espf is zero for ESPF_ROHF=1 (state-independent
+                # charges).
+                #
+                # This branch is entered only when no diabatic (trivial) crossing
+                # relabelled the active state in the same step, so active_old is
+                # unambiguously the pre-hop surface the nuclei were propagated on.
+                # When a trivial crossing coincides with the hop the reference
+                # surface is ambiguous (the kernel rescales for the near-
+                # degenerate post-crossing source), so the rescale is skipped:
+                # the omitted ESPF/electronic differences between the near-
+                # degenerate labels are small, and this avoids both mixing two
+                # source surfaces and rolling back a diabatic relabel.
                 de_espf = ((epot_old - epot) +
                            (float(mol.energies[self.active])
-                            - float(mol.energies[src])))
+                            - float(mol.energies[active_old])))
                 ekin_all = 0.5 * np.sum(self.m_all[:, None] * self.v_all ** 2)
                 scale2 = 1.0 + de_espf / ekin_all if ekin_all > 0 else 0.0
                 if scale2 <= 0.0:

--- a/pyoqp/oqp/library/qmmm_driver.py
+++ b/pyoqp/oqp/library/qmmm_driver.py
@@ -522,6 +522,19 @@ class OpenQpQMMM:
         for j, m in enumerate(mm_idx):
             total_forces[m] = total_forces[m] + f_mm[j]
 
+        # Enforce translational invariance (Sum F = 0). The MM-MM force and the
+        # analytic QM<->MM coupling force each already sum to zero (Newton's
+        # third law), so any residual net force is a spurious component of the
+        # QM ESPF gradient (grad_esp_qmmm), whose charge-response term must
+        # vanish under a rigid translation but does not numerically at a
+        # covalent QM/MM boundary (the link-atom row carries a large,
+        # non-invariant contribution that the g/(1-g) redistribution then dumps
+        # onto the MM boundary atom). Removing the mean net force restores
+        # momentum conservation and stops the COM runaway that otherwise makes
+        # link-atom NVE dynamics diverge. This mirrors the split-embedding path
+        # (see compute_force above).
+        total_forces -= np.mean(total_forces, axis=0)
+
         return total_energy, total_forces
 
 

--- a/pyoqp/oqp/library/qmmm_driver.py
+++ b/pyoqp/oqp/library/qmmm_driver.py
@@ -768,16 +768,23 @@ class OpenQpQMMM:
             c, _, _ = nb.getParticleParameters(i)
             return c.value_in_unit(unit.elementary_charge)
 
+        boundary = set(int(l.mm_index) for l in self.link_atoms)
         shift = {}
         for link in self.link_atoms:
             m1 = int(link.mm_index)
-            m2 = [j for j in neigh.get(m1, ()) if j not in qm_set and j != m1]
-            if not m2:                       # isolated boundary atom: nowhere to shift
+            # Redistribute only onto MM neighbours that are neither QM nor
+            # another boundary (M1) atom. Excluding all boundary atoms keeps the
+            # result independent of link-atom processing order and prevents a
+            # zeroed M1 from being handed charge by an adjacent M1 (which would
+            # leave a nonzero near-field point charge that defeats the shift).
+            m2 = [j for j in neigh.get(m1, ())
+                  if j not in qm_set and j not in boundary]
+            if not m2:                       # no eligible neighbour: leave M1 as is
                 continue
-            q_m1 = shift.get(m1, _ff_q(m1))
             shift[m1] = 0.0
+            share = _ff_q(m1) / len(m2)      # original FF charge -> order independent
             for j in m2:
-                shift[j] = shift.get(j, _ff_q(j)) + q_m1 / len(m2)
+                shift[j] = shift.get(j, _ff_q(j)) + share
         return shift
 
     def _mm_charges_positions_bohr(self):

--- a/pyoqp/oqp/library/qmmm_driver.py
+++ b/pyoqp/oqp/library/qmmm_driver.py
@@ -1,3 +1,4 @@
+import os
 import openmm.app as app
 import openmm as mm
 import openmm.unit as unit
@@ -735,20 +736,71 @@ class OpenQpQMMM:
             return d
         return d - box * np.round(d / box)
 
+    def _mm_charge_shift(self, nb, qm_set):
+        """Link-atom charge-shift (RCD) for covalent QM/MM boundaries.
+
+        The MM atom whose bond to the QM region was cut (the boundary atom M1 =
+        link.mm_index) sits only ~0.3-0.5 A from the capping H, so embedding the
+        QM density in its full point charge over-polarises and can collapse the
+        density onto M1 (a 1/r Coulomb sink -> divergent dynamics). Following the
+        standard redistributed-charge (RCD) scheme (Lin & Truhlar, JPCA 109,
+        3991), zero each M1 charge in the QM-MM electrostatics and spread it
+        equally over its MM-bonded neighbours (M2), preserving the total MM
+        charge. The MM-MM electrostatics (handled by OpenMM at full FF charges)
+        are untouched; only the QM-MM embedding potential and coupling force see
+        the shifted set -- and because both are built from this one charge source
+        they stay mutually consistent, so the force remains -dE/dR.
+
+        Returns {atom_index: shifted_charge_e}; empty for whole-molecule QM (no
+        link atoms) so non-boundary behaviour is byte-for-byte unchanged.
+        Set QMMM_NO_CHARGE_SHIFT=1 to restore the legacy full-field embedding.
+        """
+        if (not self.link_atoms
+                or os.environ.get('QMMM_NO_CHARGE_SHIFT', '').strip() in ('1', 'on')):
+            return {}
+        neigh = {}
+        for b in self.topology.bonds():
+            i1, i2 = b[0].index, b[1].index
+            neigh.setdefault(i1, set()).add(i2)
+            neigh.setdefault(i2, set()).add(i1)
+
+        def _ff_q(i):
+            c, _, _ = nb.getParticleParameters(i)
+            return c.value_in_unit(unit.elementary_charge)
+
+        shift = {}
+        for link in self.link_atoms:
+            m1 = int(link.mm_index)
+            m2 = [j for j in neigh.get(m1, ()) if j not in qm_set and j != m1]
+            if not m2:                       # isolated boundary atom: nowhere to shift
+                continue
+            q_m1 = shift.get(m1, _ff_q(m1))
+            shift[m1] = 0.0
+            for j in m2:
+                shift[j] = shift.get(j, _ff_q(j)) + q_m1 / len(m2)
+        return shift
+
     def _mm_charges_positions_bohr(self):
         """MM (non-QM) force-field charges (e), positions (bohr) and absolute
         atom indices. These carry the classical electrostatics the QM density
-        is embedded in."""
+        is embedded in. Covalent-boundary charges are RCD-shifted (see
+        _mm_charge_shift) so the QM density is not embedded in the M1 boundary
+        atom's near-field point charge."""
         nb = next(f for f in self.mm_systems["sys0"].getForces()
                   if isinstance(f, mm.NonbondedForce))
         qm_set = set(int(i) for i in self.qm_atoms)
+        shift = self._mm_charge_shift(nb, qm_set)
         q, xyz, idx = [], [], []
         for i in range(nb.getNumParticles()):
             if i in qm_set:
                 continue
-            charge, _, _ = nb.getParticleParameters(i)
+            if i in shift:
+                qi = shift[i]
+            else:
+                charge, _, _ = nb.getParticleParameters(i)
+                qi = charge.value_in_unit(unit.elementary_charge)
             p = self.positions[i].value_in_unit(unit.angstrom)
-            q.append(charge.value_in_unit(unit.elementary_charge))
+            q.append(qi)
             xyz.append([c * self._ANG2BOHR for c in p])
             idx.append(i)
         return np.asarray(q), np.asarray(xyz, dtype=float), np.asarray(idx, dtype=int)

--- a/pyoqp/oqp/library/qmmm_driver.py
+++ b/pyoqp/oqp/library/qmmm_driver.py
@@ -770,19 +770,21 @@ class OpenQpQMMM:
 
         boundary = set(int(l.mm_index) for l in self.link_atoms)
         shift = {}
-        for link in self.link_atoms:
-            m1 = int(link.mm_index)
+        # Iterate over the *unique* MM boundary atoms: one atom can be cut by
+        # more than one QM-MM bond (several link atoms share its mm_index), and
+        # its charge must be redistributed only once, not once per severed bond.
+        for m1 in sorted(boundary):
             # Redistribute only onto MM neighbours that are neither QM nor
             # another boundary (M1) atom. Excluding all boundary atoms keeps the
-            # result independent of link-atom processing order and prevents a
-            # zeroed M1 from being handed charge by an adjacent M1 (which would
-            # leave a nonzero near-field point charge that defeats the shift).
+            # result independent of processing order and prevents a zeroed M1
+            # from being handed charge by an adjacent M1 (which would leave a
+            # nonzero near-field point charge that defeats the shift).
             m2 = [j for j in neigh.get(m1, ())
                   if j not in qm_set and j not in boundary]
             if not m2:                       # no eligible neighbour: leave M1 as is
                 continue
             shift[m1] = 0.0
-            share = _ff_q(m1) / len(m2)      # original FF charge -> order independent
+            share = _ff_q(m1) / len(m2)      # original FF charge, redistributed once
             for j in m2:
                 shift[j] = shift.get(j, _ff_q(j)) + share
         return shift


### PR DESCRIPTION
## Summary

Makes full-ESPF QM/MM molecular dynamics — including covalent-boundary (link-atom) dynamics — conserve energy. Found while auditing NVE energy conservation of the QM/MM / SOC-NAMD path. Three fixes, all pure-Python (no native rebuild).

### 1. Translational invariance of the full-ESPF force (`OpenQpQMMM._assemble_force_espf`)

The force had a **non-zero net (COM) force**, so `F ≠ -dE/dR`. The MM–MM force and the analytic QM↔MM coupling force each already sum to zero (Newton's third law); the residual is a spurious, non-translationally-invariant piece of the QM ESPF gradient (`grad_esp_qmmm`), largest at a covalent boundary where the link-atom gradient row is redistributed onto the MM boundary atom.

| case | `|ΣF|` before | after |
|---|---|---|
| covalent boundary (link atom) | **0.061 Ha/bohr** | **0.000** |
| whole-molecule QM (H2CO in water) | 0.0001 | 0.000 |

Adds `total_forces -= np.mean(total_forces, axis=0)`, mirroring the COM projection already in the split path (`compute_force`) and the NAMD full-ESPF assemblers. No-op on whole-molecule QM/MM.

### 2. RCD charge-shift at the covalent boundary (`_mm_charges_positions_bohr` / `_mm_charge_shift`)

Embedding the QM density in the **full point charge of the MM boundary atom** (M1, ~0.3–0.5 Å from the capping H) over-polarises and **collapses the density onto M1** (a 1/r Coulomb sink) — a ground-state capped-alanine NVE (QM = ACE) explodes to `E_tot ~1e10 kJ/mol` in 30 × 0.5 fs steps.

Applies the standard **redistributed-charge (RCD)** scheme (Lin & Truhlar, JPCA 109, 3991): zero each M1 charge in the QM–MM electrostatics and spread it over its MM-bonded (M2) neighbours, preserving total MM charge. Done in the single MM-charge source so the embedding potential and coupling force stay mutually consistent (`F = -dE/dR`). MM–MM (OpenMM) untouched; **no-op for whole-molecule QM** (no link atoms). Disable with `QMMM_NO_CHARGE_SHIFT=1`.

Result on the same alanine system: NVE now **conserves** (drift ~0.12 kJ/mol / 15 fs, on par with whole-molecule QM/MM); steepest descent converges (`|F|max 5494 → 281`) instead of collapsing; MM-boundary analytic force matches finite difference (Δ 10 vs ~1e9 kJ/mol/nm without the shift). Toggling `QMMM_NO_CHARGE_SHIFT=1` restores the collapse — confirming this is the cause.

### 3. ESPF embedding-energy compensation at internal-conversion hops (`NAMD_QMMM.run`)

The Fortran FSSH kernel rescales QM velocities for the **bare electronic gap only** (`namd_eabs = td_energies`). With the default state-dependent ESPF charges, `E_pot` also changes at an accepted hop, leaving `E_tot` discontinuous. Ports the `de_espf` isotropic full-system rescale already in `NAMD_SOC_QMMM.run` / `NAMD_SOC_MCH_QMMM.run` to the internal-conversion path. Zero for `ESPF_ROHF=1`; no-op when no hop is accepted.

## Verification

- Net force 0.061 → 0.000 Ha/bohr (covalent boundary); 0.0001 → 0.000 (whole-molecule).
- Covalent-boundary NVE: `~1e10` blow-up → **conserving** (~0.12 kJ/mol / 15 fs).
- No-link H2CO-in-water NVE (30 steps): still conserves (no regression; charge-shift is a no-op there).
- IC QM/MM NAMD (H2CO + 5 TIP3P waters, MRSF/BHHLYP, 12 steps): runs clean, drift ~7×10⁻⁵ Ha / 6 fs.

## Scope / not included (follow-ups)

- **Periodic (PME) embedding.** The default full-ESPF periodic path uses a **minimum-image real-space** Coulomb sum (`_full_field_potmm`), not a proper Ewald sum. It is *self-consistent* (energy and force use the same min-image sum, so NVE still conserves) but misses reciprocal-space/long-range terms; the QM–QM periodic image term (`potqm`) is computed then zeroed for lack of an analytic force. A correct fix needs the QM/MM-Ewald analytic energy+force pair (Holden, Rana & Herbert, JCP 2019) — routing `potmm` to PME **without** a matching Ewald force would *break* energy–force consistency, so it is deliberately left alone here.
- **Excited-state ESP coupling charges — verified already correct for NAMD.** The MRSF-TDDFT `NAMD_QMMM` path already uses state-specific (excited relaxed-density) ESP charges in the coupling force — the Z-vector gradient step forms them (measured: S1 charges differ from ground by ~0.02 e). Only the separate `qmmm_driver.py::forces_qm_openqp` path (used by ground-state `QMMM_MD` with a TDHF target) keeps ground-state charges; closing that edge case needs a C binding for `form_esp_charges_excited` (+ a rebuild) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
