### PR TITLE
Protect rstctmo references from TRAH recovery

### DIFF
--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -648,6 +648,19 @@ class SinglePoint(Calculator):
         # Drop the primary and de-duplicate while preserving order.
         _seen = set()
         chain = [c for c in chain if c != primary and not (c in _seen or _seen.add(c))]
+        # TRAH is not occupation constrained and may rotate a MOM/rstctmo
+        # core-hole reference into a different electronic state.  Keep the
+        # occupation-preserving recovery stages, but never silently enter TRAH
+        # for a restricted-orbital calculation.
+        rstctmo = bool(scf_config.get('rstctmo', False))
+        if rstctmo and 'trah' in chain:
+            chain = [c for c in chain if c != 'trah']
+            dump_log(
+                self.mol,
+                title='PyOQP: TRAH recovery disabled because scf.rstctmo=true; '
+                      'TRAH cannot preserve the requested orbital ordering',
+                section='input',
+            )
         for conv in chain:
             if converged:
                 break
@@ -673,7 +686,8 @@ class SinglePoint(Calculator):
         # is reverted below by restoring the snapshot.
         td_type = str(getattr(self, 'td', '')).lower()
         spin_flip_reference = self.method == 'tdhf' and td_type in ('sf', 'mrsf', 'umrsf')
-        if converged and stability and primary != 'trah' and (self.method == 'hf' or spin_flip_reference):
+        if (converged and stability and not rstctmo and primary != 'trah'
+                and (self.method == 'hf' or spin_flip_reference)):
             e_pre = self.mol.mol_energy.energy
             mol_energy_snapshot = self._snapshot_mol_energy_state()
             # Snapshot the converged orbitals so the safeguard is a true no-op

--- a/tests/test_single_point_scf_fallback.py
+++ b/tests/test_single_point_scf_fallback.py
@@ -72,6 +72,10 @@ def install_single_point_stubs():
     setattr(frequency, "thermal_analysis", lambda *args, **kwargs: None)
     sys.modules["oqp.library.frequency"] = frequency
 
+    openqp_dftb = types.ModuleType("oqp.library.openqp_dftb")
+    setattr(openqp_dftb, "OpenQPDFTBAdapter", type("OpenQPDFTBAdapter", (), {}))
+    sys.modules["oqp.library.openqp_dftb"] = openqp_dftb
+
 
 class FakeData(dict):
     def __init__(self):
@@ -204,6 +208,27 @@ class TestSinglePointScfFallback(unittest.TestCase):
         energy = calc.reference(do_init_scf=False)
 
         self.assertEqual(energy, [-3.0])
+        self.assertEqual(calc.mol.data.convergers, ["diis", "soscf", "diis"])
+
+    def test_rstctmo_never_escalates_to_trah(self):
+        calc = self.make_calculator()
+        calc.mol.config["scf"]["rstctmo"] = True
+
+        def scf_never_converges():
+            calc.scf_calls += 1
+            calc.mol.mol_energy.SCF_converged = False
+
+        calc.scf = scf_never_converges
+
+        self.assertFalse(calc._run_scf())
+        self.assertEqual(calc.mol.data.convergers, ["diis", "soscf", "diis"])
+
+    def test_rstctmo_disables_requested_trah_stability_pass(self):
+        calc = self.make_calculator()
+        calc.mol.config["scf"]["rstctmo"] = True
+        calc.stability = True
+
+        self.assertTrue(calc._run_scf())
         self.assertEqual(calc.mol.data.convergers, ["diis", "soscf", "diis"])
 
     def test_ml_selector_maps_diis_subtype_to_native_controls(self):


### PR DESCRIPTION
## Summary
- prevent automatic TRAH recovery when `scf.rstctmo=true`
- skip the optional TRAH stability pass for restricted-orbital references
- emit a clear diagnostic explaining why TRAH is disabled
- repair the SCF fallback test stub for the current DFTB adapter import

## Rationale
TRAH does not preserve MOM/rstctmo orbital ordering. Silently entering it can turn a requested core-hole reference into a scientifically different state. Occupation-preserving SOSCF recovery remains available; if that fails, the calculation now fails instead of silently changing the reference.

## Validation
- `python -m unittest tests.test_single_point_scf_fallback` (13 passed)
- `git diff --check`

Fixes #171
