### PR TITLE
dftb: bundled-parameter auto-resolution; examples run out of the box (follow-up to #275)

### DIFF
--- a/examples/DFTB/C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.inp
+++ b/examples/DFTB/C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.inp
@@ -2,7 +2,9 @@
 # operator (omega=0.25, cam_beta=1.2), which restores the MRSF-TDDFT
 # bright/dark state ordering. The lc_ground_state flag turns on the
 # long-range-corrected ROKS reference; the trust mixer is recommended for
-# the cam_beta>1 SCC.
+# the cam_beta>1 SCC. With parameter_path empty the bundled openqp-dftb
+# OB2W0PT3 SKF set (official spinw.txt included) is resolved automatically;
+# set parameter_path or OPENQP_DFTB_PARAMETER_PATH only to override it.
 [input]
 system=
    6   0.000000000   0.000000000   0.000000000
@@ -27,7 +29,7 @@ nstate=3
 [dftb]
 backend=native
 type=mrsf
-parameter_path=params
+parameter_path=
 lc_ground_state=true
 lc_gamma=erf
 omega=0.25

--- a/examples/DFTB/C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.oqp
+++ b/examples/DFTB/C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.oqp
@@ -1,1 +1,1 @@
-mrsf-tddftb(nstate=3) geom="../geometries/C2-d0affeda5215.xyz" charge=0 energy(S0) guess(type=huckel) dftb(backend=native,parameter_path=params,lc_ground_state=true,lc_gamma=erf,omega=0.25,cam_beta=1.2,scc_mixer=trust)
+mrsf-tddftb(nstate=3) geom="../geometries/C2-d0affeda5215.xyz" charge=0 energy(S0) guess(type=huckel) dftb(backend=native,parameter_path="",lc_ground_state=true,lc_gamma=erf,omega=0.25,cam_beta=1.2,scc_mixer=trust)

--- a/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.inp
+++ b/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.inp
@@ -6,11 +6,13 @@
 #    input   runtype          grad
 #    tdhf    type             mrsf
 #    dftb    type             mrsf
-#    dftb    parameter_path   <SKF dir or .opdftb file>
+#    dftb    parameter_path   (optional: SKF dir or .opdftb file)
 #
-# The DFTB backend is an optional external library (libopenqp_dftb_c); set
-# [dftb] parameter_path to a Slater-Koster parameter set. See the
-# openqp-docs [dftb] keyword page and the MRSF-TDDFTB workflow page.
+# The DFTB backend is an optional external library (libopenqp_dftb_c). With
+# parameter_path empty the bundled openqp-dftb OB2W0PT3 SKF set (official
+# spinw.txt included) is resolved automatically; set [dftb] parameter_path
+# or OPENQP_DFTB_PARAMETER_PATH only to use another Slater-Koster set. See
+# the openqp-docs [dftb] keyword page and the MRSF-TDDFTB workflow page.
 [input]
 system=
    6   0.000000000   0.000000000   0.000000000
@@ -36,7 +38,7 @@ nstate=3
 [dftb]
 backend=native
 type=mrsf
-parameter_path=params
+parameter_path=
 
 [properties]
 grad=1

--- a/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.oqp
+++ b/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.oqp
@@ -1,1 +1,1 @@
-mrsf-tddftb(nstate=3) geom="../geometries/CH2-e41258125cee.xyz" charge=0 grad(S0) guess(type=huckel) dftb(backend=native,parameter_path=params)
+mrsf-tddftb(nstate=3) geom="../geometries/CH2-e41258125cee.xyz" charge=0 grad(S0) guess(type=huckel) dftb(backend=native,parameter_path="")

--- a/examples/DFTB/README.md
+++ b/examples/DFTB/README.md
@@ -1,0 +1,21 @@
+# MRSF-TDDFTB (OpenQP-DFTB backend) examples
+
+Plain long-range-corrected and uncorrected MRSF-TDDFTB through the optional
+openqp-dftb backend (`[input] method=dftb`), without the DTCAM-TB operator
+preset (for that, see `../DTCAM-TB`).
+
+Parameters: nothing to configure with a current openqp-dftb wheel -- it
+ships the bundled OB2W0PT3 SKF set (official shell-resolved `spinw.txt`
+included, so the spin-polarization W kernels are complete), resolved
+automatically when `[dftb] parameter_path` is empty and
+`OPENQP_DFTB_PARAMETER_PATH` is unset. Point either knob at another
+`.opdftb`/SKF directory to override the bundled default.
+
+- `H2CH2_MRSF-TDDFTB_GRADIENT.inp`: analytic S0 gradient of CH2 on the
+  triplet ROKS reference (relaxed Z-vector path).
+- `C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.inp`: LC-corrected reference
+  (`lc_ground_state=true`) with the erf-tuned response operator
+  (omega=0.25, cam_beta=1.2) that restores the MRSF bright/dark ordering.
+
+State convention: physical S0 is singlet response root 1; S1/S2 are roots
+2/3. The high-spin ROKS determinant is only the auxiliary reference.

--- a/examples/DTCAM-TB/BUTADIENE_DTCAMTB_ENERGY.inp
+++ b/examples/DTCAM-TB/BUTADIENE_DTCAMTB_ENERGY.inp
@@ -1,8 +1,8 @@
 # DTCAM-TB (MRSF-TDDFTB) vertical energies of s-trans butadiene.
 # model=dtcam-tb resolves the complete published operator and the fast
-# numerical protocol inside openqp-dftb; set parameter_path to the OB2W0PT3
-# SKF directory (with the official OB2 v1.1.0 spinw.txt alongside), or export
-# OPENQP_DFTB_PARAMETER_PATH instead.
+# numerical protocol inside openqp-dftb; the bundled OB2W0PT3 set (official
+# spinw.txt included) is resolved automatically when parameter_path is empty --
+# set parameter_path or OPENQP_DFTB_PARAMETER_PATH only to override it.
 # Physical S0 is singlet response root 1; S1/S2 are roots 2/3.
 [input]
 system=

--- a/examples/DTCAM-TB/BUTADIENE_DTCAMTB_S1_GRADIENT.inp
+++ b/examples/DTCAM-TB/BUTADIENE_DTCAMTB_S1_GRADIENT.inp
@@ -1,7 +1,7 @@
 # DTCAM-TB analytic gradient of physical S1 (singlet response root 2) of
 # s-trans butadiene. The gradient uses the relaxed Z-vector formulation
 # (single pair-space solve). See BUTADIENE_DTCAMTB_ENERGY.inp for the
-# parameter_path convention.
+# bundled-parameter convention (parameter_path empty = bundled OB2W0PT3).
 [input]
 system=
    6   0.605000   0.398000   0.000000

--- a/examples/DTCAM-TB/README.md
+++ b/examples/DTCAM-TB/README.md
@@ -16,8 +16,11 @@ A model preset is all-inclusive: combining it with individual `[dftb]`
 operator keys is rejected by the input checker. Omit `model=` to tune the
 operator manually.
 
-Parameters: point `[dftb] parameter_path` (or `OPENQP_DFTB_PARAMETER_PATH`)
-at the OB2W0PT3 SKF directory containing the official `spinw.txt`.
+Parameters: nothing to configure with a current openqp-dftb wheel -- it
+ships the bundled OB2W0PT3 SKF set (official `spinw.txt` included), which is
+resolved automatically when `[dftb] parameter_path` is empty and
+`OPENQP_DFTB_PARAMETER_PATH` is unset. Point either knob at another
+`.opdftb`/SKF directory to override the bundled default.
 
 State convention: physical S0 is singlet response root 1; S1/S2 are roots
 2/3. The high-spin ROKS determinant is only the auxiliary reference.

--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -29,6 +29,22 @@ _EXCITED_METHOD_BY_TDHF_TYPE = {
 _GROUND_TYPES = {"ground", "dftb", "dftb0", "ground_noscc", "noscc"}
 
 
+def _bundled_parameter_path() -> str | None:
+    """Bundled OB2W0PT3 default of the installed openqp-dftb wheel, if any.
+
+    The wheel ships the SKF set plus the official shell-resolved spinw.txt
+    (required by every W kernel) next to its locator package; wheels that
+    predate the bundled data simply lack the accessor.
+    """
+    try:
+        import openqp_dftb  # noqa: PLC0415
+
+        return openqp_dftb.default_parameter_path()
+    except (ImportError, AttributeError, FileNotFoundError):
+        return None
+
+
+
 @dataclass(frozen=True)
 class _StateResult:
     state: int
@@ -421,12 +437,13 @@ class OpenQPDFTBAdapter:
             abi_version = int(abi_probe())
         else:
             abi_version = 1
-        if abi_version != 2:
+        if abi_version not in (2, 3):
             raise RuntimeError(
                 f"{path} exports openqp-dftb C ABI version {abi_version}, but this "
-                "OpenQP adapter requires version 2 (full DTCAM operator surface + "
-                "model presets). Rebuild openqp-dftb from a source revision that "
-                "provides capi ABI v2."
+                "OpenQP adapter requires version 2 or 3 (the v2 full DTCAM operator "
+                "surface; v3 only adds the bundled-parameter default resolution and "
+                "keeps the state-gradient argument list unchanged). Rebuild "
+                "openqp-dftb from a source revision that provides capi ABI v2/v3."
             )
         lib.openqp_dftb_state_gradient.restype = None
         cache["__native_library__"] = lib
@@ -842,9 +859,20 @@ class OpenQPDFTBAdapter:
 
     def _parameter_path(self) -> str:
         raw = self.dftb.get("parameter_path") or os.environ.get("OPENQP_DFTB_PARAMETER_PATH")
-        if not raw:
-            raise ValueError("Set [dftb] parameter_path or OPENQP_DFTB_PARAMETER_PATH.")
-        return str(self._resolve_user_path(raw))
+        if raw:
+            return str(self._resolve_user_path(raw))
+        bundled = _bundled_parameter_path()
+        if bundled:
+            dump_log(
+                self.mol,
+                title="PyOQP: OpenQP-DFTB bundled parameter set (parameter_path not set)\n   "
+                + bundled,
+            )
+            return bundled
+        raise ValueError(
+            "Set [dftb] parameter_path or OPENQP_DFTB_PARAMETER_PATH "
+            "(this openqp-dftb installation ships no bundled parameter set)."
+        )
 
     def _probe_executable(self) -> str:
         raw = self.dftb.get("executable") or os.environ.get("OPENQP_DFTB_STATE_GRADIENT_PROBE")

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -50,7 +50,14 @@ DFTB_MODEL_LOCKED_KEYS = (
     "onsite_exchange_scale", "spc", "spc_coco", "spc_ovov", "spc_coov",
     "onsite_ss", "onsite_sp", "onsite_pp",
     "mrsf_shift_oo", "mrsf_shift_co", "mrsf_shift_ov", "mrsf_shift_cv",
+    # The preset also fixes the numerical protocol (openqp-dftb
+    # openqp_dftb_apply_dtcam_tb_preset): Broyden mixing, SCC budget and
+    # tolerance, the Davidson response solver, and the Z-vector gradient
+    # path. Keys the preset does NOT touch (response_tolerance,
+    # response_max_iterations, response_max_subspace, nstate, ...) stay
+    # user-tunable and are deliberately absent here.
     "scc_mixer", "scc_mixing", "scc_history", "scc_max_step",
+    "scc_tolerance", "max_scc_iterations", "response_solver", "zvector",
 )
 # New-generation operator keys the probe CLI never forwards (native only).
 DFTB_NATIVE_ONLY_KEYS = (

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -91,7 +91,7 @@ WIKI_HELP = {
     "pcm.mode": "Use mode=reference_scf for MRSF-compatible PCM on the RHF/ROHF reference. post_state_correction and reference_scf_plus_post_state are planned perturbative extensions.",
     "optimize.lib": "oqp is the default optimizer backend: the built-in NumPy/SciPy optimizer (redundant internals/DLC/TRIC + restricted-step RFO) supporting optimize, ts, meci, mecp, tci, neb, irc, and mep. geometric (the external geomeTRIC package) supports optimize, MECI, MECP, TS, IRC, and NEB. scipy supports optimize, meci, mecp, and mep.",
     "nac.states": "Use state pairs such as 1 2,2 3 for NAC calculations. Each index must be a TDHF excited state.",
-    "dftb.parameter_path": "Set [dftb] parameter_path to an .opdftb file or an SKF parameter directory; OPENQP_DFTB_PARAMETER_PATH may also provide it.",
+    "dftb.parameter_path": "Set [dftb] parameter_path to an .opdftb file or an SKF parameter directory; OPENQP_DFTB_PARAMETER_PATH may also provide it. When neither is set, the bundled openqp-dftb parameter set (OB2W0PT3 with the official spinw.txt) is used automatically if installed.",
     "dftb.namd": "OpenQP-DFTB can provide NAMD surface data through runtype=data. NAC/NACME requires an implemented DFTB state-overlap backend.",
 }
 
@@ -1071,14 +1071,28 @@ def _check_dftb(config: dict[str, Any], report: CheckReport) -> None:
         )
 
     if not parameter_path and not os.environ.get("OPENQP_DFTB_PARAMETER_PATH"):
-        report.add(
-            "ERROR",
-            "dftb.parameter_path",
-            "OpenQP-DFTB requires an explicit parameter source.",
-            expected=".opdftb file or SKF directory",
-            action="Set [dftb] parameter_path, or export OPENQP_DFTB_PARAMETER_PATH.",
-            wiki=WIKI_HELP["dftb.parameter_path"],
-        )
+        # The openqp-dftb wheel ships a bundled default parameter set
+        # (OB2W0PT3 with the official spinw.txt); when it is resolvable the
+        # runtime uses it automatically and no explicit source is required.
+        bundled = None
+        try:
+            import openqp_dftb  # noqa: PLC0415
+
+            bundled = openqp_dftb.default_parameter_path()
+        except (ImportError, AttributeError, FileNotFoundError):
+            bundled = None
+        if not bundled:
+            report.add(
+                "ERROR",
+                "dftb.parameter_path",
+                "OpenQP-DFTB requires an explicit parameter source.",
+                expected=".opdftb file or SKF directory",
+                action=(
+                    "Set [dftb] parameter_path, export OPENQP_DFTB_PARAMETER_PATH, or "
+                    "install an openqp-dftb wheel that ships the bundled parameter set."
+                ),
+                wiki=WIKI_HELP["dftb.parameter_path"],
+            )
 
     if backend == "probe" and not executable and not os.environ.get("OPENQP_DFTB_STATE_GRADIENT_PROBE"):
         report.add(

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -1806,6 +1806,11 @@ def _resolve_path(value: Any, source_dir: Optional[Path]) -> Any:
     # File-backed geometries/products are normally .xyz/.pdb; retain arbitrary
     # one-token names so the existing checker can give its usual file error.
     stripped = value.strip()
+    # An empty value means "unset" (for example dftb.parameter_path resolving
+    # the bundled default); Path("") would otherwise lower it to the .oqp
+    # source directory itself.
+    if not stripped:
+        return value
     # QM/MM compact geometry references append atom selectors after the PDB
     # filename (``system.pdb 1 2 5-8``).  Resolve only the path prefix against
     # the .oqp source directory and preserve the selector suffix verbatim.


### PR DESCRIPTION
## Summary

Follow-up to #275 (the unified `[dftb]` DTCAM-TB interface): with a current openqp-dftb wheel installed, DFTB runs work **with zero parameter configuration**.

openqp-dftb remains a **separately installed** package (by design — no pip dependency or extra couples OpenQP to the private repository): install it from [Open-Quantum-Platform/openqp-dftb#11](https://github.com/Open-Quantum-Platform/openqp-dftb/pull/11) (or `@main` once that PR merges), then install OpenQP as usual.

- **Bundled parameters, no configuration**: when `[dftb] parameter_path` is empty and `OPENQP_DFTB_PARAMETER_PATH` is unset, the adapter resolves the installed openqp-dftb wheel's bundled OB2W0PT3 SKF set (official shell-resolved `spinw.txt` included — required by every spin-polarization W kernel) via `openqp_dftb.default_parameter_path()` and logs the choice; explicit sources always win. The input checker errors only when no bundled set is resolvable either.
- **ABI**: accepts openqp-dftb C ABI v2 and v3 (v3 only adds the default-parameter export; the state-gradient argument list is unchanged).
- **Examples**: all seven DFTB inputs (`examples/DFTB` + `examples/DTCAM-TB`) leave `parameter_path=` empty and run as shipped; `examples/DFTB` previously pointed at a nonexistent `params` placeholder and was unrunnable. `examples/DFTB` gains a README; job descriptors follow (`parameter_path=""`).

- **Review fixes (9e5d724)**: `.oqp` lowering no longer resolves an empty `dftb.parameter_path` to the source directory (empty = unset, so the concise examples use the bundled set as advertised), and `model=` now also locks the preset-fixed numerical keys (`scc_tolerance`, `max_scc_iterations`, `response_solver`, `zvector`).
- **Docs**: companion PR [openqp-docs#15](https://github.com/Open-Quantum-Platform/openqp-docs/pull/15) (the `model` keyword and the bundled `parameter_path` semantics).

## Verification

- Clean venv with the openqp-dftb PR #11 wheel + this branch: all seven DFTB examples exit 0 with no parameter source configured; butadiene S0 = −10.46523113 Eh identical across the `model=dtcam-tb` preset, its explicit-vector twin, and the locked openqp-dftb state-gradient probe; S1 optimization converges; the MECI example runs to its documented iteration cap.
- Bundled-set provenance and W-loading are regression-guarded on the openqp-dftb side (PR #11).

## Merge order

1. [Open-Quantum-Platform/openqp-dftb#11](https://github.com/Open-Quantum-Platform/openqp-dftb/pull/11) (bundled parameters + default resolution + ABI v3).
2. This PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
