### PR TITLE
Fix TD response-vector JSON layout

### DIFF
--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -1286,7 +1286,7 @@ class Molecule:
             if key in self.skip_tag[scf_type]:
                 continue
             try:
-                data[key] = json_array(key, self.data[key])
+                data[key] = np.array(self.data[key]).tolist()
 
             except AttributeError:
                 continue
@@ -1591,6 +1591,10 @@ class Molecule:
         else:
             jsonfile = self.log.replace('.log', '.json')
         data = self.get_data()
+        # Keep get_data() in the native tag-array layout for restart, back-door,
+        # and NAMD consumers.  Only the on-disk JSON presentation needs the TD
+        # response-vector axes repaired.
+        data = {key: json_array(key, value) for key, value in data.items()}
         data.update(self.get_results())
         data.update(self.set_config_json())
 

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -13,6 +13,7 @@ from oqp.utils.mpi_utils import MPIManager
 from oqp.utils.mpi_utils import mpi_get_attr, mpi_dump
 from oqp import ffi
 from oqp.utils import regression as regkeys
+from oqp.utils.json_utils import json_array
 
 # Environment variable that opts JSON dumps into "lean" mode: internal
 # ``OQP::`` arrays (density/Fock/MO matrices, etc.) and any other non-regression
@@ -1285,7 +1286,7 @@ class Molecule:
             if key in self.skip_tag[scf_type]:
                 continue
             try:
-                data[key] = np.array(self.data[key]).tolist()
+                data[key] = json_array(key, self.data[key])
 
             except AttributeError:
                 continue

--- a/pyoqp/oqp/utils/json_utils.py
+++ b/pyoqp/oqp/utils/json_utils.py
@@ -1,0 +1,28 @@
+"""Helpers for presenting internal OpenQP arrays in JSON."""
+
+import numpy as np
+
+
+_TD_BVEC_KEYS = {
+    "OQP::td_bvec_mo",
+    "OQP::td_bvec_mo_old",
+    "OQP::td_bvec_mo_s",
+    "OQP::td_bvec_mo_t",
+}
+
+
+def json_array(key, value):
+    """Return an array with axes laid out as documented for JSON output.
+
+    TD response vectors originate in Fortran as ``(N_DRF, N_States)``.  The
+    tag-array bridge exposes the contiguous buffer with that shape to NumPy,
+    whose default C-order interpretation groups adjacent values by the second
+    axis.  Rebuild these arrays from their state-major buffer so JSON rows are
+    DRFs and columns are states.  This conversion is intentionally limited to
+    serialization; the runtime/tag-array representation remains unchanged.
+    """
+    array = np.asarray(value)
+    if key in _TD_BVEC_KEYS and array.ndim == 2:
+        n_drf, n_states = array.shape
+        array = array.ravel().reshape(n_states, n_drf).T
+    return array.tolist()

--- a/tests/test_json_td_layout.py
+++ b/tests/test_json_td_layout.py
@@ -1,4 +1,5 @@
 import importlib.util
+import ast
 from pathlib import Path
 import unittest
 
@@ -26,6 +27,31 @@ class TestJsonTdLayout(unittest.TestCase):
         matrix = np.array([[1.0, 2.0], [3.0, 4.0]])
 
         self.assertEqual(JSON_UTILS.json_array("OQP::SM", matrix), matrix.tolist())
+
+    def test_conversion_is_confined_to_json_save_path(self):
+        source = (ROOT / "pyoqp/oqp/molecule/molecule.py").read_text()
+        tree = ast.parse(source)
+        methods = {
+            node.name: node
+            for cls in tree.body
+            if isinstance(cls, ast.ClassDef) and cls.name == "Molecule"
+            for node in cls.body
+            if isinstance(node, ast.FunctionDef)
+        }
+
+        get_data_calls = [
+            node for node in ast.walk(methods["get_data"])
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            and node.func.id == "json_array"
+        ]
+        save_data_calls = [
+            node for node in ast.walk(methods["save_data"])
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            and node.func.id == "json_array"
+        ]
+
+        self.assertEqual(get_data_calls, [])
+        self.assertEqual(len(save_data_calls), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_json_td_layout.py
+++ b/tests/test_json_td_layout.py
@@ -1,0 +1,32 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "openqp_json_utils", ROOT / "pyoqp/oqp/utils/json_utils.py"
+)
+JSON_UTILS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(JSON_UTILS)
+
+
+class TestJsonTdLayout(unittest.TestCase):
+    def test_td_response_vectors_are_written_as_drf_by_state(self):
+        # Fortran buffer for three DRFs and two states: state 1, then state 2.
+        bridged = np.array([[11.0, 12.0], [13.0, 21.0], [22.0, 23.0]])
+
+        result = JSON_UTILS.json_array("OQP::td_bvec_mo", bridged)
+
+        self.assertEqual(result, [[11.0, 21.0], [12.0, 22.0], [13.0, 23.0]])
+
+    def test_unrelated_matrices_keep_their_layout(self):
+        matrix = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+        self.assertEqual(JSON_UTILS.json_array("OQP::SM", matrix), matrix.tolist())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- serialize TD response vectors as DRF-by-state matrices in JSON
- keep the internal tag-array representation unchanged
- cover TD response-vector and unrelated-matrix layouts with unit tests

## Root cause
The Fortran `(N_DRF, N_States)` buffer was exposed with that shape and then interpreted in NumPy C order, causing state-major contiguous values to be grouped into the wrong JSON rows.

## Validation
- `python -m unittest tests.test_json_td_layout`
- `git diff --check`

Fixes #268
