### PR TITLE
DFTB: per-state major configurations (AE MRSF-style excitation analysis)

### DIFF
--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -721,6 +721,37 @@ class OpenQPDFTBAdapter:
         dump_log(self.mol, title=title, section="text",
                  info={"text": "\n\n".join(block for block in blocks if block)})
 
+    # Configurations below this |coefficient| stay out of the per-state
+    # excitation analysis (the native MRSF-TDDFT log uses the same cutoff).
+    _CONFIGURATION_COEFF_CUTOFF = 0.05
+
+    def _state_configurations(self, result, labels):
+        """Dominant SF/MRSF amplitudes per state, keyed by public label."""
+        vectors = result.response_vectors
+        noca, nocb, nbf = int(result.noca), int(result.nocb), int(result.nbf)
+        if vectors is None or noca <= 0 or nbf <= nocb:
+            return {}
+        if vectors.shape[0] != noca * (nbf - nocb):
+            return {}
+        configurations = {}
+        for position, label in enumerate(labels):
+            if position >= vectors.shape[1]:
+                break
+            column = vectors[:, position]
+            entries = []
+            for raw_index in np.nonzero(
+                    np.abs(column) >= self._CONFIGURATION_COEFF_CUTOFF)[0]:
+                index = int(raw_index) + 1
+                occ, vir = dftb_trace.spin_flip_pair(index, noca, nocb)
+                entries.append({
+                    "index": index,
+                    "coeff": float(column[raw_index]),
+                    "occ": occ,
+                    "vir": vir,
+                })
+            configurations[label] = entries
+        return configurations
+
     def _excited_state_summary(self, result):
         """Build the excited-state summary payload from one response solve."""
         method = self._resolved_method()
@@ -774,6 +805,10 @@ class OpenQPDFTBAdapter:
                 "oscillator": row["oscillator"],
             } for row in spectrum.get("rows", [])]
 
+        configurations = {}
+        if canonical in {"mrsf", "sf"}:
+            configurations = self._state_configurations(result, labels)
+
         return {
             "method": canonical,
             "state_labels": labels,
@@ -781,6 +816,7 @@ class OpenQPDFTBAdapter:
             "spin_squares": spins,
             "oscillator": oscillator,
             "transitions": transitions,
+            "configurations": configurations,
             "approximation": approximation,
             "reference_label": reference_label,
             "reference_energy": reference_energy,

--- a/pyoqp/oqp/utils/dftb_trace.py
+++ b/pyoqp/oqp/utils/dftb_trace.py
@@ -1017,6 +1017,47 @@ def final_energy_label(summary, index, default):
     return default
 
 
+def spin_flip_pair(index, noca, nocb):
+    """Map a 1-based spin-flip amplitude index to (occ, vir) MO numbers.
+
+    The exported SF/MRSF response vectors are ``amplitudes(noca, n_virt_beta)``
+    flattened column-major: index = (vir - nocb - 1) * noca + occ, with occ an
+    alpha-occupied MO (1..noca) and vir a beta-virtual MO (nocb+1..nbf).
+    """
+    position = int(index) - 1
+    return position % int(noca) + 1, int(nocb) + position // int(noca) + 1
+
+
+def format_state_configurations(summary):
+    """AE-style per-state dominant configurations (coeff, OCC -> VIR)."""
+    configurations = summary.get("configurations") or {}
+    if not any(configurations.values()):
+        return ""
+    labels = summary.get("state_labels") or []
+    energies = summary.get("state_energies") or []
+    spins = summary.get("spin_squares") or []
+    base = energies[0] if energies else None
+    lines = ["     Spin-adapted spin-flip excitations", ""]
+    for position, label in enumerate(labels):
+        entries = configurations.get(label)
+        if not entries:
+            continue
+        header = "   State %-6s" % label
+        if base is not None and position < len(energies):
+            header += "  VEE = %10.6f eV" % (
+                (energies[position] - base) * HARTREE_TO_EV)
+        if position < len(spins) and spins[position] is not None:
+            header += "     <S^2> = %7.4f" % spins[position]
+        lines.append(header)
+        lines.append("         #      Coeff        OCC       VIR")
+        lines.append("       ----   ---------     -----     -----")
+        for entry in entries:
+            lines.append("      %5d   %9.6f     %5d  ->  %4d" % (
+                entry["index"], entry["coeff"], entry["occ"], entry["vir"]))
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
 def format_excited_state_summary(summary):
     """The OpenQP-style excited-state summary + state-to-state tables.
 
@@ -1045,7 +1086,11 @@ def format_excited_state_summary(summary):
         text += "%11.4f" % (entry.get("oscillator") or 0.0)
         return text
 
-    lines = ["     Summary table", ""]
+    lines = []
+    configurations_text = format_state_configurations(summary)
+    if configurations_text:
+        lines.extend([configurations_text, ""])
+    lines.extend(["     Summary table", ""])
     lines.append("   State        Energy        Excitation   <S^2>"
                  "          Transition dipole (a.u.)        Oscillator")
     lines.append("                Hartree           eV               "

--- a/tests/test_dftb_trace.py
+++ b/tests/test_dftb_trace.py
@@ -306,6 +306,47 @@ def test_timing_footer_format():
     assert "0.013" in text and "0.700" in text
 
 
+def test_spin_flip_pair_mapping_is_column_major():
+    # amplitudes(noca, n_virt_beta) flattened column-major:
+    # index = (vir - nocb - 1) * noca + occ.
+    noca, nocb = 12, 10
+    assert dftb_trace.spin_flip_pair(1, noca, nocb) == (1, 11)
+    assert dftb_trace.spin_flip_pair(12, noca, nocb) == (12, 11)
+    assert dftb_trace.spin_flip_pair(13, noca, nocb) == (1, 12)
+    assert dftb_trace.spin_flip_pair(26, noca, nocb) == (2, 13)
+
+
+def test_state_configurations_render_before_summary_table():
+    summary = {
+        "method": "mrsf",
+        "state_labels": ["S0", "S1"],
+        "state_energies": [-10.4652311259, -10.2097555403],
+        "spin_squares": [0.009, 0.0],
+        "oscillator": {},
+        "transitions": [],
+        "configurations": {
+            "S0": [{"index": 131, "coeff": 0.981013, "occ": 11, "vir": 20}],
+            "S1": [
+                {"index": 11, "coeff": -0.171425, "occ": 11, "vir": 11},
+                {"index": 132, "coeff": 0.953585, "occ": 12, "vir": 20},
+            ],
+        },
+        "reference_energy": -10.0480223817,
+        "reference_label": "Reference: high-spin ROKS (internal)",
+    }
+    text = dftb_trace.format_excited_state_summary(summary)
+
+    assert "Spin-adapted spin-flip excitations" in text
+    assert text.index("Spin-adapted spin-flip excitations") \
+        < text.index("Summary table")
+    assert "0.981013" in text and "11  ->    20" in text
+    assert "-0.171425" in text
+    assert "<S^2> =" in text and "VEE =" in text
+    # States with no dominant configurations are simply omitted.
+    summary["configurations"] = {"S0": [], "S1": []}
+    assert "Spin-adapted" not in dftb_trace.format_excited_state_summary(summary)
+
+
 def test_charge_block_lists_atoms_and_dipole():
     text = dftb_trace.format_charge_block(
         ["C", "H"], [-0.1, 0.1], [0.0, 0.2, 0.0],


### PR DESCRIPTION
## What

Adds the native MRSF-TDDFT "Spin-adapted spin-flip excitations" analysis to the SF/MRSF-TDDFTB excited-states log: for every state, the dominant response amplitudes (|coeff| ≥ 0.05, the native cutoff) with their α-occupied → β-virtual MO pair, printed before the Summary table:

```
     Spin-adapted spin-flip excitations

   State S0      VEE =   0.000000 eV     <S^2> =  0.0087
         #      Coeff        OCC       VIR
       ----   ---------     -----     -----
         12    0.987370        12  ->    11
   State S1      VEE =   6.951845 eV     <S^2> =  0.0000
         11    0.700039        11  ->    11
         24   -0.700039        12  ->    12
```

The data comes from the response vectors the openqp-dftb C API already exports (`amplitudes(noca, n_virt_beta)`, column-major) — no ABI change. The block also rides along in the results JSON under `dftb_excited_states.configurations`. Closed-shell TD-DFTB does not export response vectors yet and simply omits the block.

## Verification

Butadiene DTCAM-TB reproduces the expected MRSF structure: S0 = closed-shell SOMO pairing (12→11, 0.987), S1 = open-shell singlet combination (11→11 / 12→12, ±0.700), S2 = HOMO−1→SOMO. 199 DFTB-related unit tests pass (adds index-mapping and rendering tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)