### PR TITLE
fix(states-overlap): out-of-bounds ddet writes on diagonal exact determinant overlaps

### DIFF
--- a/source/modules/get_states_overlap.F90
+++ b/source/modules/get_states_overlap.F90
@@ -513,6 +513,35 @@ contains
 
     select case (itype)
     case (1)
+       if (i1 == i2) then
+    !     Diagonal element: principal minor with occupied orbital i1 deleted from
+    !     both determinants. The off-diagonal block layout below assumes imin < imax
+    !     and degenerates for i1 == i2: for i1 == 1 the (3,*)/(*,3) blocks start at
+    !     index 0 (out-of-bounds ddet writes), and for i1 >= 2 the overlapping block
+    !     writes delete orbital i1-1 instead of i1.
+          do i = 1, i1-1
+             do ipp = 1, i1-1
+                iipp = (ipp-1)*noc+i
+                ddet(iipp) = s_mo(i+ilow-1,ipp+ilow-1)
+             end do
+             do ipp = i1, noc
+                iipp = (ipp-1)*noc+i
+                ddet(iipp) = s_mo(i+ilow-1,ipp+1+ilow-1)
+             end do
+          end do
+          do i = i1, noc
+             do ipp = 1, i1-1
+                iipp = (ipp-1)*noc+i
+                ddet(iipp) = s_mo(i+1+ilow-1,ipp+ilow-1)
+             end do
+             do ipp = i1, noc
+                iipp = (ipp-1)*noc+i
+                ddet(iipp) = s_mo(i+1+ilow-1,ipp+1+ilow-1)
+             end do
+          end do
+          temp1 = comp_det(ddet, noc)
+          return
+       end if
        imin = min(i1,i2)
        imax = max(i1,i2)
     !  (1,1) block


### PR DESCRIPTION
## Summary

`ov_exact` (itype 1, exact alpha determinant overlaps in `source/modules/get_states_overlap.F90`) reuses its off-diagonal three-block layout for diagonal calls `i1 == i2`, which `mrsf_tlf` makes for every `s_ij(k,k)` when `ndtlf = 0` (`tdhf tlf=0`, exact determinant overlaps). The layout assumes `imin < imax` and degenerates on the diagonal:

- **`i1 == i2 == 1`**: the `(3,*)`/`(*,3)` blocks run `do i/ipp = imax-1 (= 0), noc-1`, so `iipp = (ipp-1)*noc + i` reaches values ≤ 0 — writes **before** the `ddet(noc*noc)` array. This is silent memory corruption / UB; in the openqp-dftb port of this exact routine it surfaced as glibc `free(): invalid pointer` aborts on RHEL8 gfortran 11 + MKL (Open-Quantum-Platform/openqp-dftb#17), and a `-fcheck=all` build traps it immediately (`Index '-4' of dimension 1 of array 'ddet' below lower bound of 1`).
- **`i1 == i2 >= 2`**: the `(1,*)` and `(3,*)` block ranges overlap at row/column `i1-1`, and the net result is the principal minor with orbital **`i1-1`** deleted instead of `i1` — a wrong overlap value, masked at same geometry where `s_mo ≈ I` makes every principal minor 1.

## Fix

Special-case `i1 == i2` at the top of `case (1)` to build the delete-`i1` principal minor directly (rows/cols `1..i1-1` map unshifted, `i1..noc` shifted by one; no sign flip), in the existing flat-`iipp` style. The off-diagonal path is untouched. The delete-`i1` minor is also the quantity the TLF order-1/2 expansions (`tlf_exp` itypes 11/12) approximate, so `tlf=0` is now genuinely the exact reference for them.

## Impact

Only `tlf=0` runs are affected; the default `tlf=2` path never calls `ov_exact` itype 1. No packaged test exercises `ndtlf = 0`.

## Verification

No ctest covers `tlf=0`, so a standalone gfortran `-fcheck=all` harness extracting the repo routines was used:

- Fixed code: diagonal results match an independently constructed delete-`i1` principal minor to < 1e-13 for all `i1 = 1..noc+1`, at `ilow = 1` and `2`; all off-diagonal `(i1, i2)` results bit-identical to the pre-fix code; no bounds errors.
- Pre-fix code under the same harness: aborts with a `ddet` lower-bound violation at `i1 == i2 == 1`, and provably returns the delete-`(i1-1)` minor for `i1 == i2 = 2..5`.
- The patched file compiles clean (`-fcheck=all`) against the current module set.

The identical fix in the openqp-dftb port (Open-Quantum-Platform/openqp-dftb#17) additionally passes that repo's full suite on macOS gfortran 15/Accelerate and RHEL8 gfortran 11.2/MKL, where the same-geometry MRSF state-overlap identity test exercises the exact path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)