### PR TITLE
DFTB logs in OpenQP style: iteration tables, spectra/charges/energy components, results JSON, production model defaults

### DIFF
--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -291,7 +291,33 @@ class OpenQPDFTBAdapter:
                 "Set [dftb] backend=native for QM/MM jobs."
             )
 
+    def _resolve_model_default(self) -> None:
+        """Materialize the production [dftb] model default, ABI permitting.
+
+        The default is decided here -- after the native library is loaded --
+        rather than at input parsing, because a C ABI v1 library cannot carry
+        model presets at all: materializing the default unconditionally would
+        abort previously working no-model ABI-v1 jobs.  On ABI v1 the default
+        is simply skipped and the input keeps its explicit-keys meaning; an
+        explicit user-provided model on ABI v1 still fails loudly in
+        _validate_abi1_request.
+        """
+        if getattr(self.mol, "_dftb_model_default_resolved", False):
+            return
+        backend = str(self.dftb.get("backend", "native")).lower()
+        if backend not in {"native", "auto"}:
+            return
+        lib = self._native_library()  # noqa: F841 -- caches the ABI version
+        self.mol._dftb_model_default_resolved = True
+        if int(self.mol._openqp_dftb_cache["__native_abi_version__"]) == 1:
+            return
+        from oqp.utils.input_checker import apply_dftb_model_default  # noqa: PLC0415
+        model = apply_dftb_model_default(self.config)
+        if model:
+            self._preset_bytes = model.encode("ascii")
+
     def _run_state(self, method: str, state: int, *, need_grad: bool) -> _StateResult:
+        self._resolve_model_default()
         key = self._cache_key(method, state, need_grad=need_grad)
         cache = self.mol._openqp_dftb_cache
         if key in cache:

--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -12,17 +12,21 @@ import sys
 import tempfile
 import textwrap
 import threading
+import time
 
 import numpy as np
 
 import oqp
 from oqp.periodic_table import ELEMENTS_NAME
 from oqp.utils.constants import ANGSTROM_TO_BOHR as BOHR_TO_ANGSTROM
+from oqp.utils import dftb_trace
 from oqp.utils.file_utils import dump_log
 from oqp.utils.state_labels import (
     DFTB_CAP_STATE_SPECTRUM,
     DFTB_CAP_STRUCTURED_TRACE,
     canonical_dftb_type,
+    dftb_method_name,
+    public_state_label,
     resolved_dftb_type,
 )
 
@@ -48,7 +52,10 @@ def _call_with_native_diagnostics(
     within this Python process and restore both even on failure.
     """
     requested_level = max(0, min(2, int(print_level)))
-    level = requested_level if structured_trace else 0
+    # The per-iteration records the OpenQP-style tables are built from are
+    # emitted at native trace level 2 only; request them whenever progress is
+    # wanted at all and let the Python formatter decide how much to show.
+    level = 2 if (structured_trace and requested_level > 0) else 0
     updates = {
         "OPENQP_DFTB_SCC_TRACE": str(level),
         "OPENQP_DFTB_SOLVER_TRACE": str(level),
@@ -148,8 +155,12 @@ class OpenQPDFTBAdapter:
         # Named operator preset ([dftb] model=...). The published parameter
         # vector lives in openqp-dftb (single source of truth) and is applied
         # by the native library; the input checker forbids mixing a model
-        # with individual operator keys.
-        self._preset_bytes = str(self.dftb.get("model", "")).strip().encode("ascii")
+        # with individual operator keys.  'none' is the explicit opt-out of
+        # the SF/MRSF dtcam-tb default (materialized in Molecule.get_config).
+        preset = str(self.dftb.get("model", "")).strip()
+        if preset.lower() == "none":
+            preset = ""
+        self._preset_bytes = preset.encode("ascii")
         if not hasattr(mol, "_openqp_dftb_cache"):
             mol._openqp_dftb_cache = {}
         # SF/MRSF-TDDFTB uses a high-spin ROKS reference: mark scf.type
@@ -250,6 +261,7 @@ class OpenQPDFTBAdapter:
                     if 0 < state <= self.nstate:
                         energies[state] = result.state_energy
             self._store_wavefunction_tags(base)
+            self._dump_excited_state_summary(base)
 
         gradient_map = {}
         if need_grad:
@@ -428,24 +440,27 @@ class OpenQPDFTBAdapter:
             and bool(self.dftb.get("state_to_state_spectrum", True))
             and bool(capabilities & DFTB_CAP_STATE_SPECTRUM)
         )
+        step_wall_start = time.perf_counter()
+        step_cpu_start = time.process_time()
         native_trace = _call_with_native_diagnostics(
             native_call,
             print_level=int(self.dftb.get("print_level", 1)),
             state_spectrum=state_spectrum,
             structured_trace=bool(capabilities & DFTB_CAP_STRUCTURED_TRACE),
         )
-        if native_trace.strip():
-            dump_log(
-                self.mol,
-                title="PyOQP: OpenQP-DFTB native progress",
-                section="dftb_runtime",
-                info={
-                    "method": canonical_dftb_type(method),
-                    "state": int(state),
-                    "gradient": bool(need_grad),
-                    "text": native_trace,
-                },
+        step_times = (time.process_time() - step_cpu_start,
+                      time.perf_counter() - step_wall_start)
+        charge_info = None
+        if status.value == 0:
+            charge_info = self._stash_mulliken_charges(
+                method, state, need_grad,
+                np.frombuffer(relaxed_charges, dtype=np.float64)[:natom],
+                atoms,
             )
+        if native_trace.strip():
+            self._log_native_progress(method, state, need_grad, native_trace,
+                                      charge_info=charge_info,
+                                      step_times=step_times)
         self._raise_native_status(
             method=method,
             state=state,
@@ -488,6 +503,287 @@ class OpenQPDFTBAdapter:
             mo_energies=mo_e,
             mo_coefficients=mo_c,
             response_vectors=vecs,
+        )
+
+    def _public_target_label(self, state):
+        """Public label for a response root (S1, T0, ...; 'state N' fallback)."""
+        label = public_state_label(self.config, state)
+        if label.startswith("state "):
+            label = "state %d" % int(state)
+        return label
+
+    def _stash_mulliken_charges(self, method, state, need_grad, charges, atoms):
+        """Record net Mulliken charges + point-charge dipole on the molecule.
+
+        On energy calls the native library returns the converged SCC reference
+        charges; on excited-state gradient calls it returns the Z-vector
+        relaxed charges of the target state.  Both are stored for the results
+        JSON; the returned dict feeds the log block.
+        """
+        charges = [float(value) for value in charges]
+        coords = np.asarray(self.mol.get_system(),
+                            dtype=np.float64).reshape(-1, 3)
+        dipole = dftb_trace.point_charge_dipole(charges, coords)
+        symbols = [ELEMENTS_NAME[int(z)].strip() for z in atoms]
+        if need_grad and int(state) > 0:
+            title = ("Relaxed Mulliken charges (%s)"
+                     % self._public_target_label(state))
+            self.mol.dftb_relaxed_mulliken = {
+                "state": int(state),
+                "charges": charges,
+                "dipole_au": dipole,
+            }
+        else:
+            if canonical_dftb_type(method) in {"sf", "mrsf"}:
+                reference = "high-spin ROKS reference"
+            else:
+                reference = "SCC reference"
+            title = "Mulliken atomic charges (%s)" % reference
+            self.mol.dftb_mulliken = {
+                "reference": reference,
+                "charges": charges,
+                "dipole_au": dipole,
+            }
+        return {
+            "title": title,
+            "symbols": symbols,
+            "charges": charges,
+            "dipole": dipole,
+        }
+
+    def _timing_footer(self, step_times):
+        """Native-OpenQP style step + cumulative CPU/wall timing lines."""
+        if step_times is None:
+            return ""
+        step_cpu, step_wall = step_times
+        start = getattr(self.mol, "start_time", None)
+        total_wall = (time.time() - start) if start else step_wall
+        return dftb_trace.format_step_timing(
+            step_cpu, step_wall, time.process_time(), total_wall)
+
+    def _dump_effective_options(self, parsed):
+        """Report the preset-resolved native options once per distinct set."""
+        options = parsed.get("resolved_options")
+        if not options:
+            return
+        self.mol.dftb_resolved_options = options
+        if getattr(self.mol, "_dftb_resolved_options_logged", None) == options:
+            return
+        self.mol._dftb_resolved_options_logged = options
+        text = dftb_trace.format_resolved_options(options)
+        if text:
+            dump_log(self.mol, title="PyOQP: DFTB effective options",
+                     section="text", info={"text": text})
+
+    def _log_native_progress(self, method, state, need_grad, native_trace,
+                             charge_info=None, step_times=None):
+        """Render the captured native trace as OpenQP-style iteration tables.
+
+        openqp-dftb cannot append to the OpenQP log itself (the log unit
+        belongs to liboqp), so its structured stdout records are parsed here
+        and written in the same style as the native SCF/Davidson/Z-vector
+        sections of an OpenQP log.  The state-to-state spectrum block is NOT
+        printed here: it is stored and reported after the excited-state
+        summary table.
+        """
+        print_level = max(0, int(self.dftb.get("print_level", 1)))
+        if print_level == 0:
+            return
+        verbose = print_level >= 2
+        parsed = dftb_trace.parse_native_trace(native_trace)
+        if parsed.get("energy_components"):
+            self.mol.dftb_energy_components = parsed["energy_components"]
+        if not any(parsed[key] for key in (
+                "scc_passes", "davidson", "zvector", "zvector_dense")):
+            # Nothing structured (old library or probe-style text): keep the
+            # raw capture so no diagnostic is silently dropped.
+            dump_log(
+                self.mol,
+                title="PyOQP: OpenQP-DFTB native progress",
+                section="dftb_runtime",
+                info={
+                    "method": canonical_dftb_type(method),
+                    "state": int(state),
+                    "gradient": bool(need_grad),
+                    "text": native_trace,
+                },
+            )
+            return
+
+        extra = dftb_trace.format_other_lines(parsed) if verbose else ""
+        charge_block = ""
+        if charge_info is not None:
+            charge_block = dftb_trace.format_charge_block(
+                charge_info["symbols"], charge_info["charges"],
+                charge_info["dipole"], charge_info["title"])
+        if not need_grad:
+            self._dump_effective_options(parsed)
+            sections = []
+            scc_blocks = []
+            scc_text = dftb_trace.format_scc_block(parsed, verbose=verbose)
+            if scc_text:
+                scc_blocks.append(scc_text)
+            components_text = dftb_trace.format_energy_components(
+                parsed.get("energy_components"),
+                reference_label="converged SCC reference")
+            if components_text:
+                scc_blocks.append(components_text)
+            if charge_block:
+                scc_blocks.append(charge_block)
+            if scc_blocks:
+                sections.append(("PyOQP: DFTB SCC steps", scc_blocks))
+            response_blocks = [
+                dftb_trace.format_davidson_block(
+                    solve, dftb_method_name(self.config))
+                for solve in parsed["davidson"]
+            ]
+            if response_blocks:
+                sections.append(("PyOQP: DFTB response steps",
+                                 response_blocks))
+            if extra:
+                sections.append(("PyOQP: DFTB native diagnostics", [extra]))
+            timing = self._timing_footer(step_times)
+            if timing and sections:
+                sections[-1][1].append(timing)
+            for title, blocks in sections:
+                dump_log(self.mol, title=title, section="text",
+                         info={"text": "\n\n".join(blocks)})
+            return
+
+        # Gradient call: the reference/response are merely re-solved for the
+        # requested state, so summarize them in one line each and give the
+        # Z-vector solve the full iteration table.
+        blocks = []
+        if verbose:
+            blocks.append("   Native call: method=%s  state=%s  gradient=yes"
+                          % (canonical_dftb_type(method), int(state)))
+            scc_text = dftb_trace.format_scc_block(parsed, verbose=True)
+            if scc_text:
+                blocks.append(scc_text)
+            blocks.extend(
+                dftb_trace.format_davidson_block(
+                    solve, dftb_method_name(self.config))
+                for solve in parsed["davidson"])
+        else:
+            summary_lines = []
+            scc_lines = dftb_trace.format_scc_summary_lines(parsed)
+            if scc_lines:
+                summary_lines.extend(scc_lines.splitlines())
+            summary_lines.extend(dftb_trace.collapse_repeats(
+                [dftb_trace.format_davidson_summary_line(solve)
+                 for solve in parsed["davidson"]]))
+            if summary_lines:
+                blocks.append("\n".join(summary_lines))
+        blocks.extend(dftb_trace.format_zvector_block(solve)
+                      for solve in parsed["zvector"])
+        blocks.extend(dftb_trace.format_zvector_dense_block(solve)
+                      for solve in parsed["zvector_dense"])
+        if charge_block:
+            blocks.append(charge_block)
+        if extra:
+            blocks.append(extra)
+        timing = self._timing_footer(step_times)
+        if timing:
+            blocks.append(timing)
+        if not blocks:
+            return
+        if state > 0:
+            title = ("PyOQP: DFTB gradient steps (%s)"
+                     % self._public_target_label(state))
+        else:
+            title = "PyOQP: DFTB gradient steps (ground state)"
+        dump_log(self.mol, title=title, section="text",
+                 info={"text": "\n\n".join(block for block in blocks if block)})
+
+    def _excited_state_summary(self, result):
+        """Build the excited-state summary payload from one response solve."""
+        method = self._resolved_method()
+        if method in _GROUND_TYPES or result.all_state_energies is None:
+            return None
+        canonical = canonical_dftb_type(method)
+        energies = [float(value) for value in result.all_state_energies]
+        n_roots = len(energies)
+        if n_roots == 0:
+            return None
+        spins = ([float(value) for value in result.all_spin_squares]
+                 if result.all_spin_squares is not None else [])
+        parsed = dftb_trace.parse_native_trace(result.stdout or "")
+        spectrum = parsed.get("spectrum")
+
+        if canonical == "mrsf":
+            labels = [public_state_label(self.config, root)
+                      for root in range(1, n_roots + 1)]
+            prefix = labels[0][0] if labels and labels[0][1:].isdigit() else "S"
+            reference_label = "Reference: high-spin ROKS (internal)"
+            reference_energy = result.reference_energy
+        elif canonical == "sf":
+            labels = ["root %d" % root for root in range(1, n_roots + 1)]
+            prefix = None
+            reference_label = "Reference: high-spin ROKS (internal)"
+            reference_energy = result.reference_energy
+        else:
+            # Closed-shell TDDFTB: the reference IS S0; roots are S1..Sn.
+            labels = ["S0"] + ["S%d" % root for root in range(1, n_roots + 1)]
+            energies = [float(result.reference_energy)] + energies
+            spins = [0.0] + spins
+            prefix = "S"
+            reference_label = None
+            reference_energy = None
+
+        oscillator = {}
+        transitions = []
+        approximation = ""
+        if spectrum:
+            approximation = spectrum.get("approximation", "")
+            oscillator = {
+                label: row for label, row in dftb_trace.spectrum_from_ground(
+                    spectrum, prefix).items()
+            }
+            transitions = [{
+                "initial": dftb_trace.map_spectrum_label(row["initial"], prefix),
+                "final": dftb_trace.map_spectrum_label(row["final"], prefix),
+                "de_ev": row["de_ev"],
+                "dipole": row["dipole"],
+                "dipole_xyz": row.get("dipole_xyz"),
+                "oscillator": row["oscillator"],
+            } for row in spectrum.get("rows", [])]
+
+        return {
+            "method": canonical,
+            "state_labels": labels,
+            "state_energies": energies,
+            "spin_squares": spins,
+            "oscillator": oscillator,
+            "transitions": transitions,
+            "approximation": approximation,
+            "reference_label": reference_label,
+            "reference_energy": reference_energy,
+        }
+
+    def _dump_excited_state_summary(self, base):
+        """Report state energies + oscillator data once per response solve.
+
+        This runs at the END of the energy stage, so the summary table (and
+        the state-to-state spectrum after it) appear in the log BEFORE any
+        'Entering Gradient Calculation' section, mirroring the native OpenQP
+        TDDFT summary placement.
+        """
+        summary = self._excited_state_summary(base)
+        if summary is None:
+            return
+        self.mol.dftb_excited_states = summary
+        key = self._cache_key(self._resolved_method(), base.state,
+                              need_grad=False)
+        if getattr(self.mol, "_dftb_summary_logged_key", None) == key:
+            return
+        self.mol._dftb_summary_logged_key = key
+        if max(0, int(self.dftb.get("print_level", 1))) == 0:
+            return
+        dump_log(
+            self.mol,
+            title="PyOQP: %s Excited States" % dftb_method_name(self.config),
+            section="text",
+            info={"text": dftb_trace.format_excited_state_summary(summary)},
         )
 
     def _state_gradient_common_arguments(self, values):

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -1392,6 +1392,26 @@ class Molecule:
         data['hess'] = np.array(self.get_hess()).tolist()
         data.update(self.get_mrsf_ekt_results())
 
+        # OpenQP-DFTB backend results.  The DFTB adapter is pure Python, so
+        # liboqp's mol_energy struct (the 'energy' scalar above) is never
+        # populated on this path; surface the adapter results explicitly:
+        # total state energies, the excited-state summary (VEE in eV,
+        # transition dipoles, oscillator strengths), the reference energy
+        # decomposition, and Mulliken charges + point-charge dipole.
+        if str(self.config.get('input', {}).get('method', '')
+               ).strip().lower() == 'dftb':
+            energies = getattr(self, 'energies', None)
+            if energies is not None and np.asarray(energies).size:
+                data['energies'] = np.asarray(
+                    energies, dtype=float).ravel().tolist()
+                data['energy'] = data['energies'][0]
+            for key in ('dftb_excited_states', 'dftb_energy_components',
+                        'dftb_resolved_options',
+                        'dftb_mulliken', 'dftb_relaxed_mulliken'):
+                value = getattr(self, key, None)
+                if value:
+                    data[key] = value
+
         return data
 
     @mpi_get_attr
@@ -1460,6 +1480,11 @@ class Molecule:
 
         # Validate the configuration and apply it
         config = parser.validate()
+
+        # Production DFTB defaults: no model= and no hand-tuned operator keys
+        # means DTCAM-TB for MRSF-TDDFTB and the DFTB+ protocol otherwise.
+        from oqp.utils.input_checker import apply_dftb_model_default
+        apply_dftb_model_default(config)
 
         return config
 

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -1481,11 +1481,6 @@ class Molecule:
         # Validate the configuration and apply it
         config = parser.validate()
 
-        # Production DFTB defaults: no model= and no hand-tuned operator keys
-        # means DTCAM-TB for MRSF-TDDFTB and the DFTB+ protocol otherwise.
-        from oqp.utils.input_checker import apply_dftb_model_default
-        apply_dftb_model_default(config)
-
         return config
 
     def load_config(self, input_source):

--- a/pyoqp/oqp/utils/dftb_trace.py
+++ b/pyoqp/oqp/utils/dftb_trace.py
@@ -34,8 +34,9 @@ _SCC_PASS_TITLES = {
 }
 
 _SPECTRUM_HEADER = "DFTB state-to-state oscillator strengths"
-# Old printers wrote 3 numbers per row (dE, |mu|, f); current ones write 6
-# (dE, mu_x, mu_y, mu_z, |mu|, f).
+# Old printers wrote 3 numbers per row (dE, |mu|, f); current ones APPEND the
+# dipole components (dE, |mu|, f, mu_x, mu_y, mu_z) so positional parsers of
+# the historical layout keep reading the same fields.
 _SPECTRUM_ROW = re.compile(
     r"^\s*(S\d+|root \d+)\s+(S\d+|root \d+)((?:\s+[-+0-9.EeDd]+){3,6})\s*$"
 )
@@ -407,15 +408,10 @@ def _parse_spectrum(lines, index):
                 "initial": match.group(1),
                 "final": match.group(2),
                 "de_ev": numbers[0],
-                "dipole_xyz": None,
+                "dipole": numbers[1] if len(numbers) > 1 else None,
+                "oscillator": numbers[2] if len(numbers) > 2 else None,
+                "dipole_xyz": numbers[3:6] if len(numbers) >= 6 else None,
             }
-            if len(numbers) >= 6:
-                row["dipole_xyz"] = numbers[1:4]
-                row["dipole"] = numbers[4]
-                row["oscillator"] = numbers[5]
-            else:
-                row["dipole"] = numbers[1] if len(numbers) > 1 else None
-                row["oscillator"] = numbers[2] if len(numbers) > 2 else None
             spectrum["rows"].append(row)
             index += 1
             continue

--- a/pyoqp/oqp/utils/dftb_trace.py
+++ b/pyoqp/oqp/utils/dftb_trace.py
@@ -1,0 +1,1102 @@
+"""Parse and pretty-print openqp-dftb structured native diagnostics.
+
+The openqp-dftb shared library cannot write into the OpenQP log directly (the
+log unit belongs to liboqp's Fortran runtime), so the adapter captures the
+library's flushed stdout.  At trace level 2 that capture carries one
+machine-readable record per SCC/Davidson/Z-vector event
+(``openqp_dftb_scc_iter ...``).  This module turns those records into the same
+kind of human-readable iteration tables OpenQP prints for its native SCF,
+Davidson, and Z-vector solvers, so a DFTB log reads like any other OpenQP log.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+HARTREE_TO_EV = 27.211386245988
+
+# Update-kind display names for the per-iteration SCC labels.  The record label
+# is "<pass label>[_<update kind>]" (e.g. rohf_trah is a TRAH step inside the
+# rohf pass).
+_SCC_ITER_MODES = {
+    "": "",
+    "trah": "TRAH",
+    "trust": "trust",
+    "ls": "level-shift",
+    "ls_trust": "level-shift+trust",
+}
+
+_SCC_PASS_TITLES = {
+    "rhf_seed": "restricted charge seed",
+    "rohf": "open-shell (ROKS) reference",
+    "restricted": "restricted reference",
+}
+
+_SPECTRUM_HEADER = "DFTB state-to-state oscillator strengths"
+# Old printers wrote 3 numbers per row (dE, |mu|, f); current ones write 6
+# (dE, mu_x, mu_y, mu_z, |mu|, f).
+_SPECTRUM_ROW = re.compile(
+    r"^\s*(S\d+|root \d+)\s+(S\d+|root \d+)((?:\s+[-+0-9.EeDd]+){3,6})\s*$"
+)
+_LINEAR_RECORD = re.compile(
+    r"^openqp_dftb_(gmres|minres|bicgstab|cg)_(start|iter|end)$"
+)
+
+
+def _float(token):
+    try:
+        return float(token.replace("D", "E").replace("d", "e"))
+    except (AttributeError, ValueError):
+        return None
+
+
+def _int(token):
+    try:
+        return int(token)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool(token):
+    return str(token).strip() in {"T", "t", "true", "True", "1"}
+
+
+def _pairs(tokens):
+    """Map ``key value key value ...`` tokens; last value wins on repeats."""
+    mapping = {}
+    for key, value in zip(tokens[0::2], tokens[1::2]):
+        mapping[key] = value
+    return mapping
+
+
+def _typed_value(token):
+    """Best-effort typed record value: bool ('T'/'F'), int, float, or str."""
+    if token in ("T", "F"):
+        return token == "T"
+    if re.fullmatch(r"[-+]?\d+", token or ""):
+        return int(token)
+    number = _float(token)
+    return number if number is not None else token
+
+
+def parse_native_trace(text):
+    """Split a captured native stdout into structured events.
+
+    Returns a dict with ``scc_passes``, ``post_updates``, ``recoveries``,
+    ``davidson``, ``zvector``, ``zvector_dense``, ``spectrum``, ``warnings``,
+    and ``other`` (verbatim unrecognized lines, e.g. ``[zvec-stage]`` timing
+    breakdowns).  The parser is tolerant: an unknown or malformed record line
+    degrades to ``other`` instead of failing the calculation log.
+    """
+    trace = {
+        "scc_passes": [],
+        "post_updates": [],
+        "recoveries": [],
+        "davidson": [],
+        "zvector": [],
+        "zvector_dense": [],
+        "energy_components": None,
+        "resolved_options": None,
+        "spectrum": None,
+        "linear": [],
+        "warnings": [],
+        "other": [],
+    }
+    open_scc = {}
+    open_davidson = None
+    open_zvector = None
+    open_dense = None
+    open_linear = None
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped == _SPECTRUM_HEADER:
+            spectrum, index = _parse_spectrum(lines, index)
+            trace["spectrum"] = spectrum
+            continue
+        tokens = stripped.split()
+        record = tokens[0]
+        try:
+            if record == "openqp_dftb_scc_pass":
+                label = tokens[1]
+                info = _pairs(tokens[2:])
+                entry = {
+                    "label": label,
+                    "pass": _int(info.get("pass")),
+                    "stage": info.get("stage", ""),
+                    "mixer": info.get("mixer", ""),
+                    "iterations": [],
+                    "trah_steps": 0,
+                    "outcome": None,
+                    "iteration_count": None,
+                    "elapsed": None,
+                }
+                trace["scc_passes"].append(entry)
+                open_scc[label] = entry
+            elif record == "openqp_dftb_scc_iter":
+                label = tokens[1]
+                iteration = _int(tokens[2])
+                info = _pairs(tokens[3:])
+                base, mode = _split_scc_iter_label(label)
+                entry = open_scc.get(base)
+                if entry is None:
+                    entry = {
+                        "label": base, "pass": _int(info.get("pass")),
+                        "stage": "", "mixer": "", "iterations": [],
+                        "trah_steps": 0, "outcome": None,
+                        "iteration_count": None, "elapsed": None,
+                    }
+                    trace["scc_passes"].append(entry)
+                    open_scc[base] = entry
+                entry["iterations"].append({
+                    "iteration": iteration,
+                    "residual": _float(info.get("residual")),
+                    "charge": _float(info.get("charge")),
+                    "spin": _float(info.get("spin")),
+                    "orbital": _float(info.get("orbital")),
+                    "tolerance": _float(info.get("tol")),
+                    "mode": mode,
+                })
+            elif record == "openqp_dftb_scc_trah_step":
+                base, _ = _split_scc_iter_label(tokens[1])
+                entry = open_scc.get(base)
+                if entry is not None:
+                    entry["trah_steps"] += 1
+            elif record == "openqp_dftb_scc_pass_end":
+                label = tokens[1]
+                info = _pairs(tokens[2:])
+                entry = open_scc.pop(label, None)
+                if entry is None:
+                    entry = {
+                        "label": label, "pass": _int(info.get("pass")),
+                        "stage": "", "mixer": "", "iterations": [],
+                        "trah_steps": 0,
+                    }
+                    trace["scc_passes"].append(entry)
+                entry["outcome"] = info.get("outcome")
+                entry["iteration_count"] = _int(info.get("iterations"))
+                entry["elapsed"] = _float(info.get("elapsed_seconds"))
+            elif record == "openqp_dftb_scc_post_update":
+                info = _pairs(tokens[2:])
+                trace["post_updates"].append({
+                    "label": tokens[1],
+                    "residual": _float(info.get("residual")),
+                    "charge": _float(info.get("charge")),
+                    "spin": _float(info.get("spin")),
+                    "density": _float(info.get("density")),
+                    "tolerance": _float(info.get("tol")),
+                    "converged": _bool(info.get("converged")),
+                    "elapsed": _float(info.get("elapsed_seconds")),
+                })
+            elif record == "openqp_dftb_scc_recovery":
+                info = _pairs(tokens[2:])
+                trace["recoveries"].append({
+                    "label": tokens[1],
+                    "kind": info.get("kind", ""),
+                    "attempted": _bool(info.get("attempted")),
+                    "succeeded": _bool(info.get("succeeded")),
+                })
+            elif record == "openqp_dftb_davidson_start":
+                info = _pairs(tokens[1:])
+                open_davidson = {
+                    "dimension": _int(info.get("dimension")),
+                    "roots": _int(info.get("roots")),
+                    "max_subspace": _int(info.get("max_subspace")),
+                    "max_iterations": _int(info.get("max_iterations")),
+                    "tolerance": _float(info.get("tolerance")),
+                    "iterations": [],
+                    "outcome": None,
+                }
+                trace["davidson"].append(open_davidson)
+            elif record == "openqp_dftb_davidson_iter":
+                info = _pairs(tokens[1:])
+                if open_davidson is None:
+                    open_davidson = {
+                        "dimension": None, "roots": None, "max_subspace": None,
+                        "max_iterations": None, "tolerance": None,
+                        "iterations": [], "outcome": None,
+                    }
+                    trace["davidson"].append(open_davidson)
+                open_davidson["iterations"].append({
+                    "iteration": _int(info.get("iteration")),
+                    "basis": _int(info.get("basis")),
+                    "converged_roots": _int(info.get("converged_roots")),
+                    "residual": _float(info.get("residual")),
+                    "matvecs": _int(info.get("matvecs")),
+                    "restarts": _int(info.get("restarts")),
+                })
+            elif record == "openqp_dftb_davidson_end":
+                info = _pairs(tokens[1:])
+                if open_davidson is None:
+                    open_davidson = {
+                        "dimension": None, "roots": None, "max_subspace": None,
+                        "max_iterations": None, "tolerance": None,
+                        "iterations": [],
+                    }
+                    trace["davidson"].append(open_davidson)
+                open_davidson.update({
+                    "outcome": info.get("outcome"),
+                    "iteration_count": _int(info.get("iterations")),
+                    "residual": _float(info.get("residual")),
+                    "matvecs": _int(info.get("matvecs")),
+                    "restarts": _int(info.get("restarts")),
+                    "elapsed": _float(info.get("elapsed_seconds")),
+                })
+                open_davidson = None
+            elif record == "openqp_dftb_zvector_start":
+                info = _pairs(tokens[1:])
+                open_zvector = {
+                    "dimension": _int(info.get("dimension")),
+                    "max_iterations": _int(info.get("max_iterations")),
+                    "tolerance": _float(info.get("tolerance")),
+                    "iterations": [],
+                    "outcome": None,
+                }
+                trace["zvector"].append(open_zvector)
+            elif record == "openqp_dftb_zvector_iter":
+                info = _pairs(tokens[1:])
+                if open_zvector is None:
+                    open_zvector = {
+                        "dimension": None, "max_iterations": None,
+                        "tolerance": None, "iterations": [], "outcome": None,
+                    }
+                    trace["zvector"].append(open_zvector)
+                open_zvector["iterations"].append({
+                    "iteration": _int(info.get("iteration")),
+                    "residual": _float(info.get("residual")),
+                    "inner_solves": _int(info.get("inner_solves")),
+                    "inner_matvecs": _int(info.get("inner_matvecs")),
+                })
+            elif record == "openqp_dftb_zvector_end":
+                info = _pairs(tokens[1:])
+                if open_zvector is None:
+                    open_zvector = {
+                        "dimension": None, "max_iterations": None,
+                        "tolerance": None, "iterations": [],
+                    }
+                    trace["zvector"].append(open_zvector)
+                open_zvector.update({
+                    "outcome": info.get("outcome"),
+                    "pair_iterations": _int(info.get("pair_iterations")),
+                    "anderson_iterations": _int(info.get("anderson_iterations")),
+                    "fallback_gmres_iterations": _int(
+                        info.get("fallback_gmres_iterations")),
+                    "residual": _float(info.get("residual")),
+                    "elapsed": _float(info.get("elapsed_seconds")),
+                })
+                open_zvector = None
+            elif record == "openqp_dftb_zvector_dense_start":
+                info = _pairs(tokens[1:])
+                open_dense = {
+                    "dimension": _int(info.get("dimension")),
+                    "solver": info.get("solver", "dense_direct"),
+                    "stages": [],
+                    "outcome": None,
+                }
+                trace["zvector_dense"].append(open_dense)
+            elif record == "openqp_dftb_zvector_dense_stage":
+                info = _pairs(tokens[1:])
+                if open_dense is not None:
+                    open_dense["stages"].append(
+                        (info.get("stage", ""), _float(info.get("elapsed_seconds")))
+                    )
+            elif record == "openqp_dftb_zvector_dense_end":
+                info = _pairs(tokens[1:])
+                if open_dense is None:
+                    open_dense = {
+                        "dimension": None, "solver": "dense_direct",
+                        "stages": [],
+                    }
+                    trace["zvector_dense"].append(open_dense)
+                open_dense.update({
+                    "outcome": info.get("outcome"),
+                    "solve_succeeded": _bool(info.get("solve_succeeded")),
+                    "residual": _float(info.get("residual")),
+                    "elapsed": _float(info.get("elapsed_seconds")),
+                })
+                open_dense = None
+            elif record == "openqp_dftb_energy_components":
+                info = _pairs(tokens[1:])
+                trace["energy_components"] = {
+                    key: _float(value) for key, value in info.items()
+                }
+            elif record == "openqp_dftb_resolved_options":
+                info = _pairs(tokens[1:])
+                trace["resolved_options"] = {
+                    key: _typed_value(value) for key, value in info.items()
+                }
+            elif record == "openqp_dftb_state_spectrum_warning":
+                trace["warnings"].append(stripped)
+            elif _LINEAR_RECORD.match(record):
+                match = _LINEAR_RECORD.match(record)
+                solver, event = match.group(1), match.group(2)
+                info = _pairs(tokens[1:])
+                if event == "start":
+                    open_linear = {
+                        "solver": solver,
+                        "dimension": _int(info.get("dimension")),
+                        "max_iterations": _int(info.get("max_iterations")),
+                        "max_subspace": _int(info.get("max_subspace")),
+                        "tolerance": _float(info.get("tolerance")),
+                        "iterations": [],
+                        "outcome": None,
+                    }
+                    # A Krylov solve running inside the Z-vector window IS the
+                    # Z-vector solve (pair-space single solve / full-space
+                    # fallback); attach it there so its iterations can be
+                    # rendered as the Z-vector iteration table.
+                    if open_zvector is not None:
+                        open_zvector.setdefault("krylov_solves", []).append(
+                            open_linear)
+                    else:
+                        trace["linear"].append(open_linear)
+                elif event == "iter" and open_linear is not None:
+                    open_linear["iterations"].append({
+                        "iteration": _int(info.get("iteration")),
+                        "cycle": _int(info.get("cycle")),
+                        "residual": _float(info.get("residual")),
+                        "matvecs": _int(info.get("matvecs")),
+                    })
+                elif event == "end" and open_linear is not None:
+                    open_linear.update({
+                        "outcome": info.get("outcome"),
+                        "iteration_count": _int(info.get("iterations")),
+                        "residual": _float(info.get("residual")),
+                        "matvecs": _int(info.get("matvecs")),
+                        "elapsed": _float(info.get("elapsed_seconds")),
+                    })
+                    open_linear = None
+            else:
+                trace["other"].append(line.rstrip())
+        except (IndexError, KeyError, TypeError, ValueError):
+            trace["other"].append(line.rstrip())
+    return trace
+
+
+def _split_scc_iter_label(label):
+    """Return (pass label, update-kind display) for a per-iteration label."""
+    for suffix, display in sorted(
+            _SCC_ITER_MODES.items(), key=lambda item: -len(item[0])):
+        if suffix and label.endswith("_" + suffix):
+            return label[: -len(suffix) - 1], display
+    return label, ""
+
+
+def _parse_spectrum(lines, index):
+    """Consume the printed state-to-state block; return (spectrum, new index)."""
+    spectrum = {"approximation": "", "rows": []}
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if stripped.startswith("Approximation:"):
+            spectrum["approximation"] = stripped[len("Approximation:"):].strip()
+            index += 1
+            continue
+        if stripped.startswith("Initial"):
+            index += 1
+            continue
+        match = _SPECTRUM_ROW.match(lines[index])
+        if match:
+            numbers = [_float(token) for token in match.group(3).split()]
+            row = {
+                "initial": match.group(1),
+                "final": match.group(2),
+                "de_ev": numbers[0],
+                "dipole_xyz": None,
+            }
+            if len(numbers) >= 6:
+                row["dipole_xyz"] = numbers[1:4]
+                row["dipole"] = numbers[4]
+                row["oscillator"] = numbers[5]
+            else:
+                row["dipole"] = numbers[1] if len(numbers) > 1 else None
+                row["oscillator"] = numbers[2] if len(numbers) > 2 else None
+            spectrum["rows"].append(row)
+            index += 1
+            continue
+        if not stripped:
+            index += 1
+            # A blank line ends the block unless the next line is still a row.
+            if index < len(lines) and _SPECTRUM_ROW.match(lines[index]):
+                continue
+            break
+        break
+    return spectrum, index
+
+
+def _fmt_seconds(value):
+    if value is None:
+        return ""
+    return " (%.3f s)" % value
+
+
+def _fmt_exp(value, width=16):
+    if value is None:
+        return " " * width
+    return ("%" + str(width) + ".6E") % value
+
+
+def format_scc_pass(entry):
+    """One OpenQP-style iteration table for a single SCC pass."""
+    title = _SCC_PASS_TITLES.get(entry["label"], entry["label"])
+    mixer = entry.get("mixer") or ""
+    qualifier = []
+    if mixer:
+        qualifier.append("%s mixer" % mixer)
+    if entry.get("pass") and entry["pass"] > 1:
+        qualifier.append("pass %d" % entry["pass"])
+    if entry.get("stage") and entry["stage"] not in {"initial", "seed"}:
+        qualifier.append("stage %s" % entry["stage"])
+    header = "   SCC iterations: %s%s" % (
+        title, " (%s)" % ", ".join(qualifier) if qualifier else "")
+
+    lines = [header]
+    iterations = entry.get("iterations") or []
+    if iterations:
+        has_components = any(
+            it.get("charge") is not None for it in iterations)
+        rule = "   " + "-" * (76 if has_components else 42)
+        lines.append(rule)
+        if has_components:
+            lines.append("    Iter        Residual          Charge"
+                         "            Spin          Step")
+        else:
+            lines.append("    Iter        Residual")
+        lines.append(rule)
+        for it in iterations:
+            row = "   %5s" % (it.get("iteration") if it.get("iteration")
+                              is not None else "?")
+            row += _fmt_exp(it.get("residual"))
+            if has_components:
+                row += _fmt_exp(it.get("charge"))
+                row += _fmt_exp(it.get("spin"))
+                mode = it.get("mode") or ""
+                row += ("    %s" % mode if mode else "")
+            lines.append(row.rstrip())
+        lines.append(rule)
+    outcome = entry.get("outcome")
+    count = entry.get("iteration_count")
+    tolerance = None
+    if iterations:
+        tolerance = iterations[-1].get("tolerance")
+    if outcome == "converged":
+        summary = "   SCC converged in %s iterations" % (
+            count if count is not None else len(iterations))
+    elif outcome == "exhausted":
+        summary = "   SCC did NOT converge within %s iterations" % (
+            count if count is not None else len(iterations))
+    elif outcome:
+        summary = "   SCC ended (%s) after %s iterations" % (
+            outcome, count if count is not None else len(iterations))
+    else:
+        summary = "   SCC pass recorded %d iterations" % len(iterations)
+    if tolerance is not None:
+        summary += ", tolerance %.2E" % tolerance
+    summary += _fmt_seconds(entry.get("elapsed"))
+    lines.append(summary)
+    if entry.get("trah_steps"):
+        lines.append("   TRAH trust-region steps accepted: %d"
+                     % entry["trah_steps"])
+    return "\n".join(lines)
+
+
+def format_scc_post_update(entry):
+    parts = ["   Final self-consistency: residual %.2E" % entry["residual"]
+             if entry.get("residual") is not None else
+             "   Final self-consistency:"]
+    components = []
+    for key in ("charge", "spin", "density"):
+        if entry.get(key) is not None:
+            components.append("%s %.2E" % (key, entry[key]))
+    if components:
+        parts.append("(%s)" % ", ".join(components))
+    if entry.get("tolerance") is not None:
+        parts.append("tolerance %.2E" % entry["tolerance"])
+    parts.append("-- converged" if entry.get("converged")
+                 else "-- NOT converged")
+    return " ".join(parts)
+
+
+def format_scc_recoveries(recoveries, verbose=False):
+    lines = []
+    for entry in recoveries:
+        if not entry.get("attempted") and not verbose:
+            continue
+        outcome = ("succeeded" if entry.get("succeeded") else
+                   "did not succeed") if entry.get("attempted") else "not needed"
+        lines.append("   SCC recovery (%s): %s" % (entry.get("kind"), outcome))
+    return "\n".join(lines)
+
+
+def format_scc_block(trace, verbose=False):
+    """All SCC passes + final residual check + recoveries as one text block."""
+    blocks = [format_scc_pass(entry) for entry in trace.get("scc_passes", [])]
+    for entry in trace.get("post_updates", []):
+        blocks.append(format_scc_post_update(entry))
+    recovery_text = format_scc_recoveries(trace.get("recoveries", []),
+                                          verbose=verbose)
+    if recovery_text:
+        blocks.append(recovery_text)
+    return "\n\n".join(block for block in blocks if block)
+
+
+def format_scc_summary_lines(trace):
+    """One line per SCC pass -- used when the reference is merely re-solved."""
+    lines = []
+    for entry in trace.get("scc_passes", []):
+        title = _SCC_PASS_TITLES.get(entry["label"], entry["label"])
+        outcome = entry.get("outcome") or "recorded"
+        count = entry.get("iteration_count")
+        if count is None:
+            count = len(entry.get("iterations") or [])
+        lines.append("   SCC %s: %s in %s iterations%s" % (
+            title, outcome, count, _fmt_seconds(entry.get("elapsed"))))
+    return "\n".join(lines)
+
+
+def format_davidson_block(solve, method_display="DFTB"):
+    lines = ["   Davidson algorithm for %s response states" % method_display]
+    params = []
+    for key, label in (("dimension", "dimension"), ("roots", "roots"),
+                       ("max_subspace", "max subspace"),
+                       ("max_iterations", "max iterations")):
+        if solve.get(key) is not None:
+            params.append("%s = %s" % (label, solve[key]))
+    if solve.get("tolerance") is not None:
+        params.append("tolerance = %.1E" % solve["tolerance"])
+    if params:
+        lines.append("   " + "    ".join(params))
+    iterations = solve.get("iterations") or []
+    if iterations:
+        rule = "   " + "-" * 58
+        lines.append("")
+        lines.append("    Iter    Subspace    Converged roots      Max residual")
+        lines.append(rule)
+        for it in iterations:
+            lines.append("   %5s   %7s    %11s     %s" % (
+                it.get("iteration"), it.get("basis"),
+                it.get("converged_roots"),
+                _fmt_exp(it.get("residual"))))
+        lines.append(rule)
+    outcome = solve.get("outcome")
+    count = solve.get("iteration_count")
+    if outcome == "converged":
+        summary = "   Davidson converged in %s iterations" % count
+    elif outcome:
+        summary = "   Davidson %s after %s iterations" % (outcome, count)
+    else:
+        summary = "   Davidson recorded %d iterations" % len(iterations)
+    details = []
+    if solve.get("residual") is not None:
+        details.append("residual %.2E" % solve["residual"])
+    if solve.get("matvecs") is not None:
+        details.append("%d matvecs" % solve["matvecs"])
+    if solve.get("restarts"):
+        details.append("%d restarts" % solve["restarts"])
+    if details:
+        summary += ": " + ", ".join(details)
+    summary += _fmt_seconds(solve.get("elapsed"))
+    lines.append(summary)
+    return "\n".join(lines)
+
+
+def format_davidson_summary_line(solve):
+    outcome = solve.get("outcome") or "recorded"
+    count = solve.get("iteration_count",
+                      len(solve.get("iterations") or []))
+    extra = ""
+    if solve.get("residual") is not None:
+        extra = " (residual %.2E)" % solve["residual"]
+    return "   Response Davidson: %s in %s iterations%s" % (
+        outcome, count, extra)
+
+
+def collapse_repeats(lines):
+    """Merge consecutive identical lines into one line with a repeat count."""
+    merged = []
+    for line in lines:
+        if merged and merged[-1][0] == line:
+            merged[-1][1] += 1
+        else:
+            merged.append([line, 1])
+    return [line if count == 1 else "%s  [x%d]" % (line, count)
+            for line, count in merged]
+
+
+_ZVECTOR_OUTCOMES = {
+    "pair_space_converged": "converged (pair-space single solve)",
+    "anderson_converged": "converged (Anderson fixed point)",
+    "gmres_converged": "converged (GMRES)",
+    "fallback_per_perturbation":
+        "fell back to the per-perturbation gradient path",
+    "converged": "converged",
+}
+
+
+def format_zvector_block(solve):
+    lines = ["   Z-vector relaxed-density solve"]
+    params = []
+    if solve.get("dimension") is not None:
+        params.append("dimension = %s" % solve["dimension"])
+    if solve.get("max_iterations") is not None:
+        params.append("max iterations = %s" % solve["max_iterations"])
+    if solve.get("tolerance") is not None:
+        params.append("tolerance = %.1E" % solve["tolerance"])
+    if params:
+        lines.append("   " + "    ".join(params))
+    iterations = solve.get("iterations") or []
+    if iterations:
+        rule = "   " + "-" * 58
+        lines.append("")
+        lines.append("    Iter        Residual        Inner solves"
+                     "    Inner matvecs")
+        lines.append(rule)
+        for it in iterations:
+            lines.append("   %5s%s   %9s        %9s" % (
+                it.get("iteration"), _fmt_exp(it.get("residual")),
+                it.get("inner_solves") if it.get("inner_solves") is not None
+                else "", it.get("inner_matvecs")
+                if it.get("inner_matvecs") is not None else ""))
+        lines.append(rule)
+    else:
+        # Production path: one pair-space Krylov solve, no outer fixed-point
+        # loop.  Its per-iteration residuals ARE the Z-vector iterations; any
+        # further Krylov solves inside the window (auxiliary contractions) are
+        # summarized in one line each.
+        krylov_solves = solve.get("krylov_solves") or []
+        for position, krylov in enumerate(krylov_solves):
+            krylov_iterations = _dedupe_iterations(
+                krylov.get("iterations") or [])
+            if position == 0 and krylov_iterations:
+                rule = "   " + "-" * 40
+                lines.append("")
+                lines.append("   Pair-space %s iterations"
+                             % krylov.get("solver", "gmres").upper())
+                lines.append("    Iter        Residual")
+                lines.append(rule)
+                for it in krylov_iterations:
+                    lines.append("   %5s%s" % (
+                        it.get("iteration"), _fmt_exp(it.get("residual"))))
+                lines.append(rule)
+            else:
+                summary = ("   Auxiliary %s solve: %s in %s iterations"
+                           % (krylov.get("solver", "gmres").upper(),
+                              krylov.get("outcome") or "recorded",
+                              krylov.get("iteration_count",
+                                         len(krylov_iterations))))
+                if krylov.get("residual") is not None:
+                    summary += " (residual %.2E)" % krylov["residual"]
+                if position == 1:
+                    lines.append("")
+                lines.append(summary)
+    outcome = _ZVECTOR_OUTCOMES.get(solve.get("outcome"),
+                                    solve.get("outcome") or "recorded")
+    summary = "   Z-vector %s" % outcome
+    details = []
+    if solve.get("pair_iterations"):
+        details.append("%d pair-space Krylov iterations"
+                       % solve["pair_iterations"])
+    if solve.get("anderson_iterations"):
+        details.append("%d fixed-point iterations"
+                       % solve["anderson_iterations"])
+    if solve.get("fallback_gmres_iterations"):
+        details.append("%d fallback GMRES iterations"
+                       % solve["fallback_gmres_iterations"])
+    if solve.get("residual") is not None:
+        details.append("residual %.2E" % solve["residual"])
+    if details:
+        summary += ": " + ", ".join(details)
+    summary += _fmt_seconds(solve.get("elapsed"))
+    lines.append(summary)
+    return "\n".join(lines)
+
+
+def _dedupe_iterations(iterations):
+    """Keep the last record per iteration number (restart edges repeat one)."""
+    merged = {}
+    order = []
+    for it in iterations:
+        number = it.get("iteration")
+        if number not in merged:
+            order.append(number)
+        merged[number] = it
+    return [merged[number] for number in order]
+
+
+def format_zvector_dense_block(solve):
+    lines = ["   Z-vector dense direct solve"]
+    if solve.get("dimension") is not None:
+        lines.append("   dimension = %s" % solve["dimension"])
+    for stage, elapsed in solve.get("stages", []):
+        label = stage.replace("_", " ")
+        lines.append("     %-24s %s" % (
+            label, ("%.3f s" % elapsed) if elapsed is not None else ""))
+    outcome = _ZVECTOR_OUTCOMES.get(solve.get("outcome"),
+                                    solve.get("outcome") or "recorded")
+    summary = "   Z-vector dense solve %s" % outcome
+    if solve.get("residual") is not None:
+        summary += ": residual %.2E" % solve["residual"]
+    summary += _fmt_seconds(solve.get("elapsed"))
+    lines.append(summary)
+    return "\n".join(lines)
+
+
+AU_TO_DEBYE = 2.541746451895
+
+_SCC_MIXER_NAMES = {0: "linear", 1: "anderson", 2: "broyden", 3: "auto",
+                    4: "diis", 5: "trust"}
+_RESPONSE_SOLVER_NAMES = {0: "dense", 1: "davidson", 2: "auto"}
+
+
+def format_resolved_options(options):
+    """Grouped table of the EFFECTIVE openqp-dftb options after resolution.
+
+    The values come from the native openqp_dftb_resolved_options record, so a
+    named preset (e.g. dtcam-tb) is expanded to its actual published parameter
+    vector without duplicating those numbers in Python.
+    """
+    if not options:
+        return ""
+    preset = str(options.get("preset", "none"))
+
+    def number(key, digits=4):
+        value = options.get(key)
+        if value is None:
+            return "?"
+        return "%.*f" % (digits, float(value))
+
+    def selector(key):
+        value = options.get(key)
+        if value is None:
+            return "?"
+        return "off" if float(value) < 0.0 else number(key)
+
+    def yes_no(key):
+        return "yes" if options.get(key) else "no"
+
+    def response_lc(key):
+        value = options.get(key)
+        if value is None:
+            return "?"
+        if float(value) < 0.0:
+            return "inherit reference"
+        return number(key)
+
+    if preset != "none":
+        header = ("   Effective operator and numerical controls "
+                  "(preset: %s)" % preset)
+    else:
+        header = ("   Effective operator and numerical controls "
+                  "(no preset: explicit [dftb] keys / schema defaults)")
+    lines = [header, ""]
+
+    lines.append("   Reference operator")
+    lines.append("     %-31s %s" % (
+        "LC ground state:", "yes" if options.get("lc_ground_state") else "no"))
+    # The LC kernel parameters below also drive the SF/MRSF response coupling
+    # (gamma^lr) whenever the response LC inherits the reference, so they are
+    # reported even for a non-LC ground state.
+    lines.append("     %-31s %s kernel" % (
+        "LC gamma:", "erf" if options.get("lc_gamma_erf") else "yukawa"))
+    lines.append("     %-31s %s / %s / %s" % (
+        "omega / cam_alpha / cam_beta:", number("omega"),
+        number("cam_alpha"), number("cam_beta")))
+    lines.append("     %-31s %s (W scale %s)" % (
+        "Spin constants:",
+        "built-in" if options.get("builtin_spin_constants")
+        else "external spinw.txt", number("w_scale")))
+
+    lines.append("   Response operator")
+    lines.append("     %-31s %s / %s / %s" % (
+        "omega / cam_alpha / cam_beta:", response_lc("response_omega"),
+        response_lc("response_cam_alpha"), response_lc("response_cam_beta")))
+    lines.append("     %-31s %s" % (
+        "Response spin W scale:", response_lc("response_w_scale")))
+    lines.append("     %-31s %s / %s / %s" % (
+        "SPC coco / ovov / coov:", number("spc_coco"), number("spc_ovov"),
+        number("spc_coov")))
+    lines.append("     %-31s %s / %s / %s" % (
+        "Onsite ss / sp / pp:", number("onsite_ss"), number("onsite_sp"),
+        number("onsite_pp")))
+    if options.get("onsite_exchange_scale"):
+        lines.append("     %-31s %s" % (
+            "Onsite exchange scale:", number("onsite_exchange_scale")))
+    lines.append("     %-31s %s / %s" % (
+        "Legacy c_mrsf / c_mrsf_oo:", selector("c_mrsf"),
+        selector("c_mrsf_oo")))
+    if options.get("response_global_hybrid") or options.get(
+            "global_hybrid_exchange"):
+        lines.append("     %-31s response %s / reference %s" % (
+            "Global hybrid exchange:", yes_no("response_global_hybrid"),
+            yes_no("global_hybrid_exchange")))
+
+    lines.append("   Numerical controls")
+    mixer = _SCC_MIXER_NAMES.get(options.get("scc_mixer"),
+                                 str(options.get("scc_mixer")))
+    max_step = options.get("scc_max_step")
+    max_step_text = ("no clamp" if max_step is not None
+                     and float(max_step) <= 0.0
+                     else number("scc_max_step", 2))
+    lines.append("     %-31s %s (mixing %s, history %s, max step %s)" % (
+        "SCC mixer:", mixer, number("scc_mixing"),
+        options.get("scc_history", "?"), max_step_text))
+    lines.append("     %-31s %.1E / %s" % (
+        "SCC tolerance / max iterations:",
+        float(options.get("scc_tolerance") or 0.0),
+        options.get("max_scc_iterations", "?")))
+    solver = _RESPONSE_SOLVER_NAMES.get(options.get("response_solver"),
+                                        str(options.get("response_solver")))
+    lines.append("     %-31s %s (tolerance %.1E, max iterations %s, "
+                 "subspace %s)" % (
+                     "Response solver:", solver,
+                     float(options.get("response_tolerance") or 0.0),
+                     options.get("response_max_iterations", "?"),
+                     options.get("response_max_subspace", "?")))
+    lines.append("     %-31s %s" % (
+        "Analytic Z-vector gradient:", yes_no("zvector")))
+    return "\n".join(lines)
+
+
+def format_step_timing(step_cpu, step_wall, total_cpu, total_wall):
+    """The native-OpenQP style per-step + cumulative timing footer."""
+    return (
+        "   Step  CPU time (seconds): %10.3f   Wall time (seconds): %10.3f\n"
+        "   Total CPU time (seconds): %10.3f   Wall time (seconds): %10.3f"
+        % (step_cpu, step_wall, total_cpu, total_wall))
+
+
+def format_energy_components(components, reference_label="SCC reference"):
+    """OpenQP-style 'Energy components' block for the converged reference.
+
+    Semantics (from the native emitter): electronic = h0 + scc + spin +
+    exchange; total = electronic + repulsive; band = sum of occupied
+    eigenvalues (informational).
+    """
+    if not components or components.get("total") is None:
+        return ""
+
+    def row(label, key, always=False):
+        value = components.get(key)
+        if value is None:
+            return None
+        if not always and abs(value) < 5.0e-13:
+            return None
+        return "   %-33s = %18.10f" % (label, value)
+
+    rule = "   %s   ------------------" % (" " * 33)
+    lines = ["   Energy components (%s)" % reference_label, ""]
+    for entry in (
+        row("Core Hamiltonian (H0) energy", "h0", always=True),
+        row("SCC charge-fluctuation energy", "scc", always=True),
+        row("Spin polarization energy", "spin"),
+        row("Long-range exchange energy", "exchange"),
+    ):
+        if entry:
+            lines.append(entry)
+    lines.append(rule)
+    lines.append(row("Electronic energy", "electronic", always=True))
+    lines.append(row("Repulsive energy", "repulsive", always=True))
+    lines.append(rule)
+    lines.append(row("TOTAL energy", "total", always=True))
+    if components.get("band") is not None:
+        lines.append("")
+        lines.append("   %-33s = %18.10f" % (
+            "Band-structure energy (occ. sum)", components["band"]))
+    return "\n".join(line for line in lines if line is not None)
+
+
+def point_charge_dipole(charges, coords_bohr):
+    """Dipole vector (a.u.) of net atomic point charges at coords (Bohr)."""
+    dipole = [0.0, 0.0, 0.0]
+    for charge, xyz in zip(charges, coords_bohr):
+        for axis in range(3):
+            dipole[axis] += float(charge) * float(xyz[axis])
+    return dipole
+
+
+def format_charge_block(symbols, charges, dipole_au, title):
+    """Mulliken charge table + point-charge dipole, OpenQP style."""
+    lines = ["   %s" % title]
+    rule = "   " + "-" * 34
+    lines.append(rule)
+    lines.append("      #   Element        Charge")
+    lines.append(rule)
+    for index, (symbol, charge) in enumerate(zip(symbols, charges), start=1):
+        lines.append("   %5d   %-7s  %12.6f" % (index, symbol, charge))
+    lines.append(rule)
+    lines.append("   %-7s  %12.6f" % ("Sum", sum(float(q) for q in charges)))
+    magnitude = sum(component ** 2 for component in dipole_au) ** 0.5
+    lines.append("")
+    lines.append("   Dipole moment (point-charge model)")
+    lines.append("      X = %10.6f   Y = %10.6f   Z = %10.6f  a.u." %
+                 tuple(dipole_au))
+    lines.append("      |mu| = %10.6f a.u. = %10.6f Debye" %
+                 (magnitude, magnitude * AU_TO_DEBYE))
+    return "\n".join(lines)
+
+
+def format_other_lines(trace):
+    lines = trace.get("other", []) + trace.get("warnings", [])
+    if not lines:
+        return ""
+    return "\n".join(["   Additional native output:"]
+                     + ["   %s" % line.strip() for line in lines])
+
+
+def map_spectrum_label(label, state_prefix="S"):
+    """Map a printed spectrum label to the public state label.
+
+    Closed-shell TDDFTB rows already carry ``S<n>`` labels.  Spin-flip and
+    MRSF rows are labeled ``root <n>``; within each spin manifold the public
+    label is zero-based from root 1 (root 1 = S0/T0).
+    """
+    label = label.strip()
+    if state_prefix and label.startswith("root"):
+        number = _int(label.split()[-1])
+        if number is None:
+            return label
+        return "%s%d" % (state_prefix, number - 1)
+    return label
+
+
+def spectrum_from_ground(spectrum, state_prefix="S"):
+    """Rows out of the lowest state, keyed by public final-state label."""
+    if not spectrum:
+        return {}
+    rows = {}
+    ground_labels = {"S0", "root 1"}
+    for row in spectrum.get("rows", []):
+        if row["initial"].strip() in ground_labels:
+            final = map_spectrum_label(row["final"], state_prefix)
+            rows[final] = row
+    return rows
+
+
+def final_energy_header(summary):
+    """One header line naming the extra Final-Energy columns."""
+    if not summary:
+        return ""
+    return "  %12s  %12s  %12s" % ("VEE (eV)", "|mu| (a.u.)", "f")
+
+
+def final_energy_annotation(summary, index):
+    """Extra Final-Energy columns (VEE in eV, |mu|, f) for state row ``index``.
+
+    Numbers only -- the column names come from :func:`final_energy_header`.
+    ``index`` is the row number in ``mol.energies``: for spin-flip/MRSF runs
+    row 0 is the internal reference and roots start at row 1; for closed-shell
+    TDDFTB row 0 is S0 itself.
+    """
+    if not summary:
+        return ""
+    labels = summary.get("state_labels") or []
+    energies = summary.get("state_energies") or []
+    offset = 1 if summary.get("method") in ("mrsf", "sf") else 0
+    position = index - offset
+    if position < 0 or position >= min(len(labels), len(energies)):
+        return ""
+    vee = (energies[position] - energies[0]) * HARTREE_TO_EV
+    text = "  %12.6f" % vee
+    if position == 0:
+        return text
+    entry = (summary.get("oscillator") or {}).get(labels[position])
+    if entry is not None:
+        text += "  %12.4f  %12.4f" % (
+            entry.get("dipole") or 0.0, entry.get("oscillator") or 0.0)
+    return text
+
+
+def final_energy_label(summary, index, default):
+    """Public state label for Final-Energy row ``index`` (TDDFTB: S0..Sn)."""
+    if not summary or summary.get("method") in ("mrsf", "sf"):
+        return default
+    labels = summary.get("state_labels") or []
+    if 0 <= index < len(labels):
+        return labels[index]
+    return default
+
+
+def format_excited_state_summary(summary):
+    """The OpenQP-style excited-state summary + state-to-state tables.
+
+    ``summary`` is the dict the adapter stores on the molecule:
+    ``reference_energy``, ``reference_label``, ``state_labels`` (public),
+    ``state_energies`` (total Hartree per root), ``spin_squares``,
+    ``oscillator`` ({public label: spectrum row}), ``transitions``
+    (spectrum rows with public labels), ``approximation``.
+    """
+    labels = summary.get("state_labels") or []
+    energies = summary.get("state_energies") or []
+    spins = summary.get("spin_squares") or []
+    oscillator = summary.get("oscillator") or {}
+
+    def dipole_columns(entry):
+        """X, Y, Z, Abs, f columns for one ground->state spectrum row."""
+        if entry is None:
+            return "%11s%11s%11s%10s%11s" % ("", "", "", "n/a", "n/a")
+        xyz = entry.get("dipole_xyz")
+        text = ""
+        if xyz is not None:
+            text += "%11.4f%11.4f%11.4f" % tuple(xyz)
+        else:
+            text += "%11s%11s%11s" % ("", "", "")
+        text += "%10.4f" % (entry.get("dipole") or 0.0)
+        text += "%11.4f" % (entry.get("oscillator") or 0.0)
+        return text
+
+    lines = ["     Summary table", ""]
+    lines.append("   State        Energy        Excitation   <S^2>"
+                 "          Transition dipole (a.u.)        Oscillator")
+    lines.append("                Hartree           eV               "
+                 "      X          Y          Z       Abs.    strength")
+    rule = "   " + "-" * 100
+    lines.append(rule)
+    base = energies[0] if len(energies) else None
+    for position, label in enumerate(labels):
+        energy = energies[position] if position < len(energies) else None
+        row = "   %-6s" % label
+        row += ("%18.10f" % energy) if energy is not None else " " * 18
+        if energy is not None and base is not None:
+            row += "%12.6f" % ((energy - base) * HARTREE_TO_EV)
+        else:
+            row += " " * 12
+        spin = spins[position] if position < len(spins) else None
+        row += ("%8.3f" % spin) if spin is not None else " " * 8
+        if label == labels[0]:
+            row += "%11s" % "--"
+        else:
+            row += dipole_columns(oscillator.get(label))
+        lines.append(row.rstrip())
+    lines.append(rule)
+    reference_energy = summary.get("reference_energy")
+    if reference_energy is not None:
+        lines.append("   %-22s %18.10f" % (
+            summary.get("reference_label", "Reference (internal)"),
+            reference_energy))
+    transitions = summary.get("transitions") or []
+    if transitions:
+        lines.append("")
+        lines.append("     State-to-state transitions")
+        if summary.get("approximation"):
+            lines.append("     (%s)" % summary["approximation"])
+        lines.append("")
+        lines.append("    Initial    Final       dE (eV)          X"
+                     "          Y          Z       Abs.          f")
+        lines.append("   " + "-" * 90)
+        for row in transitions:
+            text = "   %7s   %6s   %12.6f" % (
+                row["initial"], row["final"], row["de_ev"] or 0.0)
+            xyz = row.get("dipole_xyz")
+            if xyz is not None:
+                text += "%11.4f%11.4f%11.4f" % tuple(xyz)
+            else:
+                text += "%11s%11s%11s" % ("", "", "")
+            text += "%11.4f%11.6f" % (row["dipole"] or 0.0,
+                                      row["oscillator"] or 0.0)
+            lines.append(text)
+    return "\n".join(lines)

--- a/pyoqp/oqp/utils/file_utils.py
+++ b/pyoqp/oqp/utils/file_utils.py
@@ -10,6 +10,11 @@ from oqp.runtime import basis_search_paths
 from oqp.utils.constants import ANGSTROM_TO_BOHR
 from oqp.utils.mpi_utils import mpi_dump
 from oqp.utils.qmmm import gradient_qmmm
+from oqp.utils.dftb_trace import (
+    final_energy_annotation,
+    final_energy_header,
+    final_energy_label,
+)
 from oqp.utils.state_labels import (
     format_calculation_request,
     format_dftb_settings,
@@ -215,6 +220,12 @@ def dump_log(mol, title=None, section=None, info=None, must_print=False):
             capabilities=details.get('capabilities'),
         )
 
+    if section == 'text':
+        # Pre-formatted body (e.g. the DFTB iteration tables built by
+        # oqp.utils.dftb_trace); the banner comes from the title above.
+        details = info if isinstance(info, dict) else {}
+        loginfo += '\n%s\n' % str(details.get('text', '')).rstrip()
+
     if section == 'dftb_runtime':
         details = info if isinstance(info, dict) else {}
         native_text = str(details.get('text', '')).strip()
@@ -340,22 +351,38 @@ def dump_log(mol, title=None, section=None, info=None, must_print=False):
             str(mol.config.get('input', {}).get('runtype', '')).lower() == 'soc'
             and is_mrsf(mol.config)
         )
-        for n, energy in enumerate(info['el']):
+        # DFTB response runs stash their excited-state summary (VEE eV,
+        # transition dipole, oscillator strength) for the final table.
+        dftb_summary = (getattr(mol, 'dftb_excited_states', None)
+                        if method == 'dftb' and not soc_triplet_ladder
+                        else None)
+        header = final_energy_header(dftb_summary)
+        if header:
+            loginfo += (f'   PyOQP {"State":<34} {"Total (Hartree)":<16}'
+                        f'{header}\n')
+
+        def energy_label(n):
             label = (public_state_label(mol.config, n, multiplicity=3)
                      if soc_triplet_ladder else
                      public_state_label(mol.config, n)
                      if is_mrsf(mol.config) else f'state {n}')
-            loginfo += f'   PyOQP {label:<34} {energy:<16.8f}\n'
+            return final_energy_label(dftb_summary, n, label)
+
+        for n, energy in enumerate(info['el']):
+            annotation = final_energy_annotation(dftb_summary, n)
+            loginfo += (f'   PyOQP {energy_label(n):<34} {energy:<16.8f}'
+                        f'{annotation}\n')
 
         d4 = float(info['d4'])
         loginfo += f'\n   PyOQP dftd correction {d4:<16.8f}\n\n'
         loginfo += '   PyOQP dispersion corrected energies\n'
+        if header:
+            loginfo += (f'   PyOQP {"State":<34} {"Total (Hartree)":<16}'
+                        f'{header}\n')
         for n, energy in enumerate(mol.energies):
-            label = (public_state_label(mol.config, n, multiplicity=3)
-                     if soc_triplet_ladder else
-                     public_state_label(mol.config, n)
-                     if is_mrsf(mol.config) else f'state {n}')
-            loginfo += f'   PyOQP {label:<34} {energy:<16.8f}\n'
+            annotation = final_energy_annotation(dftb_summary, n)
+            loginfo += (f'   PyOQP {energy_label(n):<34} {energy:<16.8f}'
+                        f'{annotation}\n')
 
     if section == 'grad':
         if not mol.config['input']['qmmm_flag']:

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -42,11 +42,13 @@ DFTB_SCC_MIXERS = {"linear", "anderson", "pulay", "broyden", "auto", "diis", "tr
 DFTB_MODELS = {"dtcam-tb", "dtcam_tb", "dtcamtb",
                "dftb+", "dftbplus", "dftb_plus"}
 # Production defaults when no model= is named and no preset-locked key is
-# tuned: MRSF-TDDFTB runs the published DTCAM-TB operator; every other SCC
-# route (ground, TD-DFTB, SF) runs the DFTB+ compatibility protocol.  DFTB0
-# (ground_noscc) stays preset-free.
+# tuned: MRSF-TDDFTB runs the published DTCAM-TB operator; the other
+# OPEN-SHELL SCC routes (SF, open-shell ground) run the DFTB+ compatibility
+# protocol.  Closed-shell routes (singlet ground, TD-DFTB) and DFTB0 stay
+# preset-free: LC-DFTB2 is not implemented for the restricted reference, and
+# the native library rejects lc_ground_state there.
 DFTB_MODEL_DEFAULT_MRSF = "dtcam-tb"
-DFTB_MODEL_DEFAULT_OTHER = "dftb+"
+DFTB_MODEL_DEFAULT_OPEN_SHELL = "dftb+"
 # Keys a [dftb] model preset fixes; the checker refuses to combine them with
 # model= (the preset overrides them inside openqp-dftb, so a user-tuned value
 # would be silently discarded).
@@ -885,12 +887,13 @@ def _dftb_key_customized(config: dict[str, Any], key: str) -> bool:
 def apply_dftb_model_default(config: dict[str, Any]) -> str:
     """Materialize the production default [dftb] model preset.
 
-    MRSF-TDDFTB defaults to the published DTCAM-TB operator; every other SCC
-    route (ground SCC-DFTB, closed-shell TD-DFTB, SF-TDDFTB) defaults to the
-    DFTB+ compatibility protocol.  ``model=none`` keeps the explicit-keys
-    route, and any tuned preset-locked key implies manual operator control
-    (legacy inputs keep meaning what they said).  DFTB0 (non-SCC) stays
-    preset-free.  Returns the effective model string.
+    MRSF-TDDFTB defaults to the published DTCAM-TB operator; the other
+    open-shell SCC routes (SF-TDDFTB, open-shell ground) default to the DFTB+
+    compatibility protocol.  Closed-shell routes (singlet ground, TD-DFTB)
+    and DFTB0 stay preset-free because the restricted reference has no
+    long-range exchange yet.  ``model=none`` keeps the explicit-keys route,
+    and any tuned preset-locked key implies manual operator control (legacy
+    inputs keep meaning what they said).  Returns the effective model string.
     """
     if _as_lower(_get(config, "input", "method", "hf")) != "dftb":
         return ""
@@ -910,13 +913,20 @@ def apply_dftb_model_default(config: dict[str, Any]) -> str:
         return ""
     from oqp.utils.state_labels import resolved_dftb_type  # noqa: PLC0415
     route = resolved_dftb_type(config)
-    if route == "ground_noscc":
-        return ""
     if any(_dftb_key_customized(config, key)
            for key in DFTB_MODEL_LOCKED_KEYS):
         return ""
-    dftb["model"] = (DFTB_MODEL_DEFAULT_MRSF if route == "mrsf"
-                     else DFTB_MODEL_DEFAULT_OTHER)
+    if route == "mrsf":
+        dftb["model"] = DFTB_MODEL_DEFAULT_MRSF
+    elif route == "sf" or (
+            route == "ground"
+            and _get(config, "dftb", "reference_multiplicity", 0)
+            and int(_get(config, "dftb", "reference_multiplicity", 0)) > 1):
+        dftb["model"] = DFTB_MODEL_DEFAULT_OPEN_SHELL
+    else:
+        # Closed-shell routes (singlet ground, TD-DFTB) and DFTB0: the
+        # restricted reference has no LC yet, so no preset default.
+        return ""
     return dftb["model"]
 
 
@@ -1041,6 +1051,29 @@ def _check_dftb(config: dict[str, Any], report: CheckReport) -> None:
                 expected="native",
                 action="Use backend=native (presets are resolved inside openqp-dftb).",
             )
+        # LC-DFTB2 exists only for the spin-polarized (ROKS) reference; the
+        # native library rejects lc_ground_state on the closed-shell
+        # restricted path, so surface that at input time for LC presets.
+        if model in {"dftb+", "dftbplus", "dftb_plus"} and \
+                dftb_type_canon in {"ground", "ground_noscc", "tddftb"}:
+            reference_multiplicity = _get(
+                config, "dftb", "reference_multiplicity", 0)
+            try:
+                reference_multiplicity = int(reference_multiplicity)
+            except (TypeError, ValueError):
+                reference_multiplicity = 0
+            if reference_multiplicity <= 1:
+                report.add(
+                    "ERROR",
+                    "dftb.model",
+                    "model=dftb+ sets an LC-DFTB2 (lc_ground_state) "
+                    "reference, which is only implemented for the "
+                    "spin-polarized (ROKS) path.",
+                    value=f"{model} with closed-shell type={dftb_type_canon}",
+                    expected="an SF/MRSF route or reference_multiplicity > 1",
+                    action="Use type=sf/mrsf, set reference_multiplicity > 1, "
+                           "or drop model= (closed-shell runs stay preset-free).",
+                )
         conflicting = [
             key for key in DFTB_MODEL_LOCKED_KEYS
             if _dftb_key_customized(config, key)

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -39,7 +39,14 @@ DFTB_TYPES = {
 }
 DFTB_SCC_MIXERS = {"linear", "anderson", "pulay", "broyden", "auto", "diis", "trust", "trah"}
 
-DFTB_MODELS = {"dtcam-tb", "dtcam_tb", "dtcamtb"}
+DFTB_MODELS = {"dtcam-tb", "dtcam_tb", "dtcamtb",
+               "dftb+", "dftbplus", "dftb_plus"}
+# Production defaults when no model= is named and no preset-locked key is
+# tuned: MRSF-TDDFTB runs the published DTCAM-TB operator; every other SCC
+# route (ground, TD-DFTB, SF) runs the DFTB+ compatibility protocol.  DFTB0
+# (ground_noscc) stays preset-free.
+DFTB_MODEL_DEFAULT_MRSF = "dtcam-tb"
+DFTB_MODEL_DEFAULT_OTHER = "dftb+"
 # Keys a [dftb] model preset fixes; the checker refuses to combine them with
 # model= (the preset overrides them inside openqp-dftb, so a user-tuned value
 # would be silently discarded).
@@ -875,6 +882,44 @@ def _dftb_key_customized(config: dict[str, Any], key: str) -> bool:
         return str(value).strip().lower() != str(default_raw).strip().lower()
 
 
+def apply_dftb_model_default(config: dict[str, Any]) -> str:
+    """Materialize the production default [dftb] model preset.
+
+    MRSF-TDDFTB defaults to the published DTCAM-TB operator; every other SCC
+    route (ground SCC-DFTB, closed-shell TD-DFTB, SF-TDDFTB) defaults to the
+    DFTB+ compatibility protocol.  ``model=none`` keeps the explicit-keys
+    route, and any tuned preset-locked key implies manual operator control
+    (legacy inputs keep meaning what they said).  DFTB0 (non-SCC) stays
+    preset-free.  Returns the effective model string.
+    """
+    if _as_lower(_get(config, "input", "method", "hf")) != "dftb":
+        return ""
+    dftb = config.get("dftb")
+    if not isinstance(dftb, dict):
+        return ""
+    model = _as_lower(_get(config, "dftb", "model", ""))
+    if model == "none":
+        dftb["model"] = ""
+        return ""
+    if model:
+        return model
+    # Presets are resolved inside the native library; the probe backend
+    # cannot carry them, so it keeps the explicit-keys route.
+    if _as_lower(_get(config, "dftb", "backend", "native")) not in {
+            "native", "auto"}:
+        return ""
+    from oqp.utils.state_labels import resolved_dftb_type  # noqa: PLC0415
+    route = resolved_dftb_type(config)
+    if route == "ground_noscc":
+        return ""
+    if any(_dftb_key_customized(config, key)
+           for key in DFTB_MODEL_LOCKED_KEYS):
+        return ""
+    dftb["model"] = (DFTB_MODEL_DEFAULT_MRSF if route == "mrsf"
+                     else DFTB_MODEL_DEFAULT_OTHER)
+    return dftb["model"]
+
+
 def _check_dftb(config: dict[str, Any], report: CheckReport) -> None:
     method = _as_lower(_get(config, "input", "method", "hf"))
     if method != "dftb":
@@ -972,6 +1017,9 @@ def _check_dftb(config: dict[str, Any], report: CheckReport) -> None:
             )
 
     model = _as_lower(_get(config, "dftb", "model", ""))
+    if model == "none":
+        # Explicit opt-out of the SF/MRSF dtcam-tb default: explicit-keys route.
+        model = ""
     if model:
         if model not in DFTB_MODELS:
             report.add(
@@ -980,7 +1028,9 @@ def _check_dftb(config: dict[str, Any], report: CheckReport) -> None:
                 "Unknown OpenQP-DFTB operator model preset.",
                 value=model,
                 expected=", ".join(sorted(DFTB_MODELS)),
-                action="Use model=dtcam-tb, or omit model and set the operator keys individually.",
+                action="Use model=dtcam-tb (DTCAM-TB paper vector), "
+                       "model=dftb+ (DFTB+ default LC-DFTB protocol), or "
+                       "omit model and set the operator keys individually.",
             )
         if backend == "probe":
             report.add(

--- a/pyoqp/oqp/utils/state_labels.py
+++ b/pyoqp/oqp/utils/state_labels.py
@@ -76,6 +76,12 @@ DFTB_CAP_STRUCTURED_TRACE = 1
 DFTB_CAP_STATE_SPECTRUM = 2
 DFTB_CAP_SCC_FINAL_TRUST = 4
 
+# Named operator presets published by openqp-dftb ([dftb] model=...).  The
+# parameter vectors themselves live in openqp-dftb (src/openqp_dftb_presets.F90,
+# the single source of truth) and are reported back through the
+# openqp_dftb_resolved_options record; this tuple only feeds the settings log.
+DFTB_KNOWN_PRESETS = ("dtcam-tb", "dftb+")
+
 
 def _section(config, name):
     value = config.get(name, {}) if isinstance(config, dict) else {}
@@ -275,6 +281,9 @@ def format_dftb_settings(
     if requested_backend != actual_backend:
         backend_text += " (requested: %s)" % requested_backend
     model = str(dftb.get("model", "")).strip()
+    if model.lower() == "none":
+        # Explicit opt-out of the SF/MRSF dtcam-tb default.
+        model = ""
 
     groups = []
     method_rows = [
@@ -319,7 +328,7 @@ def format_dftb_settings(
     elif model:
         scc_rows = [
             ("Enabled", "yes"),
-            ("Protocol", "%s preset (resolved by openqp-dftb backend)" % model),
+            ("Protocol", "%s preset" % model),
         ]
     else:
         mixer = str(dftb.get("scc_mixer", "auto")).strip().lower()
@@ -344,7 +353,7 @@ def format_dftb_settings(
 
     if method not in {"ground", "ground_noscc"}:
         solver = (
-            "%s preset (resolved by openqp-dftb backend)" % model
+            "%s preset" % model
             if model else
             "%s (requested)" % str(dftb.get("response_solver", "auto")).lower()
         )
@@ -374,7 +383,7 @@ def format_dftb_settings(
             )
         groups[-1][1].append(("State-to-state spectrum", spectrum_text))
         zvector = (
-            "%s preset (resolved by openqp-dftb backend)" % model
+            "%s preset" % model
             if model else _yes_no(dftb.get("zvector", True))
         )
         groups.append(("gradient", [("Relaxed Z-vector", zvector)]))
@@ -382,11 +391,13 @@ def format_dftb_settings(
     if model:
         operator_rows = [
             ("Model preset", "%s (operator resolved by openqp-dftb backend)" % model),
+            ("Effective values", "reported under 'DFTB effective options'"),
         ]
     elif method == "ground_noscc":
         operator_rows = [("Hamiltonian", "non-SCC DFTB0")]
     else:
         operator_rows = [
+            ("Model preset", "none (explicit [dftb] keys; schema defaults)"),
             ("LC ground state", _yes_no(dftb.get("lc_ground_state", False))),
         ]
         if method in {"sf", "mrsf"} or bool(dftb.get("lc_ground_state", False)):
@@ -419,16 +430,28 @@ def format_dftb_settings(
                         "mrsf_shift_ov", "mrsf_shift_cv",
                     )
                 )))
+    if method != "ground_noscc":
+        operator_rows.append(
+            ("Available presets", ", ".join(DFTB_KNOWN_PRESETS))
+        )
     groups.append(("operator", operator_rows))
 
-    lines = []
+    titles = {
+        "calculation": "Calculation",
+        "SCC": "SCC",
+        "response": "Response",
+        "gradient": "Gradient",
+        "operator": "Operator",
+    }
+    blocks = []
     for group, rows in groups:
-        lines.append("   PyOQP DFTB %s settings" % group)
+        lines = ["   %s" % titles.get(group, group.capitalize())]
         lines.extend(
-            "   PyOQP   %-27s %s" % (label + ":", value)
+            "     %-29s %s" % (label + ":", value)
             for label, value in rows
         )
-    return "\n".join(lines)
+        blocks.append("\n".join(lines))
+    return "\n\n".join(blocks)
 
 
 def is_mrsf(config):

--- a/tests/test_dftb_model_default.py
+++ b/tests/test_dftb_model_default.py
@@ -1,0 +1,75 @@
+"""Policy tests for the production [dftb] model default resolution."""
+
+from oqp.utils.input_checker import apply_dftb_model_default
+
+
+def _config(dftb=None, tdhf_type="mrsf", runtype="energy"):
+    config = {
+        "input": {"method": "dftb", "runtype": runtype},
+        "tdhf": {"type": tdhf_type, "nstate": 3},
+        "properties": {"grad": []},
+        "optimize": {},
+        "dftb": {"backend": "native", "type": "auto", "model": ""},
+    }
+    if dftb:
+        config["dftb"].update(dftb)
+    return config
+
+
+def test_mrsf_defaults_to_dtcam_tb():
+    config = _config(dftb={"type": "mrsf"})
+    assert apply_dftb_model_default(config) == "dtcam-tb"
+    assert config["dftb"]["model"] == "dtcam-tb"
+
+
+def test_sf_defaults_to_dftb_plus():
+    config = _config(dftb={"type": "sf"}, tdhf_type="sf")
+    assert apply_dftb_model_default(config) == "dftb+"
+
+
+def test_closed_shell_routes_stay_preset_free():
+    # Singlet ground and closed-shell TD-DFTB: LC-DFTB2 is not implemented
+    # for the restricted reference, so no preset default there.
+    for dftb, td in ((({"type": "ground"}), "rpa"),
+                     (({"type": "tddftb"}), "tda"),
+                     (({"type": "ground_noscc"}), "rpa")):
+        config = _config(dftb=dftb, tdhf_type=td)
+        assert apply_dftb_model_default(config) == ""
+        assert config["dftb"]["model"] == ""
+
+
+def test_open_shell_ground_defaults_to_dftb_plus():
+    config = _config(dftb={"type": "ground", "reference_multiplicity": 3},
+                     tdhf_type="rpa")
+    assert apply_dftb_model_default(config) == "dftb+"
+
+
+def test_model_none_is_an_explicit_opt_out():
+    config = _config(dftb={"type": "mrsf", "model": "none"})
+    assert apply_dftb_model_default(config) == ""
+    assert config["dftb"]["model"] == ""
+
+
+def test_explicit_model_wins():
+    config = _config(dftb={"type": "mrsf", "model": "dftb+"})
+    assert apply_dftb_model_default(config) == "dftb+"
+    assert config["dftb"]["model"] == "dftb+"
+
+
+def test_tuned_locked_key_keeps_the_explicit_keys_route():
+    # erf-tuning style inputs keep meaning what they said.
+    config = _config(dftb={"type": "mrsf", "omega": 0.25, "lc_gamma": "erf"})
+    assert apply_dftb_model_default(config) == ""
+    assert config["dftb"]["model"] == ""
+
+
+def test_probe_backend_gets_no_preset_default():
+    config = _config(dftb={"type": "mrsf", "backend": "probe"})
+    assert apply_dftb_model_default(config) == ""
+
+
+def test_non_dftb_methods_are_untouched():
+    config = _config(dftb={"type": "mrsf"})
+    config["input"]["method"] = "tdhf"
+    assert apply_dftb_model_default(config) == ""
+    assert config["dftb"]["model"] == ""

--- a/tests/test_dftb_trace.py
+++ b/tests/test_dftb_trace.py
@@ -62,9 +62,9 @@ openqp_dftb_energy_components total -1.04652311259000E+001 electronic -1.0700000
 
 DFTB state-to-state oscillator strengths
   Approximation: unrelaxed TDA/state interaction, length gauge, DFTB Mulliken-monopole transition dipoles
-  Initial  Final      Delta E (eV)    mu_x (a.u.)    mu_y (a.u.)    mu_z (a.u.)      |mu| (a.u.)                f
-  root 1   root 2         6.951845       0.000000       2.504000       0.000000         2.504000     1.067900E+000
-  root 1   root 3         7.376022       0.000000       0.000000       0.000000         0.000000     0.000000E+000
+  Initial  Final      Delta E (eV)      |mu| (a.u.)                f    mu_x (a.u.)    mu_y (a.u.)    mu_z (a.u.)
+  root 1   root 2         6.951845         2.504000     1.067900E+000       0.000000       2.504000       0.000000
+  root 1   root 3         7.376022         0.000000     0.000000E+000       0.000000       0.000000       0.000000
 """
 
 

--- a/tests/test_dftb_trace.py
+++ b/tests/test_dftb_trace.py
@@ -1,0 +1,323 @@
+"""Unit tests for the openqp-dftb structured-trace parser and formatters."""
+
+import importlib.util
+from pathlib import Path
+
+MODULE = Path(__file__).parents[1] / "pyoqp" / "oqp" / "utils" / "dftb_trace.py"
+SPEC = importlib.util.spec_from_file_location("oqp_dftb_trace", MODULE)
+dftb_trace = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(dftb_trace)
+
+
+LEVEL2_TRACE = """
+openqp_dftb_scc_pass rhf_seed pass 1 stage seed mixer broyden elapsed_seconds  0.000000E+000
+openqp_dftb_scc_iter rhf_seed 1 residual  2.500000E-002 tol  1.000000E-005 pass 1 elapsed_seconds  1.000000E-004
+openqp_dftb_scc_iter rhf_seed 2 residual  3.100000E-006 tol  1.000000E-005 pass 1 elapsed_seconds  2.000000E-004
+openqp_dftb_scc_pass_end rhf_seed pass 1 outcome converged iterations 2 elapsed_seconds  2.000000E-003
+openqp_dftb_scc_pass rohf pass 1 stage initial mixer broyden elapsed_seconds  0.000000E+000
+openqp_dftb_scc_iter rohf 1 residual  1.200000E-002 charge  1.200000E-002 spin  3.000000E-003 tol  1.000000E-008
+openqp_dftb_scc_iter rohf_trah 2 residual  4.000000E-006 charge  4.000000E-006 spin  1.000000E-007 tol  1.000000E-008
+openqp_dftb_scc_iter rohf 3 residual  5.000000E-009 charge  5.000000E-009 spin  2.000000E-011 tol  1.000000E-008
+openqp_dftb_scc_pass_end rohf pass 1 outcome converged iterations 3 elapsed_seconds  9.000000E-003
+openqp_dftb_scc_post_update rohf residual  6.434884E-010 charge  6.434884E-010 spin  4.727729E-011 density  3.197395E-010 tol  1.000000E-008 converged T elapsed_seconds  1.000000E-002
+openqp_dftb_scc_recovery rohf kind level_shift attempted F succeeded F elapsed_seconds  1.000000E-002
+openqp_dftb_scc_recovery rohf kind charge_spin_trah attempted F succeeded F elapsed_seconds  1.000000E-002
+openqp_dftb_davidson_start dimension 143 roots 3 max_subspace 100 max_iterations 50 tolerance  1.000000E-006 elapsed_seconds  0.000000E+000
+openqp_dftb_davidson_iter iteration 1 basis 3 converged_roots 0 residual  1.500000E-003 matvecs 3 restarts 0 elapsed_seconds  1.000000E-004
+openqp_dftb_davidson_iter iteration 2 basis 6 converged_roots 2 residual  8.000000E-006 matvecs 6 restarts 0 elapsed_seconds  3.000000E-004
+openqp_dftb_davidson_end outcome converged iterations 7 residual  6.480064E-007 matvecs 20 restarts 0 elapsed_seconds  1.000000E-003
+
+DFTB state-to-state oscillator strengths
+  Approximation: unrelaxed TDA/state interaction, length gauge, DFTB Mulliken-monopole transition dipoles
+  Initial  Final      Delta E (eV)      |mu| (a.u.)                f
+  root 1   root 2         3.984014         0.716700     9.990000E-002
+  root 1   root 3         7.942290         0.124000     3.300000E-003
+  root 2   root 3         3.958276         0.500000     2.500000E-002
+"""
+
+GRADIENT_TRACE = """
+openqp_dftb_scc_pass rohf pass 1 stage initial mixer broyden elapsed_seconds  0.000000E+000
+openqp_dftb_scc_iter rohf 1 residual  1.200000E-002 charge  1.200000E-002 spin  3.000000E-003 tol  1.000000E-008
+openqp_dftb_scc_pass_end rohf pass 1 outcome converged iterations 12 elapsed_seconds  9.000000E-003
+openqp_dftb_zvector_start dimension 286 max_iterations 50 tolerance  1.000000E-010 elapsed_seconds  0.000000E+000
+[zvec-pair] using pair-space single solve, gmres_iters 11 fixed_point_max_abs  3.200000E-012 preconditioned_l2  1.100000E-013
+openqp_dftb_zvector_iter iteration 1 residual  1.000000E-004 inner_solves 2 inner_matvecs 14 elapsed_seconds  1.000000E-002
+openqp_dftb_zvector_iter iteration 2 residual  9.000000E-011 inner_solves 2 inner_matvecs 12 elapsed_seconds  2.000000E-002
+openqp_dftb_zvector_end outcome pair_space_converged pair_iterations 11 anderson_iterations 2 fallback_gmres_iterations 0 residual_kind fixed_point_max_abs residual  3.200000E-012 elapsed_seconds  8.000000E-001
+"""
+
+PAIR_SOLVE_TRACE = """
+openqp_dftb_zvector_start dimension 968 max_iterations 2000 tolerance  1.000000E-009 elapsed_seconds  0.000000E+000
+openqp_dftb_gmres_start dimension 240 max_iterations 2000 max_subspace 100 tolerance  1.000000E-009 elapsed_seconds  0.000000E+000
+openqp_dftb_gmres_iter iteration 0 cycle 1 residual  4.100000E-002 matvecs 1 elapsed_seconds  1.000000E-004
+openqp_dftb_gmres_iter iteration 1 cycle 1 residual  6.300000E-004 matvecs 2 elapsed_seconds  2.000000E-004
+openqp_dftb_gmres_iter iteration 2 cycle 1 residual  8.800000E-007 matvecs 3 elapsed_seconds  3.000000E-004
+openqp_dftb_gmres_iter iteration 3 cycle 1 residual  2.100000E-010 matvecs 4 elapsed_seconds  4.000000E-004
+openqp_dftb_gmres_end outcome converged iterations 3 residual  2.100000E-010 matvecs 5 elapsed_seconds  5.000000E-004
+openqp_dftb_zvector_end outcome pair_space_converged pair_iterations 3 anderson_iterations 0 fallback_gmres_iterations 0 residual_kind fixed_point_max_abs residual  2.650000E-013 elapsed_seconds  1.000000E-003
+"""
+
+COMPONENT_SPECTRUM_TRACE = """
+openqp_dftb_energy_components total -1.04652311259000E+001 electronic -1.07000000000000E+001 h0 -1.05000000000000E+001 scc -2.00000000000000E-001 spin  0.00000000000000E+000 exchange  0.00000000000000E+000 repulsive  2.34768874100000E-001 band -5.60000000000000E+000
+
+DFTB state-to-state oscillator strengths
+  Approximation: unrelaxed TDA/state interaction, length gauge, DFTB Mulliken-monopole transition dipoles
+  Initial  Final      Delta E (eV)    mu_x (a.u.)    mu_y (a.u.)    mu_z (a.u.)      |mu| (a.u.)                f
+  root 1   root 2         6.951845       0.000000       2.504000       0.000000         2.504000     1.067900E+000
+  root 1   root 3         7.376022       0.000000       0.000000       0.000000         0.000000     0.000000E+000
+"""
+
+
+def test_parse_level2_trace_collects_iterations_and_spectrum():
+    trace = dftb_trace.parse_native_trace(LEVEL2_TRACE)
+
+    assert [entry["label"] for entry in trace["scc_passes"]] == \
+        ["rhf_seed", "rohf"]
+    seed, rohf = trace["scc_passes"]
+    assert len(seed["iterations"]) == 2
+    assert seed["outcome"] == "converged"
+    assert len(rohf["iterations"]) == 3
+    assert rohf["iterations"][1]["mode"] == "TRAH"
+    assert rohf["iterations"][2]["charge"] == 5.0e-9
+
+    assert trace["post_updates"][0]["converged"] is True
+    assert all(not entry["attempted"] for entry in trace["recoveries"])
+
+    davidson = trace["davidson"][0]
+    assert davidson["dimension"] == 143
+    assert len(davidson["iterations"]) == 2
+    assert davidson["outcome"] == "converged"
+    assert davidson["iteration_count"] == 7
+
+    spectrum = trace["spectrum"]
+    assert spectrum["rows"][0]["initial"] == "root 1"
+    assert spectrum["rows"][0]["oscillator"] == 9.99e-2
+    assert len(spectrum["rows"]) == 3
+
+
+def test_scc_table_shows_iterations_and_convergence():
+    trace = dftb_trace.parse_native_trace(LEVEL2_TRACE)
+    text = dftb_trace.format_scc_block(trace)
+
+    assert "SCC iterations: restricted charge seed" in text
+    assert "SCC iterations: open-shell (ROKS) reference" in text
+    assert "Iter" in text and "Residual" in text
+    assert "TRAH" in text
+    assert "SCC converged in 3 iterations" in text
+    assert "Final self-consistency" in text
+    # Recoveries that were never attempted stay out of the default log.
+    assert "recovery" not in text
+
+
+def test_davidson_table_shows_iterations():
+    trace = dftb_trace.parse_native_trace(LEVEL2_TRACE)
+    text = dftb_trace.format_davidson_block(
+        trace["davidson"][0], "MRSF-TDDFTB")
+
+    assert "Davidson algorithm for MRSF-TDDFTB response states" in text
+    assert "dimension = 143" in text
+    assert "Converged roots" in text
+    assert "Davidson converged in 7 iterations" in text
+    assert "20 matvecs" in text
+
+
+def test_zvector_table_shows_iterations_and_outcome():
+    trace = dftb_trace.parse_native_trace(GRADIENT_TRACE)
+    text = dftb_trace.format_zvector_block(trace["zvector"][0])
+
+    assert "Z-vector relaxed-density solve" in text
+    assert "dimension = 286" in text
+    assert "Inner solves" in text
+    assert "pair-space single solve" in text
+    assert "residual 3.20E-12" in text
+    # The bracketed debug line is not a structured record.
+    assert "[zvec-pair]" in "\n".join(trace["other"])
+
+
+def test_gradient_summary_lines_are_compact():
+    trace = dftb_trace.parse_native_trace(GRADIENT_TRACE)
+    text = dftb_trace.format_scc_summary_lines(trace)
+
+    assert "SCC open-shell (ROKS) reference: converged in 12 iterations" in text
+
+
+def test_spectrum_root_labels_map_to_public_states():
+    assert dftb_trace.map_spectrum_label("root 1", "S") == "S0"
+    assert dftb_trace.map_spectrum_label("root 3", "T") == "T2"
+    assert dftb_trace.map_spectrum_label("S2", "S") == "S2"
+    assert dftb_trace.map_spectrum_label("root 2", None) == "root 2"
+
+
+def test_excited_state_summary_table_and_transitions():
+    trace = dftb_trace.parse_native_trace(LEVEL2_TRACE)
+    spectrum = trace["spectrum"]
+    oscillator = dftb_trace.spectrum_from_ground(spectrum, "S")
+    summary = {
+        "method": "mrsf",
+        "state_labels": ["S0", "S1", "S2"],
+        "state_energies": [-114.43, -114.28, -114.13],
+        "spin_squares": [0.0, 0.0, 0.0],
+        "oscillator": oscillator,
+        "transitions": [{
+            "initial": dftb_trace.map_spectrum_label(row["initial"], "S"),
+            "final": dftb_trace.map_spectrum_label(row["final"], "S"),
+            "de_ev": row["de_ev"],
+            "dipole": row["dipole"],
+            "oscillator": row["oscillator"],
+        } for row in spectrum["rows"]],
+        "approximation": spectrum["approximation"],
+        "reference_label": "Reference: high-spin ROKS (internal)",
+        "reference_energy": -114.32,
+    }
+    text = dftb_trace.format_excited_state_summary(summary)
+
+    assert "Summary table" in text
+    assert "Excitation" in text and "Oscillator" in text
+    lines = [line for line in text.splitlines() if line.strip().startswith("S1")]
+    assert lines and "0.7167" in lines[0] and "0.0999" in lines[0]
+    assert "Reference: high-spin ROKS (internal)" in text
+    assert "State-to-state transitions" in text
+    assert text.index("Summary table") < text.index("State-to-state transitions")
+    transition_lines = [line for line in text.splitlines()
+                        if line.strip().startswith("S1 ")
+                        or "S1        S2" in line.replace("   ", " ")]
+    assert "S2" in text
+
+
+def test_final_energy_annotation_alignment():
+    summary = {
+        "method": "mrsf",
+        "state_labels": ["S0", "S1"],
+        "state_energies": [-114.43, -114.28],
+        "oscillator": {
+            "S1": {"dipole": 0.7167, "oscillator": 0.0999},
+        },
+    }
+    # Row 0 is the internal reference: no annotation.
+    assert dftb_trace.final_energy_annotation(summary, 0) == ""
+    # Column names live in the header, not in every row.
+    header = dftb_trace.final_energy_header(summary)
+    assert "VEE (eV)" in header and "|mu| (a.u.)" in header
+    s0 = dftb_trace.final_energy_annotation(summary, 1)
+    assert "VEE" not in s0 and s0.strip() == "0.000000"
+    s1 = dftb_trace.final_energy_annotation(summary, 2)
+    assert "VEE" not in s1
+    assert "0.7167" in s1 and "0.0999" in s1
+    assert dftb_trace.final_energy_annotation(summary, 3) == ""
+    assert dftb_trace.final_energy_annotation(None, 1) == ""
+    assert dftb_trace.final_energy_header(None) == ""
+
+
+def test_final_energy_labels_for_closed_shell_tddftb():
+    summary = {"method": "tddftb", "state_labels": ["S0", "S1", "S2"]}
+    assert dftb_trace.final_energy_label(summary, 0, "state 0") == "S0"
+    assert dftb_trace.final_energy_label(summary, 1, "state 1") == "S1"
+    assert dftb_trace.final_energy_label(summary, 9, "state 9") == "state 9"
+    mrsf = {"method": "mrsf", "state_labels": ["S0"]}
+    # MRSF rows keep public_state_label (row 0 is the internal reference).
+    assert dftb_trace.final_energy_label(mrsf, 0, "reference") == "reference"
+
+
+def test_zvector_pair_solve_iterations_are_rendered():
+    trace = dftb_trace.parse_native_trace(PAIR_SOLVE_TRACE)
+    solve = trace["zvector"][0]
+
+    assert not solve["iterations"]
+    assert len(solve["krylov_solves"]) == 1
+    assert len(solve["krylov_solves"][0]["iterations"]) == 4
+
+    text = dftb_trace.format_zvector_block(solve)
+    assert "Pair-space GMRES iterations" in text
+    assert "2.100000E-10" in text
+    assert "pair-space single solve" in text
+
+
+def test_gmres_outside_zvector_stays_generic():
+    trace = dftb_trace.parse_native_trace(
+        "openqp_dftb_gmres_start dimension 10 max_iterations 5 "
+        "max_subspace 5 tolerance  1.000000E-008 elapsed_seconds  0.0\n"
+        "openqp_dftb_gmres_end outcome converged iterations 2 residual "
+        " 1.000000E-009 matvecs 3 elapsed_seconds  1.000000E-003\n")
+    assert len(trace["linear"]) == 1
+    assert not trace["zvector"]
+
+
+def test_energy_components_block_and_spectrum_components():
+    trace = dftb_trace.parse_native_trace(COMPONENT_SPECTRUM_TRACE)
+
+    components = trace["energy_components"]
+    assert components["total"] == -10.4652311259
+    text = dftb_trace.format_energy_components(components)
+    assert "Core Hamiltonian (H0) energy" in text
+    assert "TOTAL energy" in text
+    # Zero-valued optional terms stay out of the block.
+    assert "Spin polarization" not in text
+    assert "Long-range exchange" not in text
+
+    rows = trace["spectrum"]["rows"]
+    assert rows[0]["dipole_xyz"] == [0.0, 2.504, 0.0]
+    assert rows[0]["dipole"] == 2.504
+    assert rows[0]["oscillator"] == 1.0679
+
+
+RESOLVED_OPTIONS_TRACE = (
+    "openqp_dftb_resolved_options preset dtcam-tb lc_ground_state T "
+    "lc_gamma_erf T omega  3.00000000E-001 cam_alpha  0.00000000E+000 "
+    "cam_beta  4.00000000E-002 response_omega  2.62500000E-001 "
+    "response_cam_alpha  0.00000000E+000 response_cam_beta  1.01250000E+000 "
+    "w_scale  1.00000000E+000 response_w_scale  6.37500000E-001 "
+    "spc_coco  1.02500000E+000 spc_ovov  2.50000000E-001 "
+    "spc_coov  2.62500000E-001 onsite_ss  0.00000000E+000 "
+    "onsite_sp  0.00000000E+000 onsite_pp -1.25000000E-002 "
+    "onsite_exchange_scale  0.00000000E+000 c_mrsf -1.00000000E+000 "
+    "c_mrsf_oo -1.00000000E+000 response_global_hybrid F "
+    "global_hybrid_exchange F builtin_spin_constants F scc_mixer 2 "
+    "scc_history 12 scc_mixing  3.50000000E-001 scc_max_step "
+    " 1.00000000E+000 scc_tolerance  1.00000000E-008 max_scc_iterations "
+    "4000 response_solver 1 response_tolerance  1.00000000E-006 "
+    "response_max_iterations 50 response_max_subspace 100 zvector T\n"
+)
+
+
+def test_resolved_options_record_expands_preset_values():
+    trace = dftb_trace.parse_native_trace(RESOLVED_OPTIONS_TRACE)
+    options = trace["resolved_options"]
+
+    assert options["preset"] == "dtcam-tb"
+    assert options["lc_ground_state"] is True
+    assert options["spc_coco"] == 1.025
+    assert options["scc_mixer"] == 2
+    assert options["max_scc_iterations"] == 4000
+
+    text = dftb_trace.format_resolved_options(options)
+    assert "preset: dtcam-tb" in text
+    assert "erf kernel" in text
+    assert "0.3000 / 0.0000 / 0.0400" in text
+    assert "0.2625 / 0.0000 / 1.0125" in text
+    assert "1.0250 / 0.2500 / 0.2625" in text
+    assert "broyden" in text and "davidson" in text
+    assert "Analytic Z-vector gradient:     yes" in text
+
+
+def test_timing_footer_format():
+    text = dftb_trace.format_step_timing(0.012, 0.013, 0.5, 0.7)
+    assert "Step  CPU time (seconds):" in text
+    assert "Total CPU time (seconds):" in text
+    assert "0.013" in text and "0.700" in text
+
+
+def test_charge_block_lists_atoms_and_dipole():
+    text = dftb_trace.format_charge_block(
+        ["C", "H"], [-0.1, 0.1], [0.0, 0.2, 0.0],
+        "Mulliken atomic charges (SCC reference)")
+    assert "Mulliken atomic charges (SCC reference)" in text
+    assert "C" in text and "H" in text
+    assert "Sum" in text
+    assert "Debye" in text
+
+
+def test_unstructured_text_yields_no_tables():
+    trace = dftb_trace.parse_native_trace("hello world\nsome text\n")
+    assert not trace["scc_passes"]
+    assert not trace["davidson"]
+    assert trace["other"] == ["hello world", "some text"]

--- a/tests/test_openqp_dftb_abi1.py
+++ b/tests/test_openqp_dftb_abi1.py
@@ -390,6 +390,22 @@ class OpenQPDFTBABITests(unittest.TestCase):
         np.testing.assert_array_equal(result.mo_coefficients, np.eye(2))
         np.testing.assert_array_equal(result.response_vectors, [[0.7, 0.8]])
 
+    def test_abi1_skips_the_production_model_default(self):
+        # A C ABI v1 library cannot carry model presets, so the production
+        # default must be skipped (NOT materialized then rejected): legacy
+        # no-model inputs keep their explicit-keys meaning.
+        adapter, library = self._adapter_with_abi1()
+        adapter.mol.config["input"]["method"] = "dftb"
+
+        adapter._resolve_model_default()
+
+        self.assertEqual(adapter.dftb.get("model", ""), "")
+        self.assertEqual(adapter._preset_bytes, b"")
+        self.assertTrue(adapter.mol._dftb_model_default_resolved)
+        # And the ABI-v1 call still proceeds without a model limitation.
+        adapter._run_native("mrsf", 1, need_grad=False)
+        self.assertEqual(len(library.openqp_dftb_state_gradient.calls), 1)
+
     def test_abi1_rejects_post_v1_operator_knobs_before_call(self):
         adapter, library = self._adapter_with_abi1(
             dftb_updates={"c_mrsf_oo": 0.7, "response_omega": 0.21}

--- a/tests/test_openqp_dftb_abi1.py
+++ b/tests/test_openqp_dftb_abi1.py
@@ -40,6 +40,19 @@ def _load_adapter_module():
     state_labels.resolved_dftb_type = (
         lambda config: str(config.get("dftb", {}).get("type", "ground")).lower()
     )
+    state_labels.dftb_method_name = lambda config: "DFTB"
+    state_labels.public_state_label = (
+        lambda config, root, **kwargs: "state %d" % int(root)
+    )
+
+    trace_spec = importlib.util.spec_from_file_location(
+        "oqp.utils.dftb_trace",
+        ROOT / "pyoqp" / "oqp" / "utils" / "dftb_trace.py",
+    )
+    assert trace_spec is not None and trace_spec.loader is not None
+    dftb_trace = importlib.util.module_from_spec(trace_spec)
+    trace_spec.loader.exec_module(dftb_trace)
+    utils.dftb_trace = dftb_trace
 
     stubs = {
         "oqp": oqp,
@@ -48,6 +61,7 @@ def _load_adapter_module():
         "oqp.utils.constants": constants,
         "oqp.utils.file_utils": file_utils,
         "oqp.utils.state_labels": state_labels,
+        "oqp.utils.dftb_trace": dftb_trace,
     }
     saved = {name: sys.modules.get(name) for name in stubs}
     sys.modules.update(stubs)

--- a/tests/test_openqp_dftb_logging.py
+++ b/tests/test_openqp_dftb_logging.py
@@ -40,6 +40,15 @@ def _load_adapter(monkeypatch, calls):
     monkeypatch.setitem(sys.modules, labels_spec.name, labels)
     labels_spec.loader.exec_module(labels)
 
+    trace_path = ROOT / "pyoqp" / "oqp" / "utils" / "dftb_trace.py"
+    trace_spec = importlib.util.spec_from_file_location(
+        "oqp.utils.dftb_trace", trace_path
+    )
+    trace = importlib.util.module_from_spec(trace_spec)
+    monkeypatch.setitem(sys.modules, trace_spec.name, trace)
+    trace_spec.loader.exec_module(trace)
+    utils.dftb_trace = trace
+
     adapter_path = ROOT / "pyoqp" / "oqp" / "library" / "openqp_dftb.py"
     adapter_spec = importlib.util.spec_from_file_location(
         "_openqp_dftb_logging_under_test", adapter_path

--- a/tests/test_state_labels.py
+++ b/tests/test_state_labels.py
@@ -230,7 +230,8 @@ def test_conventional_tddftb_log_omits_inactive_sf_and_cam_controls():
     config = dftb_config("tddftb", nstate=3)
     text = state_labels.format_dftb_settings(config, backend="native")
 
-    assert "Response manifold:          closed-shell singlet TDA" in text
+    assert "Response manifold:" in text
+    assert "closed-shell singlet TDA" in text
     assert "Spin completion:" not in text
     assert "Gamma kernel / omega:" not in text
     assert "CAM alpha / beta:" not in text
@@ -251,11 +252,11 @@ def test_dftb_settings_are_grouped_and_report_resolved_paths():
         library_path="/site-packages/openqp_dftb/libopenqp_dftb_c.dylib",
     )
 
-    assert "DFTB calculation settings" in text
-    assert "DFTB SCC settings" in text
-    assert "DFTB response settings" in text
-    assert "DFTB gradient settings" in text
-    assert "DFTB operator settings" in text
+    assert "   Calculation\n" in text
+    assert "   SCC\n" in text
+    assert "   Response\n" in text
+    assert "   Gradient\n" in text
+    assert "   Operator\n" in text
     assert "MRSF-TDDFTB" in text
     assert "/parameters/OB2W0PT3" in text
     assert "trah (requested)" in text
@@ -275,8 +276,8 @@ def test_zero_capability_mask_never_claims_new_native_features():
         capabilities=0,
     )
 
-    assert "C API ABI:                  3" in text
-    assert "C API capabilities:         none advertised" in text
+    assert "C API ABI:" in text
+    assert "none advertised" in text
     assert "structured progress tracing" in text
     assert "loaded library (C ABI 3) does not advertise all-pair state spectrum" in text
     assert "loaded library (C ABI 3) does not advertise final trust-region SCC recovery" in text
@@ -296,8 +297,9 @@ def test_advertised_capabilities_enable_native_feature_summary():
     )
 
     assert "structured trace, state spectrum, SCC final trust recovery" in text
-    assert "Native progress trace:      level 1" in text
-    assert "State-to-state spectrum:    yes (unrelaxed TDA/state interaction)" in text
+    assert "Native progress trace:" in text
+    assert "level 1" in text
+    assert "yes (unrelaxed TDA/state interaction)" in text
     assert "final charge/spin trust-TRAH pass when eligible" in text
 
 
@@ -310,14 +312,16 @@ def test_probe_settings_do_not_advertise_native_trace_or_spectrum():
     )
 
     assert "Native progress trace:" not in text
-    assert "State-to-state spectrum:    requested; unavailable with probe backend" in text
-    assert "Failed-cycle recovery:      unavailable with probe backend" in text
+    assert "requested; unavailable with probe backend" in text
+    assert "Failed-cycle recovery:" in text
+    assert "unavailable with probe backend" in text
 
 
 def test_dftb_preset_log_does_not_claim_schema_defaults_are_effective():
     config = dftb_config("mrsf", td_type="mrsf", model="dtcam-tb")
     text = state_labels.format_dftb_settings(config, backend="native")
 
-    assert "dtcam-tb preset (resolved by openqp-dftb backend)" in text
+    assert "dtcam-tb preset" in text
+    assert "dtcam-tb (operator resolved by openqp-dftb backend)" in text
     assert "Mixer:" not in text
     assert "CAM alpha / beta:" not in text


### PR DESCRIPTION
## Motivation

DFTB logs were hard to read: raw machine-readable trace lines dumped verbatim, no SCC/Davidson/Z-vector iteration display, the state-to-state spectrum printed before the final energies, and no VEE/oscillator/dipole/charge information anywhere. openqp-dftb cannot append to the OpenQP log itself (the log unit belongs to liboqp), so its captured structured stdout is now parsed and rendered in the same style as the native SCF/Davidson/Z-vector sections.

## What's new (all in pyoqp; parser lives in `oqp/utils/dftb_trace.py`)

**Log layout** (energy stage → gradient stage, mirroring native OpenQP):
- Grouped settings table + a "DFTB effective options" section that renders the native `openqp_dftb_resolved_options` record — a named preset (e.g. `dtcam-tb`) is expanded to its actual published parameter vector without duplicating those values in Python.
- SCC iteration tables per pass (residual/charge/spin, TRAH step kind), final self-consistency line; energy-components block (H0/SCC/spin/LC-exchange → electronic; + repulsive → TOTAL); Mulliken charges + point-charge dipole (a.u./Debye). State-relaxed charges/dipole appear in the gradient section.
- Davidson iteration table; Z-vector solve with pair-space GMRES per-iteration residuals.
- Excited-state summary table (total E, VEE eV, ⟨S²⟩, transition-dipole X/Y/Z, |mu|, f) followed by the state-to-state transition table, printed at the END of the energy stage — i.e. BEFORE "Entering Gradient Calculation".
- Final Energy with one header line (VEE (eV) / |mu| / f); TDDFTB rows labeled S0..Sn (root 1 = S1; MRSF root 1 = S0 as before). Per-step CPU/wall + cumulative timing footers.

**Results JSON** (`save_mol`): `energies`, corrected scalar `energy` (the liboqp `mol_energy` struct is never populated on the DFTB path), `dftb_excited_states` (VEE, dipole components, f, transitions), `dftb_energy_components`, `dftb_resolved_options`, `dftb_mulliken`, `dftb_relaxed_mulliken`.

**Production model defaults** (materialized in `Molecule.get_config`): with no `model=` and no hand-tuned preset-locked key, MRSF-TDDFTB defaults to `model=dtcam-tb`; SF and open-shell ground default to `model=dftb+`; closed-shell routes (singlet ground, TD-DFTB) and DFTB0 stay preset-free because LC-DFTB2 exists only for the ROKS reference (the DFTB+ compatibility protocol, added in the paired openqp-dftb PR). `model=none` is the explicit opt-out; inputs that tune any locked key (e.g. erf-tuning scans) keep the explicit-keys route unchanged; DFTB0 and the probe backend stay preset-free.

## Compatibility

- Old openqp-dftb libraries without the capability mask fall back to the previous raw-capture dump; the spectrum parser accepts both the old (|mu| only) and new (x/y/z components) row formats.
- Per-iteration records exist only at native trace level 2, so the adapter always requests level 2 when progress is wanted; `[dftb] print_level` controls display (1 = tables, 2 = + raw diagnostics).
- Energies/gradients bit-identical for unchanged routes; the new defaults change which operator runs for bare no-model inputs by design (visible in the settings + effective-options sections).
- Pairs with Open-Quantum-Platform/openqp-dftb#19 (energy-components + resolved-options records, spectrum dipole components, `dftb+` preset).

## Tests

187 DFTB-related unit tests pass (`test_dftb_trace`, `test_state_labels`, `test_openqp_dftb_*`, `test_oqp_input`); verified end-to-end on MRSF gradient / MRSF energy / closed-shell TDDFTB / ground runs (butadiene DTCAM-TB values unchanged: S1 −10.20975554 Eh, VEE 6.951845 eV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
