### PR TITLE
Expose DFTB modes, diagnostics, and ABI-aware integration

### DIFF
--- a/examples/DFTB/CH2_MRSF-TDDFTB_ENERGY.oqp
+++ b/examples/DFTB/CH2_MRSF-TDDFTB_ENERGY.oqp
@@ -1,0 +1,1 @@
+mrsf-tddftb(nstate=3) geom="../geometries/CH2-e41258125cee.xyz" energy(S0) dftb(backend=native,parameter_path="")

--- a/examples/DFTB/CH2_SF-TDDFTB_ENERGY.oqp
+++ b/examples/DFTB/CH2_SF-TDDFTB_ENERGY.oqp
@@ -1,0 +1,1 @@
+sf-tddftb(nstate=3) geom="../geometries/CH2-e41258125cee.xyz" energy() dftb(backend=native,parameter_path="")

--- a/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.inp
+++ b/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.inp
@@ -1,4 +1,4 @@
-# MRSF-TDDFTB S1 gradient with the optional OpenQP-DFTB backend.
+# MRSF-TDDFTB S0 gradient with the optional OpenQP-DFTB backend.
 #
 #    group   keyword          value
 #  --------------------------------------

--- a/examples/DFTB/H2O_TDDFTB_ENERGY.oqp
+++ b/examples/DFTB/H2O_TDDFTB_ENERGY.oqp
@@ -1,0 +1,1 @@
+tddftb(nstate=3) geom="../geometries/H2O-1bdadad53a3a.xyz" energy() dftb(backend=native,parameter_path="")

--- a/examples/DFTB/H2_DFTB_ENERGY.oqp
+++ b/examples/DFTB/H2_DFTB_ENERGY.oqp
@@ -1,0 +1,1 @@
+dftb geom="../geometries/H2-069e977a383f.xyz" energy() dftb(backend=native,parameter_path="")

--- a/examples/DFTB/README.md
+++ b/examples/DFTB/README.md
@@ -1,8 +1,18 @@
-# MRSF-TDDFTB (OpenQP-DFTB backend) examples
+# DFTB response-family examples
 
-Plain long-range-corrected and uncorrected MRSF-TDDFTB through the optional
-openqp-dftb backend (`[input] method=dftb`), without the DTCAM-TB operator
-preset (for that, see `../DTCAM-TB`).
+Ground-state DFTB, conventional TD-DFTB, SF-TDDFTB, and MRSF-TDDFTB all use
+the optional openqp-dftb backend (`[input] method=dftb`). The four minimal
+semantic inputs show the method routes without unrelated controls:
+
+- `H2_DFTB_ENERGY.oqp`: SCC-DFTB ground-state energy.
+- `H2O_TDDFTB_ENERGY.oqp`: conventional singlet TD-DFTB response. The current
+  openqp-dftb response kernel is TDA, so logs identify this as
+  `TD-DFTB (TDA)`.
+- `CH2_SF-TDDFTB_ENERGY.oqp`: spin-flip TD-DFTB roots from the triplet ROKS
+  reference. Use `root=N` when selecting one SF state because its spin
+  character is assigned after the calculation.
+- `CH2_MRSF-TDDFTB_ENERGY.oqp`: physical singlet S0 and higher MRSF states
+  from the internal triplet ROKS reference.
 
 Parameters: nothing to configure with a current openqp-dftb wheel -- it
 ships the bundled OB2W0PT3 SKF set (official shell-resolved `spinw.txt`
@@ -11,11 +21,17 @@ automatically when `[dftb] parameter_path` is empty and
 `OPENQP_DFTB_PARAMETER_PATH` is unset. Point either knob at another
 `.opdftb`/SKF directory to override the bundled default.
 
-- `H2CH2_MRSF-TDDFTB_GRADIENT.inp`: analytic S0 gradient of CH2 on the
+Conventional TD-DFTB currently supports singlet targets only. Use the
+SF-TDDFTB or MRSF-TDDFTB route for triplet-state work rather than requesting
+a conventional TD-DFTB triplet.
+
+The directory also retains two more detailed MRSF inputs:
+
+- `H2CH2_MRSF-TDDFTB_GRADIENT.inp` / `.oqp`: analytic S0 gradient of CH2 on the
   triplet ROKS reference (relaxed Z-vector path).
-- `C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.inp`: LC-corrected reference
+- `C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.inp` / `.oqp`: LC-corrected reference
   (`lc_ground_state=true`) with the erf-tuned response operator
   (omega=0.25, cam_beta=1.2) that restores the MRSF bright/dark ordering.
 
-State convention: physical S0 is singlet response root 1; S1/S2 are roots
-2/3. The high-spin ROKS determinant is only the auxiliary reference.
+MRSF state convention: physical S0 is singlet response root 1; S1/S2 are
+roots 2/3. The high-spin ROKS determinant is only the auxiliary reference.

--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -76,6 +76,21 @@ def _call_with_native_diagnostics(callback, *, print_level, state_spectrum):
                 else:
                     os.environ[name] = value
 
+# C ABI v1 includes embedding/exports and the first three DTCAM controls
+# (c_mrsf, response_global_hybrid, onsite_exchange_scale). These later v2
+# controls are the only current options its shorter argument list cannot carry.
+_ABI1_UNSUPPORTED_OPTION_DEFAULTS = {
+    "c_mrsf_oo": -1.0,
+    "w_scale": 1.0,
+    "response_w_scale": -1.0,
+    "response_omega": -1.0,
+    "response_cam_alpha": -1.0,
+    "response_cam_beta": -1.0,
+    "onsite_ss": 0.0,
+    "onsite_sp": 0.0,
+    "onsite_pp": 0.0,
+}
+
 
 def _bundled_parameter_path() -> str | None:
     """Bundled OB2W0PT3 default of the installed openqp-dftb wheel, if any.
@@ -267,9 +282,12 @@ class OpenQPDFTBAdapter:
         generation = (key[0], key[1], key[2][0])
         if cache.get("__generation__") != generation:
             library = cache.get("__native_library__")
+            library_abi = cache.get("__native_abi_version__")
             cache.clear()
             if library is not None:
                 cache["__native_library__"] = library
+            if library_abi is not None:
+                cache["__native_abi_version__"] = library_abi
             cache["__generation__"] = generation
 
         backend = str(self.dftb.get("backend", "native")).lower()
@@ -299,6 +317,7 @@ class OpenQPDFTBAdapter:
             parameter_path=parameter_path,
             library_path=str(getattr(lib, "_name", "")),
         )
+        abi_version = int(self.mol._openqp_dftb_cache["__native_abi_version__"])
         natom = self.natom
         atoms = np.ascontiguousarray(
             np.asarray(self.mol.get_atoms(), dtype=np.int64).reshape(-1)
@@ -343,86 +362,51 @@ class OpenQPDFTBAdapter:
         vec_capacity = mo_capacity * nstate
         response_vectors = (ctypes.c_double * vec_capacity)()
 
-        native_call = lambda: lib.openqp_dftb_state_gradient(
-            ctypes.c_int64(natom),
-            atoms.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
-            coords_bohr.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-            parameter,
-            ctypes.c_int32(len(parameter)),
-            method_name,
-            ctypes.c_int32(len(method_name)),
-            ctypes.c_int64(int(state)),
-            ctypes.c_int64(int(max(1, self.nstate))),
-            ctypes.c_int64(int(bool(need_grad))),
-            ctypes.c_int64(int(self.config.get("input", {}).get("charge", 0))),
-            ctypes.c_int64(self._scc_mixer_code()),
-            ctypes.c_int64(int(self.dftb.get("scc_history", 12))),
-            ctypes.c_int64(int(self.dftb.get("max_scc_iterations", 1200))),
-            ctypes.c_int64(int(self.dftb.get("response_max_iterations", 50))),
-            ctypes.c_int64(int(self.dftb.get("response_max_subspace", 100))),
-            ctypes.c_int64(self._response_solver_code()),
-            ctypes.c_int64(self._reference_multiplicity(method)),
-            ctypes.c_int64(int(self.dftb.get("target_multiplicity", 1))),
-            ctypes.c_int64(int(bool(self.dftb.get("spin_complete", True)))),
-            ctypes.c_int64(int(bool(self.dftb.get("lc_ground_state", False)))),
-            ctypes.c_int64(int(self._lc_gamma_is_erf())),
-            ctypes.c_int64(int(bool(self.dftb.get("zvector", True)))),
-            ctypes.c_double(float(self.dftb.get("scc_tolerance", 1.0e-8))),
-            ctypes.c_double(float(self.dftb.get("scc_mixing", 0.35))),
-            ctypes.c_double(float(self.dftb.get("scc_max_step", 0.5))),
-            ctypes.c_double(float(self.dftb.get("response_tolerance", 1.0e-6))),
-            ctypes.c_double(self._spc_channel("spc_coco")),
-            ctypes.c_double(self._spc_channel("spc_ovov")),
-            ctypes.c_double(self._spc_channel("spc_coov")),
-            ctypes.c_double(float(self.dftb.get("omega", 0.3))),
-            ctypes.c_double(float(self.dftb.get("cam_alpha", 0.0))),
-            ctypes.c_double(float(self.dftb.get("cam_beta", 1.0))),
-            ctypes.c_double(float(self.dftb.get("mrsf_shift_oo", 0.0))),
-            ctypes.c_double(float(self.dftb.get("mrsf_shift_co", 0.0))),
-            ctypes.c_double(float(self.dftb.get("mrsf_shift_ov", 0.0))),
-            ctypes.c_double(float(self.dftb.get("mrsf_shift_cv", 0.0))),
-            # Full DTCAM operator surface (capi ABI v2); defaults equal the
-            # openqp-dftb type defaults so pre-existing inputs are
-            # bit-identical. The preset (model=) is applied last inside
-            # openqp-dftb and overrides the individual knobs.
-            ctypes.c_double(float(self.dftb.get("c_mrsf", -1.0))),
-            ctypes.c_int64(int(bool(self.dftb.get("response_global_hybrid", False)))),
-            ctypes.c_double(float(self.dftb.get("onsite_exchange_scale", 0.0))),
-            ctypes.c_double(float(self.dftb.get("w_scale", 1.0))),
-            ctypes.c_double(float(self.dftb.get("response_w_scale", -1.0))),
-            ctypes.c_double(float(self.dftb.get("response_omega", -1.0))),
-            ctypes.c_double(float(self.dftb.get("response_cam_alpha", -1.0))),
-            ctypes.c_double(float(self.dftb.get("response_cam_beta", -1.0))),
-            ctypes.c_double(float(self.dftb.get("c_mrsf_oo", -1.0))),
-            ctypes.c_double(float(self.dftb.get("onsite_ss", 0.0))),
-            ctypes.c_double(float(self.dftb.get("onsite_sp", 0.0))),
-            ctypes.c_double(float(self.dftb.get("onsite_pp", 0.0))),
-            self._preset_bytes,
-            ctypes.c_int32(len(self._preset_bytes)),
-            ctypes.c_int64(n_ext),
-            ext_potential,
-            ctypes.byref(reference_energy),
-            ctypes.byref(state_energy),
-            ctypes.byref(excitation_energy),
-            ctypes.byref(spin_square),
-            gradient,
-            ctypes.byref(n_roots_out),
-            all_state_energies,
-            all_spin_squares,
-            relaxed_charges,
-            ctypes.byref(nbf_out),
-            ctypes.byref(noca_out),
-            ctypes.byref(nocb_out),
-            ctypes.byref(vec_dim_out),
-            ctypes.c_int64(mo_capacity),
-            mo_energies,
-            mo_coefficients,
-            ctypes.c_int64(vec_capacity),
-            response_vectors,
-            status_message,
-            ctypes.c_int32(1024),
-            ctypes.byref(status),
-        )
+        call_kwargs = {
+            "natom": natom,
+            "atoms": atoms,
+            "coords_bohr": coords_bohr,
+            "parameter": parameter,
+            "method_name": method_name,
+            "state": state,
+            "need_grad": need_grad,
+            "n_ext": n_ext,
+            "ext_potential": ext_potential,
+            "reference_energy": reference_energy,
+            "state_energy": state_energy,
+            "excitation_energy": excitation_energy,
+            "spin_square": spin_square,
+            "gradient": gradient,
+            "n_roots_out": n_roots_out,
+            "all_state_energies": all_state_energies,
+            "all_spin_squares": all_spin_squares,
+            "relaxed_charges": relaxed_charges,
+            "nbf_out": nbf_out,
+            "noca_out": noca_out,
+            "nocb_out": nocb_out,
+            "vec_dim_out": vec_dim_out,
+            "mo_capacity": mo_capacity,
+            "mo_energies": mo_energies,
+            "mo_coefficients": mo_coefficients,
+            "vec_capacity": vec_capacity,
+            "response_vectors": response_vectors,
+            "status_message": status_message,
+            "status": status,
+        }
+
+        def native_call():
+            if abi_version == 1:
+                self._call_state_gradient_abi1(
+                    lib.openqp_dftb_state_gradient, **call_kwargs
+                )
+            else:
+                self._call_state_gradient_current(
+                    lib.openqp_dftb_state_gradient, **call_kwargs
+                )
+
+        if abi_version == 1:
+            self._validate_abi1_request()
+
         state_spectrum = (
             method not in _GROUND_TYPES
             and not need_grad
@@ -445,13 +429,12 @@ class OpenQPDFTBAdapter:
                     "text": native_trace,
                 },
             )
-        if status.value != 0:
-            detail = status_message.value.decode("utf-8", errors="replace").strip()
-            suffix = f": {detail}" if detail else ""
-            raise RuntimeError(
-                f"openqp-dftb native library call failed for method={method}, "
-                f"state={state}, status={status.value}{suffix}"
-            )
+        self._raise_native_status(
+            method=method,
+            state=state,
+            status=status,
+            status_message=status_message,
+        )
 
         gradient_bohr = np.frombuffer(gradient, dtype=np.float64).reshape((natom, 3)).copy()
         n_roots = int(n_roots_out.value)
@@ -490,6 +473,162 @@ class OpenQPDFTBAdapter:
             response_vectors=vecs,
         )
 
+    def _state_gradient_common_arguments(self, values):
+        """Arguments shared by every state-gradient ABI (slots 1--37)."""
+        return [
+            ctypes.c_int64(values["natom"]),
+            values["atoms"].ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
+            values["coords_bohr"].ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+            values["parameter"],
+            ctypes.c_int32(len(values["parameter"])),
+            values["method_name"],
+            ctypes.c_int32(len(values["method_name"])),
+            ctypes.c_int64(int(values["state"])),
+            ctypes.c_int64(int(max(1, self.nstate))),
+            ctypes.c_int64(int(bool(values["need_grad"]))),
+            ctypes.c_int64(int(self.config.get("input", {}).get("charge", 0))),
+            ctypes.c_int64(self._scc_mixer_code()),
+            ctypes.c_int64(int(self.dftb.get("scc_history", 12))),
+            ctypes.c_int64(int(self.dftb.get("max_scc_iterations", 1200))),
+            ctypes.c_int64(int(self.dftb.get("response_max_iterations", 50))),
+            ctypes.c_int64(int(self.dftb.get("response_max_subspace", 100))),
+            ctypes.c_int64(self._response_solver_code()),
+            ctypes.c_int64(
+                self._reference_multiplicity(
+                    values["method_name"].decode("ascii")
+                )
+            ),
+            ctypes.c_int64(int(self.dftb.get("target_multiplicity", 1))),
+            ctypes.c_int64(int(bool(self.dftb.get("spin_complete", True)))),
+            ctypes.c_int64(int(bool(self.dftb.get("lc_ground_state", False)))),
+            ctypes.c_int64(int(self._lc_gamma_is_erf())),
+            ctypes.c_int64(int(bool(self.dftb.get("zvector", True)))),
+            ctypes.c_double(float(self.dftb.get("scc_tolerance", 1.0e-8))),
+            ctypes.c_double(float(self.dftb.get("scc_mixing", 0.35))),
+            ctypes.c_double(float(self.dftb.get("scc_max_step", 0.5))),
+            ctypes.c_double(float(self.dftb.get("response_tolerance", 1.0e-6))),
+            ctypes.c_double(self._spc_channel("spc_coco")),
+            ctypes.c_double(self._spc_channel("spc_ovov")),
+            ctypes.c_double(self._spc_channel("spc_coov")),
+            ctypes.c_double(float(self.dftb.get("omega", 0.3))),
+            ctypes.c_double(float(self.dftb.get("cam_alpha", 0.0))),
+            ctypes.c_double(float(self.dftb.get("cam_beta", 1.0))),
+            ctypes.c_double(float(self.dftb.get("mrsf_shift_oo", 0.0))),
+            ctypes.c_double(float(self.dftb.get("mrsf_shift_co", 0.0))),
+            ctypes.c_double(float(self.dftb.get("mrsf_shift_ov", 0.0))),
+            ctypes.c_double(float(self.dftb.get("mrsf_shift_cv", 0.0))),
+        ]
+
+    @staticmethod
+    def _state_gradient_output_arguments(values):
+        """Embedding and result tail shared by ABI v1 and current ABIs."""
+        return [
+            ctypes.c_int64(values["n_ext"]),
+            values["ext_potential"],
+            ctypes.byref(values["reference_energy"]),
+            ctypes.byref(values["state_energy"]),
+            ctypes.byref(values["excitation_energy"]),
+            ctypes.byref(values["spin_square"]),
+            values["gradient"],
+            ctypes.byref(values["n_roots_out"]),
+            values["all_state_energies"],
+            values["all_spin_squares"],
+            values["relaxed_charges"],
+            ctypes.byref(values["nbf_out"]),
+            ctypes.byref(values["noca_out"]),
+            ctypes.byref(values["nocb_out"]),
+            ctypes.byref(values["vec_dim_out"]),
+            ctypes.c_int64(values["mo_capacity"]),
+            values["mo_energies"],
+            values["mo_coefficients"],
+            ctypes.c_int64(values["vec_capacity"]),
+            values["response_vectors"],
+            values["status_message"],
+            ctypes.c_int32(1024),
+            ctypes.byref(values["status"]),
+        ]
+
+    def _call_state_gradient_abi1(self, function, **values) -> None:
+        """Call the stable 63-argument openqp-dftb C ABI v1.
+
+        ABI v1 includes the first DTCAM controls, QM/MM embedding, all-root
+        results, relaxed charges, and wavefunction exports. ABI v2 inserted
+        later DTCAM/preset arguments immediately before the shared result tail,
+        so dispatching only on an accepted version number would shift pointers.
+        """
+        function(
+            *self._state_gradient_common_arguments(values),
+            ctypes.c_double(float(self.dftb.get("c_mrsf", -1.0))),
+            ctypes.c_int64(
+                int(bool(self.dftb.get("response_global_hybrid", False)))
+            ),
+            ctypes.c_double(
+                float(self.dftb.get("onsite_exchange_scale", 0.0))
+            ),
+            *self._state_gradient_output_arguments(values),
+        )
+
+    def _call_state_gradient_current(self, function, **values) -> None:
+        """Call the ABI-v2/v3 state-gradient layout."""
+        function(
+            *self._state_gradient_common_arguments(values),
+            ctypes.c_double(float(self.dftb.get("c_mrsf", -1.0))),
+            ctypes.c_int64(
+                int(bool(self.dftb.get("response_global_hybrid", False)))
+            ),
+            ctypes.c_double(
+                float(self.dftb.get("onsite_exchange_scale", 0.0))
+            ),
+            ctypes.c_double(float(self.dftb.get("w_scale", 1.0))),
+            ctypes.c_double(float(self.dftb.get("response_w_scale", -1.0))),
+            ctypes.c_double(float(self.dftb.get("response_omega", -1.0))),
+            ctypes.c_double(float(self.dftb.get("response_cam_alpha", -1.0))),
+            ctypes.c_double(float(self.dftb.get("response_cam_beta", -1.0))),
+            ctypes.c_double(float(self.dftb.get("c_mrsf_oo", -1.0))),
+            ctypes.c_double(float(self.dftb.get("onsite_ss", 0.0))),
+            ctypes.c_double(float(self.dftb.get("onsite_sp", 0.0))),
+            ctypes.c_double(float(self.dftb.get("onsite_pp", 0.0))),
+            self._preset_bytes,
+            ctypes.c_int32(len(self._preset_bytes)),
+            *self._state_gradient_output_arguments(values),
+        )
+
+    def _validate_abi1_request(self) -> None:
+        """Reject features that cannot be represented by the ABI-v1 call."""
+        limitations = []
+
+        model = str(self.dftb.get("model", "")).strip()
+        if model:
+            limitations.append(f"model={model!r}")
+
+        for key, default in _ABI1_UNSUPPORTED_OPTION_DEFAULTS.items():
+            value = self.dftb.get(key, default)
+            if isinstance(default, bool):
+                differs = bool(value) is not default
+            else:
+                differs = float(value) != default
+            if differs:
+                limitations.append(f"{key}={value!r}")
+
+        if limitations:
+            detail = ", ".join(limitations)
+            raise RuntimeError(
+                "The loaded openqp-dftb library provides C ABI v1, which cannot "
+                f"represent: {detail}. Install openqp-dftb >= 0.2.0 (C ABI v3) "
+                "or reset the unsupported option(s) to their ABI-v1 defaults."
+            )
+
+    @staticmethod
+    def _raise_native_status(*, method, state, status, status_message) -> None:
+        if status.value == 0:
+            return
+        detail = status_message.value.decode("utf-8", errors="replace").strip()
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(
+            f"openqp-dftb native library call failed for method={method}, "
+            f"state={state}, status={status.value}{suffix}"
+        )
+
     def _native_library(self):
         cache = self.mol._openqp_dftb_cache
         lib = cache.get("__native_library__")
@@ -507,24 +646,40 @@ class OpenQPDFTBAdapter:
             )
         # The state-gradient arguments are passed by value with no argtypes
         # metadata, so an adapter/library revision mismatch would silently
-        # read garbage. Require the exact ABI generation this adapter emits
-        # (a library without the version symbol predates the check).
+        # read garbage. Detect the ABI before the first call and dispatch its
+        # exact argument layout. The released v1 predates the version symbol.
         abi_probe = getattr(lib, "openqp_dftb_capi_abi_version", None)
         if abi_probe is not None:
             abi_probe.restype = ctypes.c_int64
             abi_version = int(abi_probe())
         else:
+            # Stable ABI v1 shipped alongside these two C exports. Earlier
+            # unversioned development snapshots used other argument layouts
+            # and cannot be distinguished by inspecting state_gradient itself.
+            abi1_markers = (
+                "openqp_dftb_states_overlap",
+                "openqp_dftb_soc_matrix",
+            )
+            missing_markers = [
+                symbol for symbol in abi1_markers if not hasattr(lib, symbol)
+            ]
+            if missing_markers:
+                missing = ", ".join(missing_markers)
+                raise RuntimeError(
+                    f"{path} has no openqp-dftb C ABI version symbol and lacks "
+                    f"the stable ABI-v1 marker export(s): {missing}. Its "
+                    "state-gradient argument layout cannot be identified "
+                    "safely; install openqp-dftb >= 0.2.0."
+                )
             abi_version = 1
-        if abi_version not in (2, 3):
+        if abi_version not in (1, 2, 3):
             raise RuntimeError(
                 f"{path} exports openqp-dftb C ABI version {abi_version}, but this "
-                "OpenQP adapter requires version 2 or 3 (the v2 full DTCAM operator "
-                "surface; v3 only adds the bundled-parameter default resolution and "
-                "keeps the state-gradient argument list unchanged). Rebuild "
-                "openqp-dftb from a source revision that provides capi ABI v2/v3."
+                "OpenQP adapter supports only versions 1, 2, and 3."
             )
         lib.openqp_dftb_state_gradient.restype = None
         cache["__native_library__"] = lib
+        cache["__native_abi_version__"] = abi_version
         return lib
 
     def _native_library_path(self) -> Path:

--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -8,8 +8,10 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 import tempfile
 import textwrap
+import threading
 
 import numpy as np
 
@@ -17,16 +19,62 @@ import oqp
 from oqp.periodic_table import ELEMENTS_NAME
 from oqp.utils.constants import ANGSTROM_TO_BOHR as BOHR_TO_ANGSTROM
 from oqp.utils.file_utils import dump_log
+from oqp.utils.state_labels import canonical_dftb_type, resolved_dftb_type
 
-
-_EXCITED_METHOD_BY_TDHF_TYPE = {
-    "rpa": "tddftb",
-    "tda": "tddftb",
-    "sf": "sf",
-    "mrsf": "mrsf",
-}
 
 _GROUND_TYPES = {"ground", "dftb", "dftb0", "ground_noscc", "noscc"}
+_NATIVE_DIAGNOSTIC_LOCK = threading.RLock()
+_NATIVE_DIAGNOSTIC_ENV = (
+    "OPENQP_DFTB_SCC_TRACE",
+    "OPENQP_DFTB_SOLVER_TRACE",
+    "OPENQP_ZVEC_TRACE",
+    "OPENQP_DFTB_STATE_SPECTRUM",
+)
+
+
+def _call_with_native_diagnostics(callback, *, print_level, state_spectrum):
+    """Run one native call while capturing flushed Fortran stdout.
+
+    The C ABI predates structured diagnostics.  Its optional trace hooks write
+    to the preconnected Fortran output unit, so capture file descriptor 1 for
+    the duration of the call and return the text for the normal OpenQP log.
+    Environment and descriptor changes are process-global; serialize them
+    within this Python process and restore both even on failure.
+    """
+    level = max(0, min(2, int(print_level)))
+    updates = {
+        "OPENQP_DFTB_SCC_TRACE": str(level),
+        "OPENQP_DFTB_SOLVER_TRACE": str(level),
+        "OPENQP_ZVEC_TRACE": str(level),
+        "OPENQP_DFTB_STATE_SPECTRUM": "1" if state_spectrum else "0",
+    }
+
+    with _NATIVE_DIAGNOSTIC_LOCK:
+        previous = {name: os.environ.get(name) for name in _NATIVE_DIAGNOSTIC_ENV}
+        for name, value in updates.items():
+            os.environ[name] = value
+        saved_stdout = None
+        try:
+            sys.stdout.flush()
+            saved_stdout = os.dup(1)
+            with tempfile.TemporaryFile(mode="w+b") as capture:
+                os.dup2(capture.fileno(), 1)
+                try:
+                    callback()
+                finally:
+                    # Core trace and spectrum writers flush their Fortran
+                    # output unit; restore stdout before decoding the capture.
+                    os.dup2(saved_stdout, 1)
+                capture.seek(0)
+                return capture.read().decode("utf-8", errors="replace")
+        finally:
+            if saved_stdout is not None:
+                os.close(saved_stdout)
+            for name, value in previous.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
 
 
 def _bundled_parameter_path() -> str | None:
@@ -244,6 +292,13 @@ class OpenQPDFTBAdapter:
         state gradient back. No OpenQP build coupling, no Fortran module seam.
         """
         lib = self._native_library()
+        parameter_path = self._parameter_path()
+        self._log_settings_once(
+            method,
+            backend="native",
+            parameter_path=parameter_path,
+            library_path=str(getattr(lib, "_name", "")),
+        )
         natom = self.natom
         atoms = np.ascontiguousarray(
             np.asarray(self.mol.get_atoms(), dtype=np.int64).reshape(-1)
@@ -251,7 +306,7 @@ class OpenQPDFTBAdapter:
         coords_bohr = np.ascontiguousarray(
             np.asarray(self.mol.get_system(), dtype=np.float64).reshape(-1)
         )
-        parameter = self._parameter_path().encode("utf-8")
+        parameter = parameter_path.encode("utf-8")
         method_name = self._probe_method_name(method).encode("ascii")
 
         reference_energy = ctypes.c_double()
@@ -288,7 +343,7 @@ class OpenQPDFTBAdapter:
         vec_capacity = mo_capacity * nstate
         response_vectors = (ctypes.c_double * vec_capacity)()
 
-        lib.openqp_dftb_state_gradient(
+        native_call = lambda: lib.openqp_dftb_state_gradient(
             ctypes.c_int64(natom),
             atoms.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
             coords_bohr.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
@@ -368,6 +423,28 @@ class OpenQPDFTBAdapter:
             ctypes.c_int32(1024),
             ctypes.byref(status),
         )
+        state_spectrum = (
+            method not in _GROUND_TYPES
+            and not need_grad
+            and bool(self.dftb.get("state_to_state_spectrum", True))
+        )
+        native_trace = _call_with_native_diagnostics(
+            native_call,
+            print_level=int(self.dftb.get("print_level", 1)),
+            state_spectrum=state_spectrum,
+        )
+        if native_trace.strip():
+            dump_log(
+                self.mol,
+                title="PyOQP: OpenQP-DFTB native progress",
+                section="dftb_runtime",
+                info={
+                    "method": canonical_dftb_type(method),
+                    "state": int(state),
+                    "gradient": bool(need_grad),
+                    "text": native_trace,
+                },
+            )
         if status.value != 0:
             detail = status_message.value.decode("utf-8", errors="replace").strip()
             suffix = f": {detail}" if detail else ""
@@ -401,6 +478,7 @@ class OpenQPDFTBAdapter:
             gradient_bohr=gradient_bohr,
             excitation_energy=float(excitation_energy.value) if state > 0 else None,
             spin_square=float(spin_square.value) if state > 0 else None,
+            stdout=native_trace,
             all_state_energies=all_e,
             all_spin_squares=all_s2,
             relaxed_charges=np.frombuffer(relaxed_charges, dtype=np.float64).copy(),
@@ -500,6 +578,12 @@ class OpenQPDFTBAdapter:
     def _run_probe(self, method: str, state: int) -> _StateResult:
         executable = self._probe_executable()
         parameter_path = self._parameter_path()
+        self._log_settings_once(
+            method,
+            backend="probe",
+            parameter_path=parameter_path,
+            executable=executable,
+        )
         with tempfile.TemporaryDirectory(prefix="openqp-dftb-") as tmpdir:
             xyz_path = Path(tmpdir) / "molecule.xyz"
             self._write_xyz(xyz_path)
@@ -523,12 +607,6 @@ class OpenQPDFTBAdapter:
                 str(int(self.config.get("input", {}).get("charge", 0))),
                 "erf" if self._lc_gamma_is_erf() else "yukawa",
             ]
-            dump_log(
-                self.mol,
-                title="PyOQP: OpenQP-DFTB state calculation",
-                section="dftb",
-                info=[method, state, parameter_path],
-            )
             completed = subprocess.run(
                 cmd,
                 check=False,
@@ -544,6 +622,47 @@ class OpenQPDFTBAdapter:
                 f"method={method}, state={state}, rc={completed.returncode}\n{tail}"
             )
         return self._parse_probe_output(state, completed.stdout)
+
+    def _log_settings_once(
+        self,
+        method: str,
+        *,
+        backend: str,
+        parameter_path: str,
+        library_path: str = "",
+        executable: str = "",
+    ) -> None:
+        """Write one settings block per distinct DFTB request, not per state."""
+        signature = (
+            canonical_dftb_type(method),
+            backend,
+            parameter_path,
+            library_path,
+            executable,
+            tuple(sorted((str(key), repr(value)) for key, value in self.dftb.items())),
+            tuple(sorted(
+                (str(key), repr(value))
+                for key, value in self.config.get("tdhf", {}).items()
+            )),
+        )
+        logged = getattr(self.mol, "_openqp_dftb_logged_settings", None)
+        if logged is None:
+            logged = set()
+            self.mol._openqp_dftb_logged_settings = logged
+        if signature in logged:
+            return
+        logged.add(signature)
+        dump_log(
+            self.mol,
+            title="PyOQP: OpenQP-DFTB settings",
+            section="dftb",
+            info={
+                "backend": backend,
+                "parameter_path": parameter_path,
+                "library_path": library_path,
+                "executable": executable,
+            },
+        )
 
     def _parse_probe_output(self, state: int, stdout: str) -> _StateResult:
         reference_energy = None
@@ -587,32 +706,10 @@ class OpenQPDFTBAdapter:
         )
 
     def _resolved_method(self) -> str:
-        explicit = str(self.dftb.get("type", "auto")).strip().lower()
-        if explicit and explicit != "auto":
-            return explicit
-
-        runtype = str(self.config.get("input", {}).get("runtype", "energy")).lower()
-        istate = int(self.config.get("optimize", {}).get("istate", 0))
-        if runtype in {"optimize", "mep"} and istate == 0:
-            return "ground"
-
-        td_type = str(self.config.get("tdhf", {}).get("type", "tda")).lower()
-
-        # A plain energy/gradient run that targets no excited state and does not
-        # explicitly request an open-shell (SF/MRSF) response is a ground-state
-        # DFTB job. An explicit tdhf.type=sf/mrsf is honored even for
-        # runtype=energy, so it is NOT collapsed to ground here.
-        if runtype in {"energy", "grad"} and td_type in {"rpa", "tda"}:
-            grad_states = [int(x) for x in self.config.get("properties", {}).get("grad", [])]
-            if not any(s > 0 for s in grad_states):
-                return "ground"
-
-        try:
-            return _EXCITED_METHOD_BY_TDHF_TYPE[td_type]
-        except KeyError as exc:
-            raise ValueError(
-                f"Cannot derive OpenQP-DFTB response type from tdhf.type={td_type!r}."
-            ) from exc
+        method = resolved_dftb_type(self.config)
+        if method not in {"ground", "ground_noscc", "tddftb", "sf", "mrsf"}:
+            raise ValueError(f"Unknown OpenQP-DFTB calculation type: {method!r}.")
+        return method
 
     def _effective_nstate(self) -> int:
         config = self.config
@@ -838,6 +935,8 @@ class OpenQPDFTBAdapter:
             int(self.dftb.get("response_max_subspace", 100)),
             int(self.dftb.get("response_max_iterations", 50)),
             float(self.dftb.get("response_tolerance", 1.0e-6)),
+            int(self.dftb.get("print_level", 1)),
+            bool(self.dftb.get("state_to_state_spectrum", True)),
             # DTCAM operator surface + preset: a Python workflow may retune
             # these on the same molecule, so cached results must not outlive
             # them.
@@ -863,11 +962,6 @@ class OpenQPDFTBAdapter:
             return str(self._resolve_user_path(raw))
         bundled = _bundled_parameter_path()
         if bundled:
-            dump_log(
-                self.mol,
-                title="PyOQP: OpenQP-DFTB bundled parameter set (parameter_path not set)\n   "
-                + bundled,
-            )
             return bundled
         raise ValueError(
             "Set [dftb] parameter_path or OPENQP_DFTB_PARAMETER_PATH "
@@ -914,20 +1008,7 @@ class OpenQPDFTBAdapter:
 
     @staticmethod
     def _probe_method_name(method: str) -> str:
-        # Normalize every accepted [dftb] type alias to one of the backend's
-        # method names (ground variants, tddftb, sf, mrsf). The input checker
-        # accepts spellings such as tda/td-dftb/sftddftb/mrsftddftb; the native
-        # C API does not recognize all of them, so canonicalize here.
-        method = method.lower()
-        canon = {
-            "dftb": "ground", "ground": "ground",
-            "dftb0": "ground_noscc", "noscc": "ground_noscc",
-            "ground_noscc": "ground_noscc",
-            "tddftb": "tddftb", "tda": "tddftb", "td-dftb": "tddftb", "rpa": "tddftb",
-            "sf": "sf", "sftddftb": "sf", "sf-tddftb": "sf",
-            "mrsf": "mrsf", "mrsftddftb": "mrsf", "mrsf-tddftb": "mrsf",
-        }
-        return canon.get(method, method)
+        return canonical_dftb_type(method)
 
     @staticmethod
     def _fmt(value) -> str:
@@ -945,9 +1026,9 @@ class OpenQPDFTBAdapter:
 
     def _reference_multiplicity(self, method: str) -> int:
         explicit = int(self.dftb.get("reference_multiplicity", 0))
-        if explicit > 0:
-            return explicit
-        return 3 if method in {"sf", "sftddftb", "sf-tddftb", "mrsf", "mrsftddftb", "mrsf-tddftb"} else 1
+        if canonical_dftb_type(method) in {"sf", "mrsf"}:
+            return explicit if explicit > 1 else 3
+        return explicit if explicit > 0 else 1
 
     def _spc_channel(self, key: str) -> float:
         value = self.dftb.get(key, None)

--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -19,7 +19,12 @@ import oqp
 from oqp.periodic_table import ELEMENTS_NAME
 from oqp.utils.constants import ANGSTROM_TO_BOHR as BOHR_TO_ANGSTROM
 from oqp.utils.file_utils import dump_log
-from oqp.utils.state_labels import canonical_dftb_type, resolved_dftb_type
+from oqp.utils.state_labels import (
+    DFTB_CAP_STATE_SPECTRUM,
+    DFTB_CAP_STRUCTURED_TRACE,
+    canonical_dftb_type,
+    resolved_dftb_type,
+)
 
 
 _GROUND_TYPES = {"ground", "dftb", "dftb0", "ground_noscc", "noscc"}
@@ -32,7 +37,8 @@ _NATIVE_DIAGNOSTIC_ENV = (
 )
 
 
-def _call_with_native_diagnostics(callback, *, print_level, state_spectrum):
+def _call_with_native_diagnostics(
+        callback, *, print_level, state_spectrum, structured_trace=True):
     """Run one native call while capturing flushed Fortran stdout.
 
     The C ABI predates structured diagnostics.  Its optional trace hooks write
@@ -41,7 +47,8 @@ def _call_with_native_diagnostics(callback, *, print_level, state_spectrum):
     Environment and descriptor changes are process-global; serialize them
     within this Python process and restore both even on failure.
     """
-    level = max(0, min(2, int(print_level)))
+    requested_level = max(0, min(2, int(print_level)))
+    level = requested_level if structured_trace else 0
     updates = {
         "OPENQP_DFTB_SCC_TRACE": str(level),
         "OPENQP_DFTB_SOLVER_TRACE": str(level),
@@ -283,11 +290,14 @@ class OpenQPDFTBAdapter:
         if cache.get("__generation__") != generation:
             library = cache.get("__native_library__")
             library_abi = cache.get("__native_abi_version__")
+            library_capabilities = cache.get("__native_capabilities__")
             cache.clear()
             if library is not None:
                 cache["__native_library__"] = library
             if library_abi is not None:
                 cache["__native_abi_version__"] = library_abi
+            if library_capabilities is not None:
+                cache["__native_capabilities__"] = library_capabilities
             cache["__generation__"] = generation
 
         backend = str(self.dftb.get("backend", "native")).lower()
@@ -311,6 +321,9 @@ class OpenQPDFTBAdapter:
         """
         lib = self._native_library()
         abi_version = int(self.mol._openqp_dftb_cache["__native_abi_version__"])
+        capabilities = int(
+            self.mol._openqp_dftb_cache.get("__native_capabilities__", 0)
+        )
         parameter_path = self._parameter_path()
         self._log_settings_once(
             method,
@@ -318,6 +331,7 @@ class OpenQPDFTBAdapter:
             parameter_path=parameter_path,
             library_path=str(getattr(lib, "_name", "")),
             abi_version=abi_version,
+            capabilities=capabilities,
         )
         natom = self.natom
         atoms = np.ascontiguousarray(
@@ -412,11 +426,13 @@ class OpenQPDFTBAdapter:
             method not in _GROUND_TYPES
             and not need_grad
             and bool(self.dftb.get("state_to_state_spectrum", True))
+            and bool(capabilities & DFTB_CAP_STATE_SPECTRUM)
         )
         native_trace = _call_with_native_diagnostics(
             native_call,
             print_level=int(self.dftb.get("print_level", 1)),
             state_spectrum=state_spectrum,
+            structured_trace=bool(capabilities & DFTB_CAP_STRUCTURED_TRACE),
         )
         if native_trace.strip():
             dump_log(
@@ -634,6 +650,9 @@ class OpenQPDFTBAdapter:
         cache = self.mol._openqp_dftb_cache
         lib = cache.get("__native_library__")
         if lib is not None:
+            if "__native_capabilities__" not in cache:
+                cache["__native_capabilities__"] = \
+                    self._native_capabilities(lib)
             return lib
         path = self._native_library_path()
         try:
@@ -681,7 +700,23 @@ class OpenQPDFTBAdapter:
         lib.openqp_dftb_state_gradient.restype = None
         cache["__native_library__"] = lib
         cache["__native_abi_version__"] = abi_version
+        cache["__native_capabilities__"] = self._native_capabilities(lib)
         return lib
+
+    @staticmethod
+    def _native_capabilities(lib) -> int:
+        """Return additive native capabilities; a missing symbol means none."""
+        probe = getattr(lib, "openqp_dftb_capi_capabilities", None)
+        if probe is None:
+            return 0
+        probe.restype = ctypes.c_int64
+        capabilities = int(probe())
+        if capabilities < 0:
+            raise RuntimeError(
+                "openqp-dftb returned a negative C capability mask: "
+                f"{capabilities}"
+            )
+        return capabilities
 
     def _native_library_path(self) -> Path:
         raw = self.dftb.get("library_path") or os.environ.get("OPENQP_DFTB_LIBRARY")
@@ -788,6 +823,7 @@ class OpenQPDFTBAdapter:
         library_path: str = "",
         executable: str = "",
         abi_version: int | None = None,
+        capabilities: int | None = None,
     ) -> None:
         """Write one settings block per distinct DFTB request, not per state."""
         signature = (
@@ -797,6 +833,7 @@ class OpenQPDFTBAdapter:
             library_path,
             executable,
             abi_version,
+            capabilities,
             tuple(sorted((str(key), repr(value)) for key, value in self.dftb.items())),
             tuple(sorted(
                 (str(key), repr(value))
@@ -820,6 +857,7 @@ class OpenQPDFTBAdapter:
                 "library_path": library_path,
                 "executable": executable,
                 "abi_version": abi_version,
+                "capabilities": capabilities,
             },
         )
 

--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -310,14 +310,15 @@ class OpenQPDFTBAdapter:
         state gradient back. No OpenQP build coupling, no Fortran module seam.
         """
         lib = self._native_library()
+        abi_version = int(self.mol._openqp_dftb_cache["__native_abi_version__"])
         parameter_path = self._parameter_path()
         self._log_settings_once(
             method,
             backend="native",
             parameter_path=parameter_path,
             library_path=str(getattr(lib, "_name", "")),
+            abi_version=abi_version,
         )
-        abi_version = int(self.mol._openqp_dftb_cache["__native_abi_version__"])
         natom = self.natom
         atoms = np.ascontiguousarray(
             np.asarray(self.mol.get_atoms(), dtype=np.int64).reshape(-1)
@@ -786,6 +787,7 @@ class OpenQPDFTBAdapter:
         parameter_path: str,
         library_path: str = "",
         executable: str = "",
+        abi_version: int | None = None,
     ) -> None:
         """Write one settings block per distinct DFTB request, not per state."""
         signature = (
@@ -794,6 +796,7 @@ class OpenQPDFTBAdapter:
             parameter_path,
             library_path,
             executable,
+            abi_version,
             tuple(sorted((str(key), repr(value)) for key, value in self.dftb.items())),
             tuple(sorted(
                 (str(key), repr(value))
@@ -816,6 +819,7 @@ class OpenQPDFTBAdapter:
                 "parameter_path": parameter_path,
                 "library_path": library_path,
                 "executable": executable,
+                "abi_version": abi_version,
             },
         )
 

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -192,6 +192,11 @@ OQP_CONFIG_SCHEMA = {
         'response_max_iterations': {'type': int, 'default': '50'},
         'response_max_subspace': {'type': int, 'default': '100'},
         'response_solver': {'type': string, 'default': 'auto'},
+        # 0: quiet native kernels, 1: stages/summaries, 2: iteration detail.
+        'print_level': {'type': int, 'default': '1'},
+        # Upward root-pair oscillator strengths (unrelaxed
+        # TDA/state-interaction approximation).
+        'state_to_state_spectrum': {'type': bool, 'default': 'True'},
         'spc': {'type': float, 'default': '0.5'},
         'spc_coco': {'type': float, 'default': '-999.0'},
         'spc_ovov': {'type': float, 'default': '-999.0'},

--- a/pyoqp/oqp/openqp.py
+++ b/pyoqp/oqp/openqp.py
@@ -15,6 +15,7 @@ from oqp.utils.geometry import (
 )
 from oqp.utils.input_parser import OQPConfigParser
 from oqp.utils.kword_map import resolve_param_key
+from oqp.utils.state_labels import canonical_dftb_type
 
 
 def dump_strings_from_parser(parser):
@@ -252,6 +253,18 @@ class _TheoryProxy:
 
     def dftb(self, **kwargs):
         return self._owner._dftb(**kwargs)
+
+    def ground_dftb(self, **kwargs):
+        return self._owner.ground_dftb(**kwargs)
+
+    def tddftb(self, **kwargs):
+        return self._owner.tddftb(**kwargs)
+
+    def sf_tddftb(self, **kwargs):
+        return self._owner.sf_tddftb(**kwargs)
+
+    def mrsf_tddftb(self, **kwargs):
+        return self._owner.mrsf_tddftb(**kwargs)
 
     def tddft(self, functional=None, **kwargs):
         if functional is None:
@@ -872,6 +885,22 @@ class OpenQP:
         """
         return _DFTBSectionProxy(self, "dftb")
 
+    def tddftb(self, **kwargs):
+        """Use the conventional singlet TD-DFTB (TDA) response helper."""
+        return self._dftb(response_type="tddftb", **kwargs)
+
+    def ground_dftb(self, **kwargs):
+        """Use the ground-state SCC-DFTB helper explicitly."""
+        return self._dftb(response_type="ground", **kwargs)
+
+    def sf_tddftb(self, **kwargs):
+        """Use the spin-flip TD-DFTB response helper."""
+        return self._dftb(response_type="sf", **kwargs)
+
+    def mrsf_tddftb(self, **kwargs):
+        """Use the mixed-reference spin-flip TD-DFTB response helper."""
+        return self._dftb(response_type="mrsf", **kwargs)
+
     def _dftb(self, runtype=None, response_type="mrsf", nstate=3,
               parameter_path=None, **keywords):
         """Use the optional OpenQP-DFTB backend through the normal OpenQP workflow."""
@@ -887,37 +916,25 @@ class OpenQP:
         # Resolve the response type BEFORE draining schema keywords: `type` is a
         # [dftb] schema key, so the generic drain below would otherwise consume
         # an explicit job.dftb(type=...) and silently fall back to response_type.
-        requested_type = str(keywords.pop("type", response_type)).lower()
+        requested_type = canonical_dftb_type(keywords.pop("type", response_type))
         for key in list(keywords.keys()):
             if key in dftb_schema and key != "type":
                 dftb_updates[key] = keywords.pop(key)
 
-        dftb_type = requested_type
         tdhf_type = {
             "ground": "tda",
-            "dftb": "tda",
-            "dftb0": "tda",
-            "noscc": "tda",
             "ground_noscc": "tda",
             "tddftb": "tda",
-            "td-dftb": "tda",
-            "tda": "tda",
             "sf": "sf",
-            "sftddftb": "sf",
-            "sf-tddftb": "sf",
             "mrsf": "mrsf",
-            "mrsftddftb": "mrsf",
-            "mrsf-tddftb": "mrsf",
         }.get(requested_type)
         if tdhf_type is None:
             raise ValueError("DFTB response_type must be ground, tddftb, sf, or mrsf.")
 
-        # The backend's response-method names are ground/tddftb/sf/mrsf; map the
-        # tda/td-dftb aliases onto tddftb so the explicit request and the auto
-        # path (tdhf.type=tda/rpa -> tddftb) reach the same backend method.
-        _BACKEND_TYPE = {"tda": "tddftb", "td-dftb": "tddftb"}
-        dftb_updates["type"] = _BACKEND_TYPE.get(dftb_type, dftb_type)
+        dftb_updates["type"] = requested_type
         self.section("dftb", **dftb_updates)
+        if requested_type in {"sf", "mrsf"}:
+            self.scf(type="rohf", multiplicity=3)
         return self.tdhf(type=tdhf_type, nstate=nstate, **keywords)
 
     def soc(self, nstate=3, functional=None, reference="rohf",

--- a/pyoqp/oqp/utils/file_utils.py
+++ b/pyoqp/oqp/utils/file_utils.py
@@ -211,6 +211,7 @@ def dump_log(mol, title=None, section=None, info=None, must_print=False):
             parameter_path=details.get('parameter_path'),
             library_path=details.get('library_path'),
             executable=details.get('executable'),
+            abi_version=details.get('abi_version'),
         )
 
     if section == 'dftb_runtime':

--- a/pyoqp/oqp/utils/file_utils.py
+++ b/pyoqp/oqp/utils/file_utils.py
@@ -212,6 +212,7 @@ def dump_log(mol, title=None, section=None, info=None, must_print=False):
             library_path=details.get('library_path'),
             executable=details.get('executable'),
             abi_version=details.get('abi_version'),
+            capabilities=details.get('capabilities'),
         )
 
     if section == 'dftb_runtime':

--- a/pyoqp/oqp/utils/file_utils.py
+++ b/pyoqp/oqp/utils/file_utils.py
@@ -12,6 +12,7 @@ from oqp.utils.mpi_utils import mpi_dump
 from oqp.utils.qmmm import gradient_qmmm
 from oqp.utils.state_labels import (
     format_calculation_request,
+    format_dftb_settings,
     is_mrsf,
     public_method_name,
     public_state_label,
@@ -201,6 +202,34 @@ def dump_log(mol, title=None, section=None, info=None, must_print=False):
         resolved = getattr(mol, 'oqp_resolved_input', None)
         loginfo += '\n%s\n' % format_calculation_request(
             mol.config, source=source, resolved=resolved)
+
+    if section == 'dftb':
+        details = info if isinstance(info, dict) else {}
+        loginfo += '\n%s\n' % format_dftb_settings(
+            mol.config,
+            backend=details.get('backend'),
+            parameter_path=details.get('parameter_path'),
+            library_path=details.get('library_path'),
+            executable=details.get('executable'),
+        )
+
+    if section == 'dftb_runtime':
+        details = info if isinstance(info, dict) else {}
+        native_text = str(details.get('text', '')).strip()
+        loginfo += (
+            "\n   Native call: method=%s  state=%s  gradient=%s\n"
+            "   ------------------------------------------------------------\n"
+            % (
+                details.get('method', 'unknown'),
+                details.get('state', '?'),
+                _to_yes_no(details.get('gradient', False)),
+            )
+        )
+        if native_text:
+            loginfo += ''.join(
+                '   %s\n' % line for line in native_text.splitlines()
+            )
+        loginfo += '\n'
 
 
     if section == 'symmetry':

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -1044,6 +1044,55 @@ def _check_dftb(config: dict[str, Any], report: CheckReport) -> None:
             action="Use auto to derive the DFTB response type from [tdhf] type, or set it explicitly.",
         )
 
+    explicit_response_types = {
+        "tddftb": {"rpa", "tda"},
+        "sf": {"sf"},
+        "mrsf": {"mrsf"},
+    }
+    compatible_tdhf_types = explicit_response_types.get(dftb_type_canon)
+    if (
+        dftb_type != "auto"
+        and compatible_tdhf_types is not None
+        and td_type not in compatible_tdhf_types
+    ):
+        report.add(
+            "ERROR",
+            "dftb.type",
+            "Explicit OpenQP-DFTB response type conflicts with [tdhf] type.",
+            value={"dftb.type": dftb_type, "tdhf.type": td_type},
+            expected="tdhf.type=" + "/".join(sorted(compatible_tdhf_types)),
+            action="Align [dftb] type with [tdhf] type, or use [dftb] type=auto.",
+        )
+
+    auto_ground = (
+        dftb_type == "auto"
+        and (
+            (runtype in {"energy", "grad"} and not any(int(state) > 0 for state in grad_states))
+            or (runtype in {"optimize", "mep"} and int(istate) == 0)
+        )
+    )
+    conventional_tddftb = dftb_type_canon == "tddftb" or (
+        dftb_type == "auto" and td_type in {"rpa", "tda"} and not auto_ground
+    )
+    if conventional_tddftb:
+        target_mult = int(_get(config, "dftb", "target_multiplicity", 1))
+        reference_mult = int(_get(config, "dftb", "reference_multiplicity", 0))
+        td_mult = int(_get(config, "tdhf", "multiplicity", 1))
+        if target_mult != 1 or td_mult != 1 or reference_mult not in {0, 1}:
+            report.add(
+                "ERROR",
+                "dftb.target_multiplicity",
+                "Conventional TD-DFTB currently implements a closed-shell singlet "
+                "reference and singlet TDA response only.",
+                value={
+                    "reference": reference_mult or 1,
+                    "dftb_target": target_mult,
+                    "tdhf_target": td_mult,
+                },
+                expected="reference and target multiplicity 1",
+                action="Use SF-TDDFTB or MRSF-TDDFTB for triplet-state calculations.",
+            )
+
     lc_gamma = _as_lower(_get(config, "dftb", "lc_gamma", "yukawa"))
     if lc_gamma not in {"yukawa", "erf"}:
         report.add(
@@ -1064,6 +1113,17 @@ def _check_dftb(config: dict[str, Any], report: CheckReport) -> None:
             value=response_solver,
             expected="auto, dense, or davidson",
             action="Use auto unless you need to force a specific eigensolver.",
+        )
+
+    print_level = int(_get(config, "dftb", "print_level", 1))
+    if print_level not in {0, 1, 2}:
+        report.add(
+            "ERROR",
+            "dftb.print_level",
+            "Unknown OpenQP-DFTB native trace level.",
+            value=print_level,
+            expected="0, 1, or 2",
+            action="Use 0 for quiet, 1 for stage summaries, or 2 for iteration detail.",
         )
 
     target_multiplicity = int(_get(config, "dftb", "target_multiplicity", 1))

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -122,8 +122,8 @@ class CalculationSpec:
             "mp2": "MP2",
             "dftb": "DFTB",
             "dftb0": "DFTB0",
-            "tddftb": "TD-DFTB",
-            "tda-dftb": "TDA-TDDFTB",
+            "tddftb": "TD-DFTB (TDA)",
+            "tda-dftb": "TD-DFTB (TDA)",
             "sf-dftb": "SF-TDDFTB",
             "mrsf-dftb": "MRSF-TDDFTB",
             "mrsf-hf": "MRSF-TDHF",
@@ -217,7 +217,8 @@ GENERIC_SCHEMA_KEYS = {
         backend parameter_path library_path executable scc_tolerance scc_mixer
         scc_mixing scc_history scc_max_step max_scc_iterations
         response_tolerance response_max_iterations response_max_subspace
-        response_solver spc spc_coco spc_ovov spc_coov omega cam_alpha
+        response_solver print_level state_to_state_spectrum
+        spc spc_coco spc_ovov spc_coov omega cam_alpha
         cam_beta lc_gamma lc_ground_state zvector spin_complete mrsf_shift_oo
         mrsf_shift_co mrsf_shift_ov mrsf_shift_cv timeout
         model c_mrsf c_mrsf_oo response_global_hybrid onsite_exchange_scale
@@ -1377,6 +1378,12 @@ def _validate_semantics(spec: CalculationSpec) -> None:
             raise OQPInputError(
                 "SF-TDDFT states are not safely labelable before the run; use root=N"
             )
+        if model in {"tddftb", "tda-dftb"} and state.label and \
+                state.label.startswith("T"):
+            raise OQPInputError(
+                "Conventional TD-DFTB currently supports singlet targets only; "
+                "use sf-tddftb or mrsf-tddftb for triplet-state calculations"
+            )
         if model in {
             "dft", "rks", "uks", "roks", "hf", "rhf", "uhf", "rohf", "mp2",
             "dftb", "dftb0",
@@ -1968,7 +1975,7 @@ def lower_to_legacy(
             "sf": "sf", "sf-hf": "sf", "sf-dftb": "sf",
             "tddft": "rpa", "tdhf": "rpa",
             "tda": "tda", "tda-hf": "tda", "tda-dftb": "tda",
-            "tddftb": "rpa",
+            "tddftb": "tda",
         }[spec.model]
         put("tdhf", "type", td_type)
         multiplicities = [state.multiplicity for state in states if state.multiplicity]
@@ -1986,8 +1993,8 @@ def lower_to_legacy(
         "dftb", "dftb0", "tddftb", "tda-dftb", "sf-dftb", "mrsf-dftb"
     }:
         put("dftb", "type", {
-            "dftb": "auto", "dftb0": "ground_noscc", "tddftb": "tddftb",
-            "tda-dftb": "tda", "sf-dftb": "sf", "mrsf-dftb": "mrsf",
+            "dftb": "ground", "dftb0": "ground_noscc", "tddftb": "tddftb",
+            "tda-dftb": "tddftb", "sf-dftb": "sf", "mrsf-dftb": "mrsf",
         }[spec.model])
         if spec.model in {"dftb", "dftb0", "tddftb", "tda-dftb"}:
             reference_mult = spec.options.get("mult", 1)

--- a/pyoqp/oqp/utils/state_labels.py
+++ b/pyoqp/oqp/utils/state_labels.py
@@ -68,6 +68,14 @@ _DFTB_METHOD_NAMES = {
     "mrsf": "MRSF-TDDFTB",
 }
 
+# Additive openqp-dftb C capability-mask bits.  These assignments are part of
+# the public C contract and deliberately do not follow the state-gradient ABI
+# version: an optional feature may be added without changing that argument
+# list.
+DFTB_CAP_STRUCTURED_TRACE = 1
+DFTB_CAP_STATE_SPECTRUM = 2
+DFTB_CAP_SCC_FINAL_TRUST = 4
+
 
 def _section(config, name):
     value = config.get(name, {}) if isinstance(config, dict) else {}
@@ -220,6 +228,7 @@ def format_dftb_settings(
     library_path=None,
     executable=None,
     abi_version=None,
+    capabilities=None,
 ):
     """Format one concise, grouped summary of effective DFTB request settings.
 
@@ -232,6 +241,36 @@ def format_dftb_settings(
     method = resolved_dftb_type(config)
     requested_backend = str(dftb.get("backend", "native")).strip().lower()
     actual_backend = str(backend or requested_backend).strip().lower()
+    if actual_backend == "probe":
+        # The command-line probe exposes energies/gradients only.  It has no
+        # C capability symbol and does not forward the native diagnostic
+        # environment hooks.
+        effective_capabilities = 0
+    elif capabilities is not None:
+        effective_capabilities = int(capabilities)
+    elif abi_version is not None:
+        # Once a native library has been loaded, a missing optional symbol is
+        # authoritatively the zero mask, including for ABI 3 builds predating
+        # capability discovery.
+        effective_capabilities = 0
+    else:
+        effective_capabilities = None
+
+    def has_capability(bit):
+        return (
+            effective_capabilities is not None
+            and bool(effective_capabilities & bit)
+        )
+
+    def unavailable_capability(label):
+        if actual_backend == "probe":
+            return "unavailable with probe backend"
+        if effective_capabilities is None:
+            return "availability checked after native library load"
+        abi = " (C ABI %s)" % abi_version if abi_version is not None else ""
+        return "unavailable; loaded library%s does not advertise %s" % (
+            abi, label)
+
     backend_text = actual_backend
     if requested_backend != actual_backend:
         backend_text += " (requested: %s)" % requested_backend
@@ -241,15 +280,36 @@ def format_dftb_settings(
     method_rows = [
         ("Method", dftb_method_name(config)),
         ("Backend", backend_text),
-        ("Native print level", dftb.get("print_level", 1)),
         ("Parameters", parameter_path or dftb.get("parameter_path") or "bundled default"),
         ("Reference", dftb_reference_description(config)),
         ("Target", dftb_target_description(config)),
     ]
+    if actual_backend == "native":
+        level = dftb.get("print_level", 1)
+        if effective_capabilities is None or has_capability(
+                DFTB_CAP_STRUCTURED_TRACE):
+            trace_text = "level %s" % level
+        else:
+            trace_text = "requested level %s; %s" % (
+                level,
+                unavailable_capability("structured progress tracing"),
+            )
+        method_rows.insert(2, ("Native progress trace", trace_text))
     if library_path:
         method_rows.insert(2, ("Shared library", library_path))
     if abi_version is not None:
         method_rows.insert(3, ("C API ABI", abi_version))
+    if actual_backend == "native" and effective_capabilities is not None:
+        names = []
+        for bit, name in (
+            (DFTB_CAP_STRUCTURED_TRACE, "structured trace"),
+            (DFTB_CAP_STATE_SPECTRUM, "state spectrum"),
+            (DFTB_CAP_SCC_FINAL_TRUST, "SCC final trust recovery"),
+        ):
+            if effective_capabilities & bit:
+                names.append(name)
+        capability_text = ", ".join(names) if names else "none advertised"
+        method_rows.insert(4, ("C API capabilities", capability_text))
     if executable:
         method_rows.insert(2, ("Probe executable", executable))
     groups.append(("calculation", method_rows))
@@ -260,7 +320,6 @@ def format_dftb_settings(
         scc_rows = [
             ("Enabled", "yes"),
             ("Protocol", "%s preset (resolved by openqp-dftb backend)" % model),
-            ("Failed-cycle recovery", "final charge/spin trust-TRAH pass when eligible"),
         ]
     else:
         mixer = str(dftb.get("scc_mixer", "auto")).strip().lower()
@@ -274,8 +333,13 @@ def format_dftb_settings(
                 dftb.get("scc_history", 12),
                 _display_number(dftb.get("scc_max_step", 0.5)),
             )),
-            ("Failed-cycle recovery", "final charge/spin trust-TRAH pass when eligible"),
         ]
+    if method != "ground_noscc":
+        if has_capability(DFTB_CAP_SCC_FINAL_TRUST):
+            recovery = "final charge/spin trust-TRAH pass when eligible"
+        else:
+            recovery = unavailable_capability("final trust-region SCC recovery")
+        scc_rows.append(("Failed-cycle recovery", recovery))
     groups.append(("SCC", scc_rows))
 
     if method not in {"ground", "ground_noscc"}:
@@ -299,11 +363,16 @@ def format_dftb_settings(
             )
         else:
             groups[-1][1].append(("Response manifold", "closed-shell singlet TDA"))
-        groups[-1][1].append((
-            "State-to-state spectrum",
-            "%s (unrelaxed TDA/state interaction)"
-            % _yes_no(dftb.get("state_to_state_spectrum", True)),
-        ))
+        spectrum_requested = bool(dftb.get("state_to_state_spectrum", True))
+        if not spectrum_requested:
+            spectrum_text = "no"
+        elif has_capability(DFTB_CAP_STATE_SPECTRUM):
+            spectrum_text = "yes (unrelaxed TDA/state interaction)"
+        else:
+            spectrum_text = "requested; %s" % unavailable_capability(
+                "all-pair state spectrum"
+            )
+        groups[-1][1].append(("State-to-state spectrum", spectrum_text))
         zvector = (
             "%s preset (resolved by openqp-dftb backend)" % model
             if model else _yes_no(dftb.get("zvector", True))
@@ -364,6 +433,8 @@ def format_dftb_settings(
 
 def is_mrsf(config):
     """True for MRSF/UMRSF response calculations, including TD-DFTB."""
+    if str(_section(config, "input").get("method", "")).strip().lower() == "dftb":
+        return resolved_dftb_type(config) == "mrsf"
     return response_type(config) in {"mrsf", "umrsf"}
 
 
@@ -560,7 +631,7 @@ def calculation_request_lines(config, source=None, resolved=None):
     if is_dftb_request:
         lines.append(("Reference", dftb_reference_description(config)))
     if is_mrsf(config):
-        target_mult = _int(_section(config, "tdhf").get("multiplicity", 1), 1)
+        target_mult = _target_multiplicity(config)
         runtype = str(inp.get("runtype", "energy")).lower()
         multi_spin = runtype in {"soc", "mecp"} or (
             runtype == "namd" and bool(_section(config, "md").get("soc", False))

--- a/pyoqp/oqp/utils/state_labels.py
+++ b/pyoqp/oqp/utils/state_labels.py
@@ -39,6 +39,35 @@ _RUN_NAMES = {
     "thermo": "Thermochemistry",
 }
 
+_DFTB_TYPE_ALIASES = {
+    "auto": "auto",
+    "ground": "ground",
+    "dftb": "ground",
+    "dftb0": "ground_noscc",
+    "noscc": "ground_noscc",
+    "ground_noscc": "ground_noscc",
+    "tddftb": "tddftb",
+    "tda": "tddftb",
+    "td-dftb": "tddftb",
+    "rpa": "tddftb",
+    "sf": "sf",
+    "sftddftb": "sf",
+    "sf-tddftb": "sf",
+    "mrsf": "mrsf",
+    "mrsftddftb": "mrsf",
+    "mrsf-tddftb": "mrsf",
+}
+
+_DFTB_METHOD_NAMES = {
+    "ground": "DFTB",
+    "ground_noscc": "DFTB0",
+    # The openqp-dftb conventional response kernel implements the TDA
+    # eigenproblem for both accepted conventional route spellings.
+    "tddftb": "TD-DFTB (TDA)",
+    "sf": "SF-TDDFTB",
+    "mrsf": "MRSF-TDDFTB",
+}
+
 
 def _section(config, name):
     value = config.get(name, {}) if isinstance(config, dict) else {}
@@ -65,6 +94,271 @@ def response_type(config):
     return str(_section(config, "tdhf").get("type", "")).strip().lower()
 
 
+def canonical_dftb_type(value):
+    """Return the backend spelling shared by API, logs, and runtime dispatch."""
+    normalized = str(value or "auto").strip().lower()
+    return _DFTB_TYPE_ALIASES.get(normalized, normalized)
+
+
+def resolved_dftb_type(config):
+    """Resolve ``[dftb] type=auto`` using the same rules as the adapter."""
+    explicit = canonical_dftb_type(_section(config, "dftb").get("type", "auto"))
+    if explicit != "auto":
+        return explicit
+
+    inp = _section(config, "input")
+    runtype = str(inp.get("runtype", "energy")).strip().lower()
+    istate = _int(_section(config, "optimize").get("istate", 0))
+    if runtype in {"optimize", "mep"} and istate == 0:
+        return "ground"
+
+    td_type = response_type(config)
+    if runtype in {"energy", "grad"} and td_type in {"", "rpa", "tda"}:
+        grad_states = _int_list(_section(config, "properties").get("grad", []))
+        if not any(state > 0 for state in grad_states):
+            return "ground"
+
+    return {
+        "rpa": "tddftb",
+        "tda": "tddftb",
+        "sf": "sf",
+        "mrsf": "mrsf",
+    }.get(td_type, td_type or "ground")
+
+
+def dftb_method_name(config):
+    """Return the scientifically accurate display name for a DFTB route."""
+    return _DFTB_METHOD_NAMES.get(resolved_dftb_type(config), "DFTB")
+
+
+def dftb_reference_description(config):
+    """Describe the reference actually requested from openqp-dftb."""
+    method = resolved_dftb_type(config)
+    dftb = _section(config, "dftb")
+    explicit = _int(dftb.get("reference_multiplicity", 0))
+    if method in {"sf", "mrsf"}:
+        # The native backend treats 0/1 as "use the required triplet
+        # high-spin reference"; report that effective value in the log.
+        multiplicity = explicit if explicit > 1 else 3
+    else:
+        multiplicity = explicit if explicit > 0 else 1
+    spin = spin_name(multiplicity)
+    if method in {"sf", "mrsf"}:
+        return "%s ROKS (internal high-spin reference)" % spin
+    if method == "ground_noscc":
+        return "%s non-SCC DFTB0 reference" % spin
+    if method == "tddftb":
+        return "singlet restricted SCC-DFTB reference"
+    return "%s SCC-DFTB reference" % spin
+
+
+def dftb_target_description(config):
+    """Describe the physical state manifold produced by the DFTB route."""
+    method = resolved_dftb_type(config)
+    if method in {"ground", "ground_noscc"}:
+        dftb = _section(config, "dftb")
+        explicit = _int(dftb.get("reference_multiplicity", 0))
+        multiplicity = explicit if explicit > 0 else 1
+        prefix = _SPIN_NAMES.get(
+            multiplicity, ("multiplicity %d" % multiplicity, "M%d-" % multiplicity)
+        )[1]
+        return "%s0 ground state" % prefix
+
+    nstate = max(1, _int(_section(config, "tdhf").get("nstate", 1), 1))
+    runtype = str(_section(config, "input").get("runtype", "energy")).lower()
+    selected_roots = []
+    if runtype in {"grad", "data", "prop"}:
+        selected_roots = _int_list(_section(config, "properties").get("grad", []))
+    elif runtype in {"optimize", "mep"}:
+        selected_roots = [_int(_section(config, "optimize").get("istate", 0))]
+    elif runtype == "meci":
+        optimize = _section(config, "optimize")
+        selected_roots = [
+            _int(optimize.get("istate", 1)),
+            _int(optimize.get("jstate", 2)),
+        ]
+
+    if method == "tddftb":
+        if selected_roots:
+            return ", ".join("S%d" % root for root in selected_roots)
+        return "singlet S1" if nstate == 1 else "singlet S1-S%d" % nstate
+    if method == "sf":
+        if selected_roots:
+            roots = ", ".join("root %d" % root for root in selected_roots)
+        else:
+            roots = "root 1" if nstate == 1 else "roots 1-%d" % nstate
+        return "spin-flip %s (character assigned after calculation)" % roots
+
+    targets = requested_states(config)
+    if targets:
+        return targets
+    multiplicity = _int(_section(config, "dftb").get("target_multiplicity", 1), 1)
+    prefix = _SPIN_NAMES.get(
+        multiplicity, ("multiplicity %d" % multiplicity, "M%d-" % multiplicity)
+    )[1]
+    return "%s0" % prefix if nstate == 1 else "%s0-%s%d" % (
+        prefix, prefix, nstate - 1
+    )
+
+
+def _yes_no(value):
+    return "yes" if bool(value) else "no"
+
+
+def _display_number(value):
+    try:
+        return "%.8g" % float(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def format_dftb_settings(
+    config,
+    *,
+    backend=None,
+    parameter_path=None,
+    library_path=None,
+    executable=None,
+):
+    """Format one concise, grouped summary of effective DFTB request settings.
+
+    A named model preset is resolved inside openqp-dftb.  In that case this
+    formatter deliberately does not present schema defaults as effective
+    operator/SCC values.
+    """
+    dftb = _section(config, "dftb")
+    td = _section(config, "tdhf")
+    method = resolved_dftb_type(config)
+    requested_backend = str(dftb.get("backend", "native")).strip().lower()
+    actual_backend = str(backend or requested_backend).strip().lower()
+    backend_text = actual_backend
+    if requested_backend != actual_backend:
+        backend_text += " (requested: %s)" % requested_backend
+    model = str(dftb.get("model", "")).strip()
+
+    groups = []
+    method_rows = [
+        ("Method", dftb_method_name(config)),
+        ("Backend", backend_text),
+        ("Native print level", dftb.get("print_level", 1)),
+        ("Parameters", parameter_path or dftb.get("parameter_path") or "bundled default"),
+        ("Reference", dftb_reference_description(config)),
+        ("Target", dftb_target_description(config)),
+    ]
+    if library_path:
+        method_rows.insert(2, ("Shared library", library_path))
+    if executable:
+        method_rows.insert(2, ("Probe executable", executable))
+    groups.append(("calculation", method_rows))
+
+    if method == "ground_noscc":
+        scc_rows = [("Enabled", "no (DFTB0)")]
+    elif model:
+        scc_rows = [
+            ("Enabled", "yes"),
+            ("Protocol", "%s preset (resolved by openqp-dftb backend)" % model),
+            ("Failed-cycle recovery", "final charge/spin trust-TRAH pass when eligible"),
+        ]
+    else:
+        mixer = str(dftb.get("scc_mixer", "auto")).strip().lower()
+        scc_rows = [
+            ("Enabled", "yes"),
+            ("Mixer", "%s (requested)" % mixer),
+            ("Tolerance", _display_number(dftb.get("scc_tolerance", 1.0e-8))),
+            ("Maximum iterations", dftb.get("max_scc_iterations", 1200)),
+            ("Mixing / history / max step", "%s / %s / %s" % (
+                _display_number(dftb.get("scc_mixing", 0.35)),
+                dftb.get("scc_history", 12),
+                _display_number(dftb.get("scc_max_step", 0.5)),
+            )),
+            ("Failed-cycle recovery", "final charge/spin trust-TRAH pass when eligible"),
+        ]
+    groups.append(("SCC", scc_rows))
+
+    if method not in {"ground", "ground_noscc"}:
+        solver = (
+            "%s preset (resolved by openqp-dftb backend)" % model
+            if model else
+            "%s (requested)" % str(dftb.get("response_solver", "auto")).lower()
+        )
+        groups.append(("response", [
+            ("Solver", solver),
+            ("States", td.get("nstate", 1)),
+            ("Tolerance", _display_number(dftb.get("response_tolerance", 1.0e-6))),
+            ("Maximum iterations / subspace", "%s / %s" % (
+                dftb.get("response_max_iterations", 50),
+                dftb.get("response_max_subspace", 100),
+            )),
+        ]))
+        if method in {"sf", "mrsf"}:
+            groups[-1][1].append(
+                ("Spin completion", _yes_no(dftb.get("spin_complete", True)))
+            )
+        else:
+            groups[-1][1].append(("Response manifold", "closed-shell singlet TDA"))
+        groups[-1][1].append((
+            "State-to-state spectrum",
+            "%s (unrelaxed TDA/state interaction)"
+            % _yes_no(dftb.get("state_to_state_spectrum", True)),
+        ))
+        zvector = (
+            "%s preset (resolved by openqp-dftb backend)" % model
+            if model else _yes_no(dftb.get("zvector", True))
+        )
+        groups.append(("gradient", [("Relaxed Z-vector", zvector)]))
+
+    if model:
+        operator_rows = [
+            ("Model preset", "%s (operator resolved by openqp-dftb backend)" % model),
+        ]
+    elif method == "ground_noscc":
+        operator_rows = [("Hamiltonian", "non-SCC DFTB0")]
+    else:
+        operator_rows = [
+            ("LC ground state", _yes_no(dftb.get("lc_ground_state", False))),
+        ]
+        if method in {"sf", "mrsf"} or bool(dftb.get("lc_ground_state", False)):
+            operator_rows.extend([
+                ("Gamma kernel / omega", "%s / %s" % (
+                    str(dftb.get("lc_gamma", "yukawa")).lower(),
+                    _display_number(dftb.get("omega", 0.3)),
+                )),
+                ("CAM alpha / beta", "%s / %s" % (
+                    _display_number(dftb.get("cam_alpha", 0.0)),
+                    _display_number(dftb.get("cam_beta", 1.0)),
+                )),
+            ])
+        if method in {"sf", "mrsf"}:
+            spc = dftb.get("spc", 0.5)
+            channels = []
+            for key in ("spc_coco", "spc_ovov", "spc_coov"):
+                value = dftb.get(key, -999.0)
+                try:
+                    value = spc if float(value) <= -900.0 else value
+                except (TypeError, ValueError):
+                    pass
+                channels.append(_display_number(value))
+            operator_rows.append(("SPC coco / ovov / coov", " / ".join(channels)))
+            if method == "mrsf":
+                operator_rows.append(("MRSF shifts oo/co/ov/cv", " / ".join(
+                    _display_number(dftb.get(key, 0.0))
+                    for key in (
+                        "mrsf_shift_oo", "mrsf_shift_co",
+                        "mrsf_shift_ov", "mrsf_shift_cv",
+                    )
+                )))
+    groups.append(("operator", operator_rows))
+
+    lines = []
+    for group, rows in groups:
+        lines.append("   PyOQP DFTB %s settings" % group)
+        lines.extend(
+            "   PyOQP   %-27s %s" % (label + ":", value)
+            for label, value in rows
+        )
+    return "\n".join(lines)
+
+
 def is_mrsf(config):
     """True for MRSF/UMRSF response calculations, including TD-DFTB."""
     return response_type(config) in {"mrsf", "umrsf"}
@@ -76,6 +370,16 @@ def spin_name(multiplicity):
     return _SPIN_NAMES.get(mult, ("multiplicity %d" % mult, "M%d-" % mult))[0]
 
 
+def _target_multiplicity(config):
+    """Return the multiplicity consumed by the active backend."""
+    if (
+        str(_section(config, "input").get("method", "")).strip().lower() == "dftb"
+        and resolved_dftb_type(config) == "mrsf"
+    ):
+        return _int(_section(config, "dftb").get("target_multiplicity", 1), 1)
+    return _int(_section(config, "tdhf").get("multiplicity", 1), 1)
+
+
 def public_method_name(config):
     """Return the method name a user recognizes, not its legacy dispatch key."""
     inp = _section(config, "input")
@@ -83,12 +387,7 @@ def public_method_name(config):
     td_type = response_type(config)
 
     if method == "dftb":
-        dftb_type = str(_section(config, "dftb").get("type", td_type)).lower()
-        if td_type == "mrsf" or dftb_type in {"mrsf", "mrsftddftb", "mrsf-tddftb"}:
-            return "MRSF-TDDFTB"
-        if td_type == "sf" or dftb_type in {"sf", "sftddftb", "sf-tddftb"}:
-            return "SF-TDDFTB"
-        return "DFTB"
+        return dftb_method_name(config)
     if method == "tdhf":
         dft = bool(str(inp.get("functional", "")).strip())
         return {
@@ -120,8 +419,7 @@ def public_state_label(config, root, multiplicity=None, *, show_reference=True):
         return "state %d" % root
 
     scf = _section(config, "scf")
-    td = _section(config, "tdhf")
-    mult = _int(td.get("multiplicity", 1) if multiplicity is None else multiplicity, 1)
+    mult = _target_multiplicity(config) if multiplicity is None else _int(multiplicity, 1)
     if root == 0 and show_reference:
         ref_type = str(scf.get("type", "rohf")).upper()
         ref_mult = _int(scf.get("multiplicity", 3), 3)
@@ -142,7 +440,7 @@ def reference_description(config):
 
 def _state_range(config):
     td = _section(config, "tdhf")
-    mult = _int(td.get("multiplicity", 1), 1)
+    mult = _target_multiplicity(config)
     nstate = max(1, _int(td.get("nstate", 1), 1))
     first = 0
     prefix = _SPIN_NAMES.get(mult, ("multiplicity %d" % mult, "M%d-" % mult))[1]
@@ -160,7 +458,7 @@ def requested_states(config):
     opt = _section(config, "optimize")
     td = _section(config, "tdhf")
     runtype = str(inp.get("runtype", "energy")).strip().lower()
-    td_mult = _int(td.get("multiplicity", 1), 1)
+    td_mult = _target_multiplicity(config)
 
     if runtype == "soc":
         ns = max(1, _int(td.get("nstate_s", 0), 0) or _int(td.get("nstate", 1), 1))
@@ -241,19 +539,23 @@ def calculation_request_lines(config, source=None, resolved=None):
     ]
     if baeka:
         lines.append(("Algorithm", "Baek adaptive penalty (BaekA)"))
-    functional = str(inp.get("functional", "")).strip()
-    basis = str(inp.get("basis", "")).strip()
-    if functional and basis:
-        lines.append(("Model chemistry", "%s/%s" % (functional, basis)))
-    elif basis:
-        lines.append(("Basis", basis))
+    is_dftb_request = str(inp.get("method", "")).strip().lower() == "dftb"
+    if not is_dftb_request:
+        functional = str(inp.get("functional", "")).strip()
+        basis = str(inp.get("basis", "")).strip()
+        if functional and basis:
+            lines.append(("Model chemistry", "%s/%s" % (functional, basis)))
+        elif basis:
+            lines.append(("Basis", basis))
 
-    targets = requested_states(config)
+    targets = dftb_target_description(config) if is_dftb_request else requested_states(config)
     if targets:
         lines.append(("Physical target state(s)", targets))
     freeze = str(_section(config, "oqp").get("freeze", "")).strip()
     if freeze:
         lines.append(("Frozen distance(s)", freeze))
+    if is_dftb_request:
+        lines.append(("Reference", dftb_reference_description(config)))
     if is_mrsf(config):
         target_mult = _int(_section(config, "tdhf").get("multiplicity", 1), 1)
         runtype = str(inp.get("runtype", "energy")).lower()
@@ -262,7 +564,8 @@ def calculation_request_lines(config, source=None, resolved=None):
         )
         if not multi_spin:
             lines.append(("Target spin", spin_name(target_mult)))
-        lines.append(("Reference", reference_description(config)))
+        if not is_dftb_request:
+            lines.append(("Reference", reference_description(config)))
         lines.append(("State labels", "physical labels shown; engine root numbers are internal"))
     if source:
         lines.append(("Input", str(source)))

--- a/pyoqp/oqp/utils/state_labels.py
+++ b/pyoqp/oqp/utils/state_labels.py
@@ -219,6 +219,7 @@ def format_dftb_settings(
     parameter_path=None,
     library_path=None,
     executable=None,
+    abi_version=None,
 ):
     """Format one concise, grouped summary of effective DFTB request settings.
 
@@ -247,6 +248,8 @@ def format_dftb_settings(
     ]
     if library_path:
         method_rows.insert(2, ("Shared library", library_path))
+    if abi_version is not None:
+        method_rows.insert(3, ("C API ABI", abi_version))
     if executable:
         method_rows.insert(2, ("Probe executable", executable))
     groups.append(("calculation", method_rows))

--- a/tests/test_openqp_api.py
+++ b/tests/test_openqp_api.py
@@ -138,6 +138,7 @@ def load_openqp_module():
         "oqp.utils.geometry",
         "oqp.utils.input_parser",
         "oqp.utils.kword_map",
+        "oqp.utils.state_labels",
         "openqp_under_test",
     )
     saved_modules = {name: sys.modules.get(name) for name in stub_names}
@@ -166,6 +167,7 @@ def load_openqp_module():
         _load_module("oqp.utils.geometry", ROOT / "pyoqp/oqp/utils/geometry.py")
         _load_module("oqp.utils.input_parser", ROOT / "pyoqp/oqp/utils/input_parser.py")
         _load_module("oqp.utils.kword_map", ROOT / "pyoqp/oqp/utils/kword_map.py")
+        _load_module("oqp.utils.state_labels", ROOT / "pyoqp/oqp/utils/state_labels.py")
 
         class FakeMol:
             def __init__(self):

--- a/tests/test_openqp_dftb_abi1.py
+++ b/tests/test_openqp_dftb_abi1.py
@@ -1,0 +1,290 @@
+"""Regression tests for the historical openqp-dftb C ABI-v1 adapter."""
+
+from __future__ import annotations
+
+import ctypes
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest import mock
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "pyoqp" / "oqp" / "library" / "openqp_dftb.py"
+
+
+def _load_adapter_module():
+    """Load the adapter with a dependency-light oqp package stub."""
+    oqp = types.ModuleType("oqp")
+    oqp.__path__ = []
+    oqp.oqp_root = ""
+
+    periodic_table = types.ModuleType("oqp.periodic_table")
+    periodic_table.ELEMENTS_NAME = ["X", "H"]
+
+    utils = types.ModuleType("oqp.utils")
+    utils.__path__ = []
+    constants = types.ModuleType("oqp.utils.constants")
+    constants.ANGSTROM_TO_BOHR = 0.529177210903
+    file_utils = types.ModuleType("oqp.utils.file_utils")
+    file_utils.dump_log = lambda *args, **kwargs: None
+    state_labels = types.ModuleType("oqp.utils.state_labels")
+    state_labels.canonical_dftb_type = lambda value: str(value).lower()
+    state_labels.resolved_dftb_type = (
+        lambda config: str(config.get("dftb", {}).get("type", "ground")).lower()
+    )
+
+    stubs = {
+        "oqp": oqp,
+        "oqp.periodic_table": periodic_table,
+        "oqp.utils": utils,
+        "oqp.utils.constants": constants,
+        "oqp.utils.file_utils": file_utils,
+        "oqp.utils.state_labels": state_labels,
+    }
+    saved = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_openqp_dftb_abi1_test_module", MODULE_PATH
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+ADAPTER_MODULE = _load_adapter_module()
+
+
+class _FakeMolecule:
+    def __init__(self, *, runtype="grad", dftb_updates=None):
+        dftb = {
+            "backend": "native",
+            "type": "mrsf",
+            "parameter_path": "/tmp/minimal.opdftb",
+            "scc_mixer": "auto",
+            "scc_history": 9,
+            "max_scc_iterations": 321,
+            "response_max_iterations": 41,
+            "response_max_subspace": 73,
+            "response_solver": "davidson",
+            "reference_multiplicity": 3,
+            "target_multiplicity": 1,
+            "spin_complete": True,
+            "lc_ground_state": False,
+            "lc_gamma": "yukawa",
+            "zvector": True,
+            "scc_tolerance": 2.0e-9,
+            "scc_mixing": 0.27,
+            "scc_max_step": 0.44,
+            "response_tolerance": 3.0e-7,
+            "spc": 0.5,
+            "spc_coco": 0.51,
+            "spc_ovov": 0.52,
+            "spc_coov": 0.53,
+            "omega": 0.31,
+            "cam_alpha": 0.02,
+            "cam_beta": 0.98,
+            "mrsf_shift_oo": 0.01,
+            "mrsf_shift_co": 0.02,
+            "mrsf_shift_ov": 0.03,
+            "mrsf_shift_cv": 0.04,
+        }
+        if dftb_updates:
+            dftb.update(dftb_updates)
+        self.config = {
+            "input": {
+                "charge": -1,
+                "runtype": runtype,
+                "qmmm_flag": False,
+            },
+            "scf": {"type": "rohf", "multiplicity": 3},
+            "tdhf": {"type": "mrsf", "nstate": 2},
+            "properties": {"grad": [2]},
+            "optimize": {},
+            "dftb": dftb,
+        }
+        self.data = {"natom": 2}
+
+    @staticmethod
+    def get_atoms():
+        return np.array([1, 1], dtype=np.int64)
+
+    @staticmethod
+    def get_system():
+        return np.array([0.0, 0.0, 0.0, 0.0, 0.0, 1.4], dtype=np.float64)
+
+
+class _RecordingABI1Function:
+    def __init__(self):
+        self.calls = []
+        self.restype = object()
+
+    def __call__(self, *args):
+        self.calls.append(args)
+        if len(args) != 63:
+            raise AssertionError(f"ABI v1 requires exactly 63 arguments, got {len(args)}")
+
+        ctypes.cast(args[42], ctypes.POINTER(ctypes.c_double))[0] = -1.25
+        ctypes.cast(args[43], ctypes.POINTER(ctypes.c_double))[0] = -1.05
+        ctypes.cast(args[44], ctypes.POINTER(ctypes.c_double))[0] = 0.20
+        ctypes.cast(args[45], ctypes.POINTER(ctypes.c_double))[0] = 0.02
+        for index, value in enumerate((1.0, 2.0, 3.0, 4.0, 5.0, 6.0)):
+            args[46][index] = value
+        ctypes.cast(args[47], ctypes.POINTER(ctypes.c_int64))[0] = 2
+        args[48][0], args[48][1] = -1.05, -0.95
+        args[49][0], args[49][1] = 0.02, 0.03
+        args[50][0], args[50][1] = 0.1, -0.1
+        ctypes.cast(args[51], ctypes.POINTER(ctypes.c_int64))[0] = 2
+        ctypes.cast(args[52], ctypes.POINTER(ctypes.c_int64))[0] = 1
+        ctypes.cast(args[53], ctypes.POINTER(ctypes.c_int64))[0] = 1
+        ctypes.cast(args[54], ctypes.POINTER(ctypes.c_int64))[0] = 1
+        args[56][0], args[56][1] = -0.5, 0.2
+        for index, value in enumerate((1.0, 0.0, 0.0, 1.0)):
+            args[57][index] = value
+        args[59][0], args[59][1] = 0.7, 0.8
+        args[60].value = b""
+        ctypes.cast(args[62], ctypes.POINTER(ctypes.c_int64))[0] = 0
+
+
+class _FakeLibrary:
+    def __init__(self):
+        self.openqp_dftb_state_gradient = _RecordingABI1Function()
+        self.openqp_dftb_states_overlap = object()
+        self.openqp_dftb_soc_matrix = object()
+
+
+class OpenQPDFTBABI1Tests(unittest.TestCase):
+    def _adapter_with_abi1(self, **mol_kwargs):
+        mol = _FakeMolecule(**mol_kwargs)
+        adapter = ADAPTER_MODULE.OpenQPDFTBAdapter(mol)
+        library = _FakeLibrary()
+        mol._openqp_dftb_cache["__native_library__"] = library
+        mol._openqp_dftb_cache["__native_abi_version__"] = 1
+        return adapter, library
+
+    def test_unversioned_library_is_classified_as_abi1(self):
+        adapter, library = self._adapter_with_abi1()
+        adapter.mol._openqp_dftb_cache.clear()
+        adapter._native_library_path = lambda: Path("/tmp/libopenqp_dftb_c.fake")
+
+        with mock.patch.object(ADAPTER_MODULE.ctypes, "CDLL", return_value=library):
+            loaded = adapter._native_library()
+
+        self.assertIs(loaded, library)
+        self.assertEqual(adapter.mol._openqp_dftb_cache["__native_abi_version__"], 1)
+        self.assertIsNone(library.openqp_dftb_state_gradient.restype)
+
+    def test_precontract_unversioned_layout_is_rejected_safely(self):
+        adapter, library = self._adapter_with_abi1()
+        adapter.mol._openqp_dftb_cache.clear()
+        adapter._native_library_path = lambda: Path("/tmp/libopenqp_dftb_c.fake")
+        del library.openqp_dftb_states_overlap
+        del library.openqp_dftb_soc_matrix
+
+        with mock.patch.object(ADAPTER_MODULE.ctypes, "CDLL", return_value=library):
+            with self.assertRaisesRegex(
+                RuntimeError, r"lacks the stable ABI-v1 marker.*cannot be identified safely"
+            ):
+                adapter._native_library()
+
+    def test_abi1_call_uses_historical_63_argument_layout(self):
+        adapter, library = self._adapter_with_abi1(
+            dftb_updates={
+                "c_mrsf": 0.71,
+                "response_global_hybrid": True,
+                "onsite_exchange_scale": 0.19,
+            }
+        )
+
+        result = adapter._run_native("mrsf", 2, need_grad=True)
+
+        self.assertEqual(len(library.openqp_dftb_state_gradient.calls), 1)
+        args = library.openqp_dftb_state_gradient.calls[0]
+        self.assertEqual(len(args), 63)
+
+        # Stable ABI-v1 layout documented when ABI v2 was introduced in
+        # openqp-dftb commit 26ddd5a (its exact predecessor is 4beaa864).
+        self.assertIsInstance(args[0], ctypes.c_int64)
+        self.assertEqual(args[0].value, 2)
+        self.assertEqual([args[1][i] for i in range(2)], [1, 1])
+        self.assertEqual([args[2][i] for i in range(6)], [0.0, 0.0, 0.0, 0.0, 0.0, 1.4])
+        self.assertEqual(args[3], b"/tmp/minimal.opdftb")
+        self.assertIsInstance(args[4], ctypes.c_int32)
+        self.assertEqual(args[4].value, len(args[3]))
+        self.assertEqual(args[5], b"mrsf")
+        self.assertEqual(args[7].value, 2)    # root
+        self.assertEqual(args[8].value, 2)    # requested roots
+        self.assertEqual(args[9].value, 1)    # need gradient
+        self.assertEqual(args[10].value, -1)  # molecular charge
+        self.assertEqual(args[11].value, 3)   # auto SCC mixer
+        self.assertEqual(args[12].value, 9)
+        self.assertEqual(args[13].value, 321)
+        self.assertEqual(args[14].value, 41)
+        self.assertEqual(args[15].value, 73)
+        self.assertEqual(args[16].value, 1)   # Davidson
+        self.assertEqual(args[17].value, 3)   # high-spin reference
+        self.assertEqual(args[18].value, 1)   # target multiplicity
+        self.assertAlmostEqual(args[23].value, 2.0e-9)
+        self.assertAlmostEqual(args[36].value, 0.04)
+        self.assertAlmostEqual(args[37].value, 0.71)
+        self.assertEqual(args[38].value, 1)
+        self.assertAlmostEqual(args[39].value, 0.19)
+        self.assertEqual(args[40].value, 0)
+        self.assertIsInstance(args[61], ctypes.c_int32)
+        self.assertEqual(args[61].value, 1024)
+
+        self.assertEqual(result.reference_energy, -1.25)
+        self.assertEqual(result.state_energy, -1.05)
+        self.assertEqual(result.excitation_energy, 0.20)
+        self.assertEqual(result.spin_square, 0.02)
+        np.testing.assert_array_equal(
+            result.gradient_bohr,
+            np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        )
+        np.testing.assert_array_equal(result.all_state_energies, [-1.05, -0.95])
+        np.testing.assert_array_equal(result.all_spin_squares, [0.02, 0.03])
+        np.testing.assert_array_equal(result.relaxed_charges, [0.1, -0.1])
+        np.testing.assert_array_equal(result.mo_energies, [-0.5, 0.2])
+        np.testing.assert_array_equal(result.mo_coefficients, np.eye(2))
+        np.testing.assert_array_equal(result.response_vectors, [[0.7, 0.8]])
+
+    def test_abi1_rejects_post_v1_operator_knobs_before_call(self):
+        adapter, library = self._adapter_with_abi1(
+            dftb_updates={"c_mrsf_oo": 0.7, "response_omega": 0.21}
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError, r"C ABI v1.*c_mrsf_oo=0\.7.*response_omega=0\.21"
+        ):
+            adapter._run_native("mrsf", 1, need_grad=False)
+
+        self.assertEqual(library.openqp_dftb_state_gradient.calls, [])
+
+    def test_abi1_forwards_qmmm_embedding_and_relaxed_charges(self):
+        adapter, library = self._adapter_with_abi1()
+        adapter.mol.dftb_external_potential = np.array([0.1, -0.1])
+
+        result = adapter._run_native("ground", 0, need_grad=True)
+
+        args = library.openqp_dftb_state_gradient.calls[0]
+        self.assertEqual(args[40].value, 2)
+        self.assertEqual([args[41][i] for i in range(2)], [0.1, -0.1])
+        np.testing.assert_array_equal(result.relaxed_charges, [0.1, -0.1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openqp_dftb_abi1.py
+++ b/tests/test_openqp_dftb_abi1.py
@@ -1,4 +1,4 @@
-"""Regression tests for the historical openqp-dftb C ABI-v1 adapter."""
+"""Regression tests for versioned openqp-dftb C ABI adapter layouts."""
 
 from __future__ import annotations
 
@@ -33,6 +33,9 @@ def _load_adapter_module():
     file_utils = types.ModuleType("oqp.utils.file_utils")
     file_utils.dump_log = lambda *args, **kwargs: None
     state_labels = types.ModuleType("oqp.utils.state_labels")
+    state_labels.DFTB_CAP_STRUCTURED_TRACE = 1
+    state_labels.DFTB_CAP_STATE_SPECTRUM = 2
+    state_labels.DFTB_CAP_SCC_FINAL_TRUST = 4
     state_labels.canonical_dftb_type = lambda value: str(value).lower()
     state_labels.resolved_dftb_type = (
         lambda config: str(config.get("dftb", {}).get("type", "ground")).lower()
@@ -167,13 +170,75 @@ class _FakeLibrary:
         self.openqp_dftb_soc_matrix = object()
 
 
-class OpenQPDFTBABI1Tests(unittest.TestCase):
+class _IntegerProbe:
+    def __init__(self, value):
+        self.value = value
+        self.restype = object()
+
+    def __call__(self):
+        return self.value
+
+
+class _RecordingCurrentFunction:
+    def __init__(self):
+        self.calls = []
+        self.restype = object()
+
+    def __call__(self, *args):
+        self.calls.append(args)
+        if len(args) != 74:
+            raise AssertionError(
+                f"ABI v2/v3 requires exactly 74 arguments, got {len(args)}"
+            )
+
+        ctypes.cast(args[53], ctypes.POINTER(ctypes.c_double))[0] = -1.25
+        ctypes.cast(args[54], ctypes.POINTER(ctypes.c_double))[0] = -1.05
+        ctypes.cast(args[55], ctypes.POINTER(ctypes.c_double))[0] = 0.20
+        ctypes.cast(args[56], ctypes.POINTER(ctypes.c_double))[0] = 0.02
+        for index, value in enumerate((1.0, 2.0, 3.0, 4.0, 5.0, 6.0)):
+            args[57][index] = value
+        ctypes.cast(args[58], ctypes.POINTER(ctypes.c_int64))[0] = 2
+        args[59][0], args[59][1] = -1.05, -0.95
+        args[60][0], args[60][1] = 0.02, 0.03
+        args[61][0], args[61][1] = 0.1, -0.1
+        ctypes.cast(args[62], ctypes.POINTER(ctypes.c_int64))[0] = 2
+        ctypes.cast(args[63], ctypes.POINTER(ctypes.c_int64))[0] = 1
+        ctypes.cast(args[64], ctypes.POINTER(ctypes.c_int64))[0] = 1
+        ctypes.cast(args[65], ctypes.POINTER(ctypes.c_int64))[0] = 1
+        args[67][0], args[67][1] = -0.5, 0.2
+        for index, value in enumerate((1.0, 0.0, 0.0, 1.0)):
+            args[68][index] = value
+        args[70][0], args[70][1] = 0.7, 0.8
+        args[71].value = b""
+        ctypes.cast(args[73], ctypes.POINTER(ctypes.c_int64))[0] = 0
+
+
+class _FakeCurrentLibrary:
+    def __init__(self, *, capabilities=7):
+        self.openqp_dftb_state_gradient = _RecordingCurrentFunction()
+        self.openqp_dftb_capi_abi_version = _IntegerProbe(3)
+        if capabilities is not None:
+            self.openqp_dftb_capi_capabilities = _IntegerProbe(capabilities)
+
+
+class OpenQPDFTBABITests(unittest.TestCase):
     def _adapter_with_abi1(self, **mol_kwargs):
         mol = _FakeMolecule(**mol_kwargs)
         adapter = ADAPTER_MODULE.OpenQPDFTBAdapter(mol)
         library = _FakeLibrary()
         mol._openqp_dftb_cache["__native_library__"] = library
         mol._openqp_dftb_cache["__native_abi_version__"] = 1
+        return adapter, library
+
+    def _adapter_with_current(self, *, capabilities=7, **mol_kwargs):
+        mol = _FakeMolecule(**mol_kwargs)
+        adapter = ADAPTER_MODULE.OpenQPDFTBAdapter(mol)
+        library = _FakeCurrentLibrary(capabilities=capabilities)
+        mol._openqp_dftb_cache["__native_library__"] = library
+        mol._openqp_dftb_cache["__native_abi_version__"] = 3
+        mol._openqp_dftb_cache["__native_capabilities__"] = (
+            0 if capabilities is None else capabilities
+        )
         return adapter, library
 
     def test_unversioned_library_is_classified_as_abi1(self):
@@ -186,7 +251,56 @@ class OpenQPDFTBABI1Tests(unittest.TestCase):
 
         self.assertIs(loaded, library)
         self.assertEqual(adapter.mol._openqp_dftb_cache["__native_abi_version__"], 1)
+        self.assertEqual(adapter.mol._openqp_dftb_cache["__native_capabilities__"], 0)
         self.assertIsNone(library.openqp_dftb_state_gradient.restype)
+
+    def test_optional_capability_symbol_is_probed_and_cached(self):
+        adapter, library = self._adapter_with_current()
+        adapter.mol._openqp_dftb_cache.clear()
+        adapter._native_library_path = lambda: Path("/tmp/libopenqp_dftb_c.fake")
+
+        with mock.patch.object(ADAPTER_MODULE.ctypes, "CDLL", return_value=library):
+            adapter._native_library()
+
+        self.assertEqual(
+            adapter.mol._openqp_dftb_cache["__native_capabilities__"], 7
+        )
+        self.assertIs(
+            library.openqp_dftb_capi_capabilities.restype, ctypes.c_int64
+        )
+
+    def test_missing_capability_symbol_means_zero_even_for_abi3(self):
+        adapter, library = self._adapter_with_current(capabilities=None)
+        adapter.mol._openqp_dftb_cache.clear()
+        adapter._native_library_path = lambda: Path("/tmp/libopenqp_dftb_c.fake")
+
+        with mock.patch.object(ADAPTER_MODULE.ctypes, "CDLL", return_value=library):
+            adapter._native_library()
+
+        self.assertEqual(
+            adapter.mol._openqp_dftb_cache["__native_capabilities__"], 0
+        )
+
+    def test_cache_generation_preserves_native_capabilities(self):
+        adapter, library = self._adapter_with_current()
+        sentinel = object()
+        adapter._cache_key = lambda *args, **kwargs: (
+            ("H", "H"), b"new-geometry", (b"embedding",)
+        )
+        adapter._run_native = lambda *args, **kwargs: sentinel
+
+        result = adapter._run_state("mrsf", 1, need_grad=False)
+
+        self.assertIs(result, sentinel)
+        self.assertIs(
+            adapter.mol._openqp_dftb_cache["__native_library__"], library
+        )
+        self.assertEqual(
+            adapter.mol._openqp_dftb_cache["__native_abi_version__"], 3
+        )
+        self.assertEqual(
+            adapter.mol._openqp_dftb_cache["__native_capabilities__"], 7
+        )
 
     def test_precontract_unversioned_layout_is_rejected_safely(self):
         adapter, library = self._adapter_with_abi1()
@@ -284,6 +398,51 @@ class OpenQPDFTBABI1Tests(unittest.TestCase):
         self.assertEqual(args[40].value, 2)
         self.assertEqual([args[41][i] for i in range(2)], [0.1, -0.1])
         np.testing.assert_array_equal(result.relaxed_charges, [0.1, -0.1])
+
+    def test_current_call_uses_exact_74_argument_layout_and_slots(self):
+        adapter, library = self._adapter_with_current(
+            dftb_updates={
+                "c_mrsf": 0.71,
+                "response_global_hybrid": True,
+                "onsite_exchange_scale": 0.19,
+                "w_scale": 0.91,
+                "response_w_scale": 0.81,
+                "response_omega": 0.21,
+                "response_cam_alpha": 0.11,
+                "response_cam_beta": 0.61,
+                "c_mrsf_oo": 0.41,
+                "onsite_ss": 0.01,
+                "onsite_sp": 0.02,
+                "onsite_pp": 0.03,
+                "model": "dtcam-tb",
+            }
+        )
+
+        result = adapter._run_native("mrsf", 2, need_grad=True)
+
+        calls = library.openqp_dftb_state_gradient.calls
+        self.assertEqual(len(calls), 1)
+        args = calls[0]
+        self.assertEqual(len(args), 74)
+        self.assertAlmostEqual(args[37].value, 0.71)
+        self.assertEqual(args[38].value, 1)
+        self.assertAlmostEqual(args[39].value, 0.19)
+        self.assertAlmostEqual(args[40].value, 0.91)
+        self.assertAlmostEqual(args[41].value, 0.81)
+        self.assertAlmostEqual(args[42].value, 0.21)
+        self.assertAlmostEqual(args[43].value, 0.11)
+        self.assertAlmostEqual(args[44].value, 0.61)
+        self.assertAlmostEqual(args[45].value, 0.41)
+        self.assertAlmostEqual(args[46].value, 0.01)
+        self.assertAlmostEqual(args[47].value, 0.02)
+        self.assertAlmostEqual(args[48].value, 0.03)
+        self.assertEqual(args[49], b"dtcam-tb")
+        self.assertEqual(args[50].value, len(args[49]))
+        self.assertEqual(args[51].value, 0)
+        self.assertIsInstance(args[72], ctypes.c_int32)
+        self.assertEqual(args[72].value, 1024)
+        self.assertEqual(result.reference_energy, -1.25)
+        np.testing.assert_array_equal(result.all_state_energies, [-1.05, -0.95])
 
 
 if __name__ == "__main__":

--- a/tests/test_openqp_dftb_api.py
+++ b/tests/test_openqp_dftb_api.py
@@ -34,7 +34,7 @@ load_openqp_module = _load_api_helpers().load_openqp_module
 
 
 class TestOpenQPDftbAPI(unittest.TestCase):
-    def test_dftb_helper_defaults_to_mrsf_response(self):
+    def test_dftb_helper_preserves_legacy_mrsf_default(self):
         openqp = load_openqp_module()
         job = (
             openqp.OpenQP(project="h2_dftb")
@@ -49,6 +49,14 @@ class TestOpenQPDftbAPI(unittest.TestCase):
         self.assertEqual(config["dftb"]["parameter_path"], "mio-1-1")
         self.assertEqual(config["tdhf"]["type"], "mrsf")
         self.assertEqual(config["tdhf"]["nstate"], "4")
+        self.assertEqual(config["scf"]["type"], "rohf")
+
+        ground = (
+            openqp.OpenQP(project="h2_explicit_ground_dftb")
+            .molecule("H 0 0 0; H 0 0 0.74")
+            .ground_dftb(parameter_path="mio-1-1")
+        )
+        self.assertEqual(ground.to_input_dict()["dftb"]["type"], "ground")
 
     def test_dftb_helper_maps_response_and_noscc_aliases(self):
         openqp = load_openqp_module()
@@ -68,7 +76,7 @@ class TestOpenQPDftbAPI(unittest.TestCase):
             .dftb(response_type="noscc", parameter_path="mio-1-1")
         )
         config = noscc.to_input_dict()
-        self.assertEqual(config["dftb"]["type"], "noscc")
+        self.assertEqual(config["dftb"]["type"], "ground_noscc")
         self.assertEqual(config["tdhf"]["type"], "tda")
 
         ground_noscc = (
@@ -109,23 +117,61 @@ class TestOpenQPDftbAPI(unittest.TestCase):
     def test_theory_namespace_dftb_response_families(self):
         openqp = load_openqp_module()
 
+        legacy_mrsf = (
+            openqp.OpenQP(project="h2_dftb")
+            .molecule("H 0 0 0; H 0 0 0.74")
+            .theory.dftb(parameter_path="mio-1-1")
+        )
+        self.assertEqual(legacy_mrsf.to_input_dict()["dftb"]["type"], "mrsf")
+
+        ground = (
+            openqp.OpenQP(project="h2_ground_dftb")
+            .molecule("H 0 0 0; H 0 0 0.74")
+            .theory.ground_dftb(parameter_path="mio-1-1")
+        )
+        self.assertEqual(ground.to_input_dict()["dftb"]["type"], "ground")
+
         mrsf = (
             openqp.OpenQP(project="h2_mrsf_dftb")
             .molecule("H 0 0 0; H 0 0 0.74")
-            .theory.dftb(response_type="mrsf", parameter_path="mio-1-1")
+            .theory.mrsf_tddftb(parameter_path="mio-1-1")
         )
         config = mrsf.to_input_dict()
         self.assertEqual(config["dftb"]["type"], "mrsf")
         self.assertEqual(config["tdhf"]["type"], "mrsf")
+        self.assertEqual(config["scf"]["type"], "rohf")
+        self.assertEqual(config["scf"]["multiplicity"], "3")
 
         sf = (
             openqp.OpenQP(project="h2_sf_dftb")
             .molecule("H 0 0 0; H 0 0 0.74")
-            .theory("sf-tddftb", parameter_path="mio-1-1")
+            .theory.sf_tddftb(parameter_path="mio-1-1")
         )
         config = sf.to_input_dict()
         self.assertEqual(config["dftb"]["type"], "sf")
         self.assertEqual(config["tdhf"]["type"], "sf")
+
+        conventional = (
+            openqp.OpenQP(project="h2_tddftb")
+            .molecule("H 0 0 0; H 0 0 0.74")
+            .theory.tddftb(nstate=2, parameter_path="mio-1-1")
+        )
+        config = conventional.to_input_dict()
+        self.assertEqual(config["dftb"]["type"], "tddftb")
+        self.assertEqual(config["tdhf"]["type"], "tda")
+
+    def test_top_level_dftb_response_helpers_are_symmetric(self):
+        openqp = load_openqp_module()
+
+        for helper, expected in (
+            ("ground_dftb", "ground"),
+            ("tddftb", "tddftb"),
+            ("sf_tddftb", "sf"),
+            ("mrsf_tddftb", "mrsf"),
+        ):
+            job = openqp.OpenQP(project=helper)
+            getattr(job, helper)(nstate=2, parameter_path="mio-1-1")
+            self.assertEqual(job.to_input_dict()["dftb"]["type"], expected)
 
     def test_workflow_soc_accepts_dftb_mrsf(self):
         openqp = load_openqp_module()

--- a/tests/test_openqp_dftb_logging.py
+++ b/tests/test_openqp_dftb_logging.py
@@ -1,0 +1,225 @@
+"""Pure-Python regression coverage for OpenQP-DFTB settings logging."""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def _load_adapter(monkeypatch, calls):
+    oqp = types.ModuleType("oqp")
+    oqp.__path__ = []
+    oqp.oqp_root = ""
+    monkeypatch.setitem(sys.modules, "oqp", oqp)
+
+    utils = types.ModuleType("oqp.utils")
+    utils.__path__ = []
+    monkeypatch.setitem(sys.modules, "oqp.utils", utils)
+
+    periodic = types.ModuleType("oqp.periodic_table")
+    periodic.ELEMENTS_NAME = {1: "H"}
+    monkeypatch.setitem(sys.modules, "oqp.periodic_table", periodic)
+
+    constants = types.ModuleType("oqp.utils.constants")
+    constants.ANGSTROM_TO_BOHR = 0.529177210903
+    monkeypatch.setitem(sys.modules, "oqp.utils.constants", constants)
+
+    file_utils = types.ModuleType("oqp.utils.file_utils")
+    file_utils.dump_log = lambda *args, **kwargs: calls.append((args, kwargs))
+    monkeypatch.setitem(sys.modules, "oqp.utils.file_utils", file_utils)
+
+    labels_path = ROOT / "pyoqp" / "oqp" / "utils" / "state_labels.py"
+    labels_spec = importlib.util.spec_from_file_location(
+        "oqp.utils.state_labels", labels_path
+    )
+    labels = importlib.util.module_from_spec(labels_spec)
+    monkeypatch.setitem(sys.modules, labels_spec.name, labels)
+    labels_spec.loader.exec_module(labels)
+
+    adapter_path = ROOT / "pyoqp" / "oqp" / "library" / "openqp_dftb.py"
+    adapter_spec = importlib.util.spec_from_file_location(
+        "_openqp_dftb_logging_under_test", adapter_path
+    )
+    module = importlib.util.module_from_spec(adapter_spec)
+    monkeypatch.setitem(sys.modules, adapter_spec.name, module)
+    adapter_spec.loader.exec_module(module)
+    return module
+
+
+def _adapter_without_native_runtime(module):
+    adapter = object.__new__(module.OpenQPDFTBAdapter)
+    adapter.mol = types.SimpleNamespace()
+    adapter.config = {
+        "input": {"method": "dftb", "runtype": "energy"},
+        "tdhf": {"type": "mrsf", "nstate": 3, "multiplicity": 1},
+        "dftb": {"type": "mrsf", "backend": "native"},
+    }
+    adapter.dftb = adapter.config["dftb"]
+    return adapter
+
+
+def _load_input_checker(monkeypatch):
+    oqp = types.ModuleType("oqp")
+    oqp.__path__ = []
+    utils = types.ModuleType("oqp.utils")
+    utils.__path__ = []
+    mpi_utils = types.ModuleType("oqp.utils.mpi_utils")
+
+    class MPIManager:
+        size = 1
+        use_mpi = False
+
+    mpi_utils.MPIManager = MPIManager
+    monkeypatch.setitem(sys.modules, "oqp", oqp)
+    monkeypatch.setitem(sys.modules, "oqp.utils", utils)
+    monkeypatch.setitem(sys.modules, "oqp.utils.mpi_utils", mpi_utils)
+
+    path = ROOT / "pyoqp" / "oqp" / "utils" / "input_checker.py"
+    spec = importlib.util.spec_from_file_location(
+        "_openqp_dftb_input_checker_under_test", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_adapter_logs_one_settings_block_for_all_states(monkeypatch):
+    calls = []
+    module = _load_adapter(monkeypatch, calls)
+    adapter = _adapter_without_native_runtime(module)
+
+    for _state in (1, 2, 3):
+        adapter._log_settings_once(
+            "mrsf",
+            backend="native",
+            parameter_path="/parameters/OB2W0PT3",
+            library_path="/wheel/libopenqp_dftb_c.dylib",
+        )
+
+    assert len(calls) == 1
+    assert calls[0][1]["section"] == "dftb"
+    assert calls[0][1]["info"]["parameter_path"] == "/parameters/OB2W0PT3"
+
+
+def test_native_diagnostics_capture_fd_and_restore_environment(monkeypatch):
+    calls = []
+    module = _load_adapter(monkeypatch, calls)
+    monkeypatch.setenv("OPENQP_DFTB_SCC_TRACE", "previous")
+
+    def native_writer():
+        os.write(1, b"openqp_dftb_davidson_end iterations 4 elapsed_seconds 0.25\n")
+
+    text = module._call_with_native_diagnostics(
+        native_writer, print_level=2, state_spectrum=True
+    )
+
+    assert "davidson_end" in text
+    assert os.environ["OPENQP_DFTB_SCC_TRACE"] == "previous"
+    assert "OPENQP_DFTB_STATE_SPECTRUM" not in os.environ
+
+
+def test_bundled_parameter_resolution_is_silent(monkeypatch):
+    calls = []
+    module = _load_adapter(monkeypatch, calls)
+    adapter = _adapter_without_native_runtime(module)
+    monkeypatch.setattr(module, "_bundled_parameter_path", lambda: "/bundle/OB2W0PT3")
+
+    assert adapter._parameter_path() == "/bundle/OB2W0PT3"
+    assert adapter._parameter_path() == "/bundle/OB2W0PT3"
+    assert calls == []
+
+
+def test_legacy_conventional_tddftb_triplet_is_rejected(monkeypatch):
+    input_checker = _load_input_checker(monkeypatch)
+    for dftb_type, runtype, grad in (
+        ("tddftb", "energy", []),
+        ("auto", "grad", [1]),
+    ):
+        config = {
+            "input": {"method": "dftb", "runtype": runtype},
+            "tdhf": {"type": "tda", "nstate": 3, "multiplicity": 3},
+            "dftb": {
+                "type": dftb_type,
+                "backend": "native",
+                "parameter_path": "/tmp/minimal.opdftb",
+                "target_multiplicity": 3,
+            },
+            "properties": {"grad": grad, "scf_prop": [], "nac": []},
+            "optimize": {"istate": 0, "jstate": 0},
+            "pcm": {"enabled": False},
+        }
+
+        report = input_checker.CheckReport()
+        input_checker._check_dftb(config, report)
+
+        assert not report.ok
+        assert "singlet TDA response only" in report.to_text()
+        assert "SF-TDDFTB or MRSF-TDDFTB" in report.to_text()
+
+
+def test_conventional_tddftb_open_shell_reference_is_rejected(monkeypatch):
+    input_checker = _load_input_checker(monkeypatch)
+    config = {
+        "input": {"method": "dftb", "runtype": "energy"},
+        "tdhf": {"type": "tda", "nstate": 1, "multiplicity": 1},
+        "dftb": {
+            "type": "tddftb",
+            "backend": "native",
+            "parameter_path": "/tmp/minimal.opdftb",
+            "reference_multiplicity": 3,
+            "target_multiplicity": 1,
+        },
+        "properties": {"grad": [], "scf_prop": [], "nac": []},
+        "optimize": {"istate": 0, "jstate": 0},
+        "pcm": {"enabled": False},
+    }
+
+    report = input_checker.CheckReport()
+    input_checker._check_dftb(config, report)
+
+    assert not report.ok
+    assert "closed-shell singlet reference" in report.to_text()
+
+
+def test_explicit_dftb_response_type_must_match_tdhf_type(monkeypatch):
+    input_checker = _load_input_checker(monkeypatch)
+    for dftb_type, td_type, expected in (
+        ("tddftb", "mrsf", "rpa/tda"),
+        ("sf", "tda", "sf"),
+        ("mrsf", "tda", "mrsf"),
+    ):
+        config = {
+            "input": {"method": "dftb", "runtype": "energy"},
+            "tdhf": {"type": td_type, "nstate": 1, "multiplicity": 1},
+            "dftb": {
+                "type": dftb_type,
+                "backend": "native",
+                "parameter_path": "/tmp/minimal.opdftb",
+                "target_multiplicity": 1,
+            },
+            "properties": {"grad": [], "scf_prop": [], "nac": []},
+            "optimize": {"istate": 0, "jstate": 0},
+            "pcm": {"enabled": False},
+        }
+
+        report = input_checker.CheckReport()
+        input_checker._check_dftb(config, report)
+
+        assert not report.ok
+        assert "response type conflicts" in report.to_text()
+        assert expected in report.to_text()
+
+
+def test_sf_reference_multiplicity_one_normalizes_to_triplet(monkeypatch):
+    calls = []
+    module = _load_adapter(monkeypatch, calls)
+    adapter = _adapter_without_native_runtime(module)
+    adapter.dftb["reference_multiplicity"] = 1
+
+    assert adapter._reference_multiplicity("sf") == 3
+    assert adapter._reference_multiplicity("mrsf") == 3

--- a/tests/test_openqp_dftb_logging.py
+++ b/tests/test_openqp_dftb_logging.py
@@ -100,12 +100,14 @@ def test_adapter_logs_one_settings_block_for_all_states(monkeypatch):
             parameter_path="/parameters/OB2W0PT3",
             library_path="/wheel/libopenqp_dftb_c.dylib",
             abi_version=3,
+            capabilities=7,
         )
 
     assert len(calls) == 1
     assert calls[0][1]["section"] == "dftb"
     assert calls[0][1]["info"]["parameter_path"] == "/parameters/OB2W0PT3"
     assert calls[0][1]["info"]["abi_version"] == 3
+    assert calls[0][1]["info"]["capabilities"] == 7
 
 
 def test_native_diagnostics_capture_fd_and_restore_environment(monkeypatch):
@@ -123,6 +125,30 @@ def test_native_diagnostics_capture_fd_and_restore_environment(monkeypatch):
     assert "davidson_end" in text
     assert os.environ["OPENQP_DFTB_SCC_TRACE"] == "previous"
     assert "OPENQP_DFTB_STATE_SPECTRUM" not in os.environ
+
+
+def test_unadvertised_native_diagnostics_are_not_requested(monkeypatch):
+    calls = []
+    module = _load_adapter(monkeypatch, calls)
+    seen = {}
+
+    def inspect_environment():
+        for name in module._NATIVE_DIAGNOSTIC_ENV:
+            seen[name] = os.environ[name]
+
+    module._call_with_native_diagnostics(
+        inspect_environment,
+        print_level=2,
+        state_spectrum=False,
+        structured_trace=False,
+    )
+
+    assert seen == {
+        "OPENQP_DFTB_SCC_TRACE": "0",
+        "OPENQP_DFTB_SOLVER_TRACE": "0",
+        "OPENQP_ZVEC_TRACE": "0",
+        "OPENQP_DFTB_STATE_SPECTRUM": "0",
+    }
 
 
 def test_bundled_parameter_resolution_is_silent(monkeypatch):

--- a/tests/test_openqp_dftb_logging.py
+++ b/tests/test_openqp_dftb_logging.py
@@ -99,11 +99,13 @@ def test_adapter_logs_one_settings_block_for_all_states(monkeypatch):
             backend="native",
             parameter_path="/parameters/OB2W0PT3",
             library_path="/wheel/libopenqp_dftb_c.dylib",
+            abi_version=3,
         )
 
     assert len(calls) == 1
     assert calls[0][1]["section"] == "dftb"
     assert calls[0][1]["info"]["parameter_path"] == "/parameters/OB2W0PT3"
+    assert calls[0][1]["info"]["abi_version"] == 3
 
 
 def test_native_diagnostics_capture_fd_and_restore_environment(monkeypatch):

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -11,7 +11,8 @@ import pytest
 # Importing oqp normally loads liboqp.  The semantic parser intentionally has no
 # native dependency, so exercise it directly to keep these tests fast and usable
 # in source-only documentation/editor environments.
-MODULE_PATH = Path(__file__).parents[1] / "pyoqp" / "oqp" / "utils" / "oqp_input.py"
+ROOT = Path(__file__).parents[1]
+MODULE_PATH = ROOT / "pyoqp" / "oqp" / "utils" / "oqp_input.py"
 SPEC = importlib.util.spec_from_file_location("_openqp_semantic_input", MODULE_PATH)
 oqp_input = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = oqp_input
@@ -1102,6 +1103,7 @@ def test_dftb_route_types_and_open_shell_reference_reach_adapter():
         'dftb(parameter_path="minimal.opdftb")'
     )
     assert td["dftb"]["type"] == "tddftb"
+    assert td["tdhf"]["type"] == "tda"
 
     _, ground = _parse(
         'dftb geom="radical.xyz" mult=2 energy() '
@@ -1113,10 +1115,10 @@ def test_dftb_route_types_and_open_shell_reference_reach_adapter():
 @pytest.mark.parametrize(
     "route,expected_type",
     [
-        ("dftb", "auto"),
+        ("dftb", "ground"),
         ("dftb0", "ground_noscc"),
         ("tddftb(nstate=2)", "tddftb"),
-        ("tda-tddftb(nstate=2)", "tda"),
+        ("tda-tddftb(nstate=2)", "tddftb"),
     ],
 )
 def test_default_dftb_reference_multiplicity_is_not_forwarded_to_probe(route, expected_type):
@@ -1151,25 +1153,53 @@ def test_dftb0_route_and_alias_lower_to_non_scc_ground_state():
     assert legacy["properties"]["grad"] == "0"
 
 
-def test_tda_tddftb_route_preserves_tda_and_physical_triplet_mapping():
+def test_tda_tddftb_route_is_canonical_tda_singlet_response():
     spec, legacy = _parse(
-        'tddftb-tda(nstate=3) geom="h2o.xyz" grad(T0) '
+        'tddftb-tda(nstate=3) geom="h2o.xyz" grad(S1) '
         'dftb(parameter_path="minimal.opdftb")'
     )
 
     assert spec.model == "tda-dftb"
-    assert spec.physical_method == "TDA-TDDFTB"
+    assert spec.physical_method == "TD-DFTB (TDA)"
     assert oqp_input.render_canonical_oqp(spec).startswith("tda-tddftb(nstate=3) ")
     assert legacy["tdhf"]["type"] == "tda"
-    assert legacy["tdhf"]["multiplicity"] == "3"
-    assert legacy["dftb"]["type"] == "tda"
-    assert legacy["dftb"]["target_multiplicity"] == "3"
+    assert legacy["tdhf"]["multiplicity"] == "1"
+    assert legacy["dftb"]["type"] == "tddftb"
+    assert legacy["dftb"]["target_multiplicity"] == "1"
     assert legacy["properties"]["grad"] == "1"
 
-    with pytest.raises(OQPInputError, match="singlet or triplet"):
+    with pytest.raises(OQPInputError, match="supports singlet targets only"):
         oqp_input.parse_canonical_oqp(
-            'tda-tddftb(nstate=3) geom="h2o.xyz" grad(Q0)'
+            'tda-tddftb(nstate=3) geom="h2o.xyz" grad(T0)'
         )
+
+
+def test_conventional_tddftb_triplet_is_rejected_with_spin_flip_guidance():
+    with pytest.raises(OQPInputError, match="use sf-tddftb or mrsf-tddftb"):
+        oqp_input.parse_canonical_oqp(
+            'tddftb(nstate=3) geom="h2o.xyz" grad(T1)'
+        )
+
+
+@pytest.mark.parametrize(
+    "filename,expected_model,expected_type",
+    [
+        ("H2_DFTB_ENERGY.oqp", "dftb", "ground"),
+        ("H2O_TDDFTB_ENERGY.oqp", "tddftb", "tddftb"),
+        ("CH2_SF-TDDFTB_ENERGY.oqp", "sf-dftb", "sf"),
+        ("CH2_MRSF-TDDFTB_ENERGY.oqp", "mrsf-dftb", "mrsf"),
+    ],
+)
+def test_minimal_dftb_family_examples_parse(filename, expected_model, expected_type):
+    example_dir = ROOT / "examples" / "DFTB"
+    text = (example_dir / filename).read_text(encoding="utf-8")
+
+    spec = oqp_input.parse_canonical_oqp(text)
+    legacy = oqp_input.lower_to_legacy(spec, source_dir=example_dir)
+
+    assert spec.model == expected_model
+    assert legacy["input"]["method"] == "dftb"
+    assert legacy["dftb"]["type"] == expected_type
 
 
 def test_sf_tddftb_route_uses_high_spin_reference_and_explicit_root():

--- a/tests/test_state_labels.py
+++ b/tests/test_state_labels.py
@@ -195,6 +195,20 @@ def test_dftb_mrsf_labels_use_backend_target_multiplicity():
     assert state_labels.public_state_label(config, 1) == "T0"
     assert state_labels.requested_states(config) == "T0-T2"
     assert state_labels.dftb_target_description(config) == "T0-T2"
+    text = state_labels.format_calculation_request(config)
+    assert "Target spin:                 triplet" in text
+
+
+def test_explicit_ground_dftb_ignores_stale_mrsf_response_defaults():
+    config = dftb_config("ground", td_type="mrsf", nstate=4)
+
+    assert not state_labels.is_mrsf(config)
+    assert state_labels.public_state_label(config, 0) == "state 0"
+    text = state_labels.format_calculation_request(config)
+    assert "Method:                      DFTB" in text
+    assert "Physical target state(s):    S0 ground state" in text
+    assert "Target spin:" not in text
+    assert "State labels:" not in text
 
 
 def test_sf_reference_multiplicity_one_logs_effective_triplet_reference():
@@ -247,6 +261,57 @@ def test_dftb_settings_are_grouped_and_report_resolved_paths():
     assert "trah (requested)" in text
     assert "davidson (requested)" in text
     assert "Relaxed Z-vector:" in text
+
+
+def test_zero_capability_mask_never_claims_new_native_features():
+    config = dftb_config("mrsf", td_type="mrsf", nstate=3)
+    config["dftb"]["state_to_state_spectrum"] = True
+
+    text = state_labels.format_dftb_settings(
+        config,
+        backend="native",
+        library_path="/wheel/libopenqp_dftb_c.dylib",
+        abi_version=3,
+        capabilities=0,
+    )
+
+    assert "C API ABI:                  3" in text
+    assert "C API capabilities:         none advertised" in text
+    assert "structured progress tracing" in text
+    assert "loaded library (C ABI 3) does not advertise all-pair state spectrum" in text
+    assert "loaded library (C ABI 3) does not advertise final trust-region SCC recovery" in text
+
+
+def test_advertised_capabilities_enable_native_feature_summary():
+    config = dftb_config("mrsf", td_type="mrsf", nstate=3)
+    text = state_labels.format_dftb_settings(
+        config,
+        backend="native",
+        abi_version=3,
+        capabilities=(
+            state_labels.DFTB_CAP_STRUCTURED_TRACE
+            | state_labels.DFTB_CAP_STATE_SPECTRUM
+            | state_labels.DFTB_CAP_SCC_FINAL_TRUST
+        ),
+    )
+
+    assert "structured trace, state spectrum, SCC final trust recovery" in text
+    assert "Native progress trace:      level 1" in text
+    assert "State-to-state spectrum:    yes (unrelaxed TDA/state interaction)" in text
+    assert "final charge/spin trust-TRAH pass when eligible" in text
+
+
+def test_probe_settings_do_not_advertise_native_trace_or_spectrum():
+    config = dftb_config("mrsf", td_type="mrsf", nstate=3)
+    text = state_labels.format_dftb_settings(
+        config,
+        backend="probe",
+        executable="/tmp/openqp_dftb_probe",
+    )
+
+    assert "Native progress trace:" not in text
+    assert "State-to-state spectrum:    requested; unavailable with probe backend" in text
+    assert "Failed-cycle recovery:      unavailable with probe backend" in text
 
 
 def test_dftb_preset_log_does_not_claim_schema_defaults_are_effective():

--- a/tests/test_state_labels.py
+++ b/tests/test_state_labels.py
@@ -29,6 +29,29 @@ def mrsf_config(runtype="energy", target_mult=1):
     }
 
 
+def dftb_config(dftb_type="ground", *, td_type="tda", nstate=3, model=""):
+    return {
+        "input": {
+            "method": "dftb",
+            "runtype": "energy",
+            # This is a legacy schema default and must never be advertised as
+            # the basis of a minimal-basis DFTB calculation.
+            "basis": "6-31g*",
+            "functional": "",
+        },
+        "scf": {"type": "rhf", "multiplicity": 1},
+        "tdhf": {"type": td_type, "multiplicity": 1, "nstate": nstate},
+        "dftb": {
+            "type": dftb_type,
+            "backend": "auto",
+            "parameter_path": "",
+            "model": model,
+        },
+        "properties": {"grad": []},
+        "optimize": {"istate": 0},
+    }
+
+
 def test_singlet_mrsf_root_one_is_s0_and_reference_is_not_s0():
     config = mrsf_config()
 
@@ -127,3 +150,109 @@ def test_prop_and_branching_plane_summaries_keep_physical_meaning():
     bp["nac"]["bp"] = True
     text = state_labels.format_calculation_request(bp)
     assert "Calculation:                 Branching-plane analysis" in text
+
+
+def test_dftb_aliases_share_one_canonical_method_display():
+    expected = {
+        "dftb": ("ground", "DFTB"),
+        "noscc": ("ground_noscc", "DFTB0"),
+        "tda": ("tddftb", "TD-DFTB (TDA)"),
+        "sf-tddftb": ("sf", "SF-TDDFTB"),
+        "mrsftddftb": ("mrsf", "MRSF-TDDFTB"),
+    }
+    for alias, (canonical, display) in expected.items():
+        config = dftb_config(alias)
+        assert state_labels.canonical_dftb_type(alias) == canonical
+        assert state_labels.public_method_name(config) == display
+
+
+def test_dftb_calculation_summary_hides_fake_gaussian_basis():
+    config = dftb_config("tddftb", nstate=4)
+    text = state_labels.format_calculation_request(config)
+
+    assert "Method:                      TD-DFTB (TDA)" in text
+    assert "Physical target state(s):    singlet S1-S4" in text
+    assert "Reference:                   singlet restricted SCC-DFTB reference" in text
+    assert "6-31g*" not in text
+    assert "Basis:" not in text
+
+
+def test_dftb_target_summary_reports_the_selected_gradient_state():
+    config = dftb_config("mrsf", td_type="mrsf", nstate=4)
+    config["input"]["runtype"] = "grad"
+    config["properties"]["grad"] = [2]
+
+    assert state_labels.dftb_target_description(config) == "S1"
+
+
+def test_dftb_mrsf_labels_use_backend_target_multiplicity():
+    config = dftb_config("mrsf", td_type="mrsf", nstate=3)
+    config["dftb"]["target_multiplicity"] = 3
+    # The legacy TDHF field may remain at its schema default; the native DFTB
+    # adapter sends dftb.target_multiplicity to the backend.
+    config["tdhf"]["multiplicity"] = 1
+
+    assert state_labels.public_state_label(config, 1) == "T0"
+    assert state_labels.requested_states(config) == "T0-T2"
+    assert state_labels.dftb_target_description(config) == "T0-T2"
+
+
+def test_sf_reference_multiplicity_one_logs_effective_triplet_reference():
+    config = dftb_config("sf", td_type="sf")
+    config["dftb"]["reference_multiplicity"] = 1
+
+    assert state_labels.dftb_reference_description(config).startswith("triplet")
+
+
+def test_open_shell_ground_dftb_is_not_labeled_singlet():
+    config = dftb_config("ground")
+    config["dftb"]["reference_multiplicity"] = 2
+
+    assert state_labels.dftb_reference_description(config).startswith("doublet")
+    assert state_labels.dftb_target_description(config) == "D0 ground state"
+
+
+def test_conventional_tddftb_log_omits_inactive_sf_and_cam_controls():
+    config = dftb_config("tddftb", nstate=3)
+    text = state_labels.format_dftb_settings(config, backend="native")
+
+    assert "Response manifold:          closed-shell singlet TDA" in text
+    assert "Spin completion:" not in text
+    assert "Gamma kernel / omega:" not in text
+    assert "CAM alpha / beta:" not in text
+
+
+def test_dftb_settings_are_grouped_and_report_resolved_paths():
+    config = dftb_config("mrsf", td_type="mrsf", nstate=3)
+    config["dftb"].update(
+        scc_mixer="trah",
+        scc_tolerance=1.0e-9,
+        response_solver="davidson",
+        zvector=True,
+    )
+    text = state_labels.format_dftb_settings(
+        config,
+        backend="native",
+        parameter_path="/parameters/OB2W0PT3",
+        library_path="/site-packages/openqp_dftb/libopenqp_dftb_c.dylib",
+    )
+
+    assert "DFTB calculation settings" in text
+    assert "DFTB SCC settings" in text
+    assert "DFTB response settings" in text
+    assert "DFTB gradient settings" in text
+    assert "DFTB operator settings" in text
+    assert "MRSF-TDDFTB" in text
+    assert "/parameters/OB2W0PT3" in text
+    assert "trah (requested)" in text
+    assert "davidson (requested)" in text
+    assert "Relaxed Z-vector:" in text
+
+
+def test_dftb_preset_log_does_not_claim_schema_defaults_are_effective():
+    config = dftb_config("mrsf", td_type="mrsf", model="dtcam-tb")
+    text = state_labels.format_dftb_settings(config, backend="native")
+
+    assert "dtcam-tb preset (resolved by openqp-dftb backend)" in text
+    assert "Mixer:" not in text
+    assert "CAM alpha / beta:" not in text


### PR DESCRIPTION
## Summary

- expose concise and programmatic routes for ground-state DFTB, conventional TD-DFTB, SF-TDDFTB, and MRSF-TDDFTB while preserving the legacy `job.dftb()` MRSF default
- add grouped DFTB calculation, SCC, response, gradient, and operator settings to the OpenQP log
- capture native SCC/Davidson/Z-vector progress safely and place it in the normal OpenQP log
- support the exact historical stable ABI-1 63-argument contract alongside the ABI-2/3 74-argument contract
- negotiate optional native capabilities so old ABI-1/2/3 libraries never claim new trace, all-pair spectrum, or final SCC recovery features that they do not implement
- add minimal examples for all four DFTB calculation families and tighten input/state-label consistency

## Why

The OpenQP input surface and logs were centered on MRSF-TDDFTB, making the other DFTB families difficult to select and interpret. The adapter also accepted only newer C layouts, while installed ABI-1 libraries remain useful for their supported feature set. Finally, ABI number alone cannot distinguish older ABI-3 binaries from new binaries that add optional diagnostics without changing the state-gradient call signature.

## User impact

- users can select `dftb`, `tddftb`, `sf-tddftb`, or `mrsf-tddftb` directly
- logs show the resolved method, physical target/reference, loaded dylib, C ABI, capability set, SCC/response/operator options, iterations, residuals, and elapsed times
- stable ABI-1 libraries run basic ground, TD-DFTB, SF/MRSF, QM/MM, relaxed-charge, overlap, SOC, and export workflows through their historical layout
- ABI-1 rejects only later ABI-2 operator/preset controls that cannot be represented; unsupported new capabilities are reported as unavailable rather than silently promised
- incompatible explicit `[dftb] type` / `[tdhf] type` combinations fail before calculation

## Compatibility

- one OpenQP installation can work with a loaded stable ABI-1, ABI-2, or ABI-3 `openqp-dftb` library
- missing `openqp_dftb_capi_capabilities()` means capability mask zero, including for older ABI-3 binaries
- unsafe pre-contract unversioned development layouts are rejected before calling because they lack the stable ABI-1 overlap/SOC marker exports
- native stdout/environment/file-descriptor state is restored after every captured call

## Validation

- 211 focused Python tests pass, including exact ABI-1 63-slot and ABI-2/3 74-slot regressions, capability/cache handling, input validation, state labels, and logging
- real authoritative ABI-1 dylib built with Homebrew `gfortran-15` + Apple Accelerate:
  - conventional TD-DFTB H2O energy passed through current OpenQP
  - ground gradient, embedded QM/MM gradient/charges, and TD-DFTB S1 energy were also validated
- current ABI-3/capability-7 dylib:
  - conventional H2O spectrum prints S0→S1/S2/S3, S1→S2/S3, and S2→S3
  - DTCAM-TB energy and analytic S1 gradient match the current `origin/main` baseline
  - pair-space Z-vector reports a physical fixed-point residual of `2.647596e-13`
- `git diff --check` and Python byte-compilation pass

## Related work

- companion documentation: Open-Quantum-Platform/openqp-docs#16
- companion native implementation: Open-Quantum-Platform/openqp-dftb#15
- packaging/version-only fix remains separate: Open-Quantum-Platform/openqp-dftb#14