### PR TITLE
DFTB: MO printout and MO/state symmetry labels

### DIFF
--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ctypes
 from dataclasses import dataclass
+import itertools
 import os
 from pathlib import Path
 import shutil
@@ -477,15 +478,21 @@ class OpenQPDFTBAdapter:
         step_times = (time.process_time() - step_cpu_start,
                       time.perf_counter() - step_wall_start)
         charge_info = None
+        mo_info = None
         if status.value == 0:
             charge_info = self._stash_mulliken_charges(
                 method, state, need_grad,
                 np.frombuffer(relaxed_charges, dtype=np.float64)[:natom],
                 atoms,
             )
+            if not need_grad:
+                mo_info = self._stash_orbital_info(
+                    method, int(nbf_out.value), int(noca_out.value),
+                    int(nocb_out.value), mo_energies, mo_coefficients)
         if native_trace.strip():
             self._log_native_progress(method, state, need_grad, native_trace,
                                       charge_info=charge_info,
+                                      mo_info=mo_info,
                                       step_times=step_times)
         self._raise_native_status(
             method=method,
@@ -602,7 +609,7 @@ class OpenQPDFTBAdapter:
                      section="text", info={"text": text})
 
     def _log_native_progress(self, method, state, need_grad, native_trace,
-                             charge_info=None, step_times=None):
+                             charge_info=None, mo_info=None, step_times=None):
         """Render the captured native trace as OpenQP-style iteration tables.
 
         openqp-dftb cannot append to the OpenQP log itself (the log unit
@@ -658,6 +665,11 @@ class OpenQPDFTBAdapter:
                 scc_blocks.append(charge_block)
             if scc_blocks:
                 sections.append(("PyOQP: DFTB SCC steps", scc_blocks))
+            if mo_info is not None:
+                mo_text = dftb_trace.format_mo_table(mo_info)
+                if mo_text:
+                    sections.append(("PyOQP: DFTB molecular orbitals",
+                                     [mo_text]))
             response_blocks = [
                 dftb_trace.format_davidson_block(
                     solve, dftb_method_name(self.config))
@@ -725,6 +737,105 @@ class OpenQPDFTBAdapter:
     # excitation analysis (the native MRSF-TDDFT log uses the same cutoff).
     _CONFIGURATION_COEFF_CUTOFF = 0.05
 
+    def _dftb_shells(self, nbf):
+        """Reconstruct the minimal-SK shell list [(atom, l, pure)], or None.
+
+        The C API does not export the per-AO map, but the minimal valence
+        basis is deterministic per element (1 = s, 4 = s+p, 9 = s+p+d AOs)
+        and shells are stored per atom in ascending l.  The assignment is
+        accepted only when exactly ONE per-element size combination matches
+        the exported nbf; d elements are declined because the SK d-component
+        order has not been validated against the labeler's convention.
+        """
+        atoms = [int(z) for z in np.asarray(self.mol.get_atoms()).reshape(-1)]
+        elements = sorted(set(atoms))
+        counts = {z: atoms.count(z) for z in elements}
+        matches = [
+            dict(zip(elements, sizes))
+            for sizes in itertools.product((1, 4, 9), repeat=len(elements))
+            if sum(counts[z] * size for z, size in zip(elements, sizes)) == nbf
+        ]
+        if len(matches) != 1:
+            return None
+        assignment = matches[0]
+        if any(size == 9 for size in assignment.values()):
+            return None
+        shells = []
+        # The labeler indexes detection permutations with the shell's atom
+        # index directly, so atoms are 0-based here.
+        for atom_index, z in enumerate(atoms):
+            for l in range({1: 1, 4: 2}[assignment[z]]):
+                shells.append((atom_index, l, True))
+        return shells
+
+    def _mo_symmetry_labels(self, coefficients, nbf):
+        """Abelian irrep label per MO when symmetry labeling is active.
+
+        Reuses the geometry-based point-group detection and the metadata-only
+        irrep assigner of the native path.  The DFTB s/p AO component order
+        (y, z, x) matches the labeler's CCA m-ascending spherical convention,
+        and the AO overlap follows from the complete orthonormal MO set as
+        S = (C C^T)^-1.  Any failure returns None (labeling is optional).
+        """
+        meta = getattr(self.mol, "symmetry_metadata", None) or {}
+        if not meta or meta.get("status", "disabled") == "disabled":
+            return None
+        if not meta.get("label_mo", True):
+            return None
+        detection = meta.get("detection")
+        if not detection:
+            return None
+        shells = self._dftb_shells(nbf)
+        if shells is None:
+            return None
+        try:
+            from oqp.library.symmetry import assign_mo_irreps  # noqa: PLC0415
+
+            overlap = np.linalg.inv(coefficients @ coefficients.T)
+            tolerance = max(float(meta.get("tolerance", 1.0e-5)), 1.0e-4)
+            result = assign_mo_irreps(
+                coefficients, overlap, shells,
+                detection["operations"], detection["character_table"],
+                tolerance=tolerance,
+                matrix_key="matrix_input_frame",
+            )
+            meta.setdefault("mo_labels", {})["dftb"] = result
+            labels = list(result.get("labels", []))
+            return labels or None
+        except Exception as exc:
+            # Metadata only: record why labeling was skipped, never fail.
+            meta.setdefault("mo_labels", {})["dftb"] = {
+                "status": "error", "error": str(exc),
+            }
+            return None
+
+    def _stash_orbital_info(self, method, nbf, noca, nocb,
+                            mo_energies, mo_coefficients):
+        """Record MO energies/occupations (+irrep labels) for log and JSON."""
+        if nbf <= 0:
+            return None
+        energies = np.frombuffer(mo_energies, dtype=np.float64)[:nbf].copy()
+        coefficients = np.frombuffer(
+            mo_coefficients, dtype=np.float64)[: nbf * nbf].reshape(
+            (nbf, nbf), order="F").copy()
+        occupations = [2 if index <= nocb else (1 if index <= noca else 0)
+                       for index in range(1, nbf + 1)]
+        labels = self._mo_symmetry_labels(coefficients, nbf)
+        if canonical_dftb_type(method) in {"sf", "mrsf"}:
+            reference = "high-spin ROKS reference"
+        else:
+            reference = "SCC reference"
+        mo_info = {
+            "reference": reference,
+            "energies": [float(value) for value in energies],
+            "occupations": occupations,
+            "labels": labels,
+            "noca": int(noca),
+            "nocb": int(nocb),
+        }
+        self.mol.dftb_mo = mo_info
+        return mo_info
+
     def _state_configurations(self, result, labels):
         """Dominant SF/MRSF amplitudes per state, keyed by public label."""
         vectors = result.response_vectors
@@ -751,6 +862,39 @@ class OpenQPDFTBAdapter:
                 })
             configurations[label] = entries
         return configurations
+
+    def _state_irreps(self, configurations, mo_labels, noca, nocb):
+        """State irrep from the dominant configuration (abelian groups).
+
+        The SF/MRSF CSF is the reference determinant with one alpha-occupied
+        electron moved to a beta-virtual orbital, so its irrep is the product
+        of the reference irrep (the singly occupied orbitals) with the hole
+        and particle irreps.  Metadata only; any failure returns {}.
+        """
+        meta = getattr(self.mol, "symmetry_metadata", None) or {}
+        detection = meta.get("detection")
+        if not detection:
+            return {}
+        try:
+            from oqp.library.symmetry import product_irrep  # noqa: PLC0415
+
+            table = detection["character_table"]
+            somos = [mo_labels[index - 1]
+                     for index in range(int(nocb) + 1, int(noca) + 1)]
+            reference = product_irrep(somos, table) if somos else None
+            irreps = {}
+            for label, entries in configurations.items():
+                if not entries:
+                    continue
+                dominant = max(entries, key=lambda entry: abs(entry["coeff"]))
+                factors = [mo_labels[dominant["occ"] - 1],
+                           mo_labels[dominant["vir"] - 1]]
+                if reference:
+                    factors.append(reference)
+                irreps[label] = product_irrep(factors, table)
+            return irreps
+        except Exception:
+            return {}
 
     def _excited_state_summary(self, result):
         """Build the excited-state summary payload from one response solve."""
@@ -808,6 +952,11 @@ class OpenQPDFTBAdapter:
         configurations = {}
         if canonical in {"mrsf", "sf"}:
             configurations = self._state_configurations(result, labels)
+        state_irreps = {}
+        mo_labels = (getattr(self.mol, "dftb_mo", None) or {}).get("labels")
+        if configurations and mo_labels:
+            state_irreps = self._state_irreps(
+                configurations, mo_labels, result.noca, result.nocb)
 
         return {
             "method": canonical,
@@ -817,6 +966,7 @@ class OpenQPDFTBAdapter:
             "oscillator": oscillator,
             "transitions": transitions,
             "configurations": configurations,
+            "state_irreps": state_irreps,
             "approximation": approximation,
             "reference_label": reference_label,
             "reference_energy": reference_energy,

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -1406,7 +1406,7 @@ class Molecule:
                     energies, dtype=float).ravel().tolist()
                 data['energy'] = data['energies'][0]
             for key in ('dftb_excited_states', 'dftb_energy_components',
-                        'dftb_resolved_options',
+                        'dftb_resolved_options', 'dftb_mo',
                         'dftb_mulliken', 'dftb_relaxed_mulliken'):
                 value = getattr(self, key, None)
                 if value:

--- a/pyoqp/oqp/utils/dftb_trace.py
+++ b/pyoqp/oqp/utils/dftb_trace.py
@@ -1017,6 +1017,59 @@ def final_energy_label(summary, index, default):
     return default
 
 
+def _display_irrep(irrep):
+    """Human display form of an irrep label ('ag' -> 'Ag'; 'mixed' as-is)."""
+    text = str(irrep or "")
+    if not text or text in {"mixed", "?"}:
+        return text
+    return text[:1].upper() + text[1:]
+
+
+def format_mo_table(mo):
+    """Molecular-orbital table: index, occupation, energies, irrep, markers."""
+    energies = mo.get("energies") or []
+    if not len(energies):
+        return ""
+    occupations = mo.get("occupations") or []
+    labels = mo.get("labels") or []
+    noca = int(mo.get("noca") or 0)
+    nocb = int(mo.get("nocb") or 0)
+    has_labels = bool(labels)
+    lines = ["   Molecular orbitals (%s)"
+             % mo.get("reference", "SCC reference")]
+    rule = "   " + "-" * (60 if has_labels else 50)
+    lines.append(rule)
+    header = "      MO   Occ      Energy (Ha)     Energy (eV)"
+    if has_labels:
+        header += "     Irrep"
+    lines.append(header)
+    lines.append(rule)
+    open_shell = noca > nocb
+    for index, energy in enumerate(energies, start=1):
+        occupation = (occupations[index - 1]
+                      if index - 1 < len(occupations) else 0)
+        row = "   %5d   %3d   %14.8f   %12.4f" % (
+            index, int(occupation), energy, energy * HARTREE_TO_EV)
+        if has_labels:
+            label = labels[index - 1] if index - 1 < len(labels) else ""
+            row += "   %7s" % _display_irrep(label)
+        if open_shell:
+            if nocb < index <= noca:
+                row += "   (SOMO)"
+            elif index == nocb and nocb > 0:
+                row += "   (HOMO)"
+            elif index == noca + 1:
+                row += "   (LUMO)"
+        else:
+            if index == noca and noca > 0:
+                row += "   (HOMO)"
+            elif index == noca + 1:
+                row += "   (LUMO)"
+        lines.append(row)
+    lines.append(rule)
+    return "\n".join(lines)
+
+
 def spin_flip_pair(index, noca, nocb):
     """Map a 1-based spin-flip amplitude index to (occ, vir) MO numbers.
 
@@ -1036,6 +1089,7 @@ def format_state_configurations(summary):
     labels = summary.get("state_labels") or []
     energies = summary.get("state_energies") or []
     spins = summary.get("spin_squares") or []
+    state_irreps = summary.get("state_irreps") or {}
     base = energies[0] if energies else None
     lines = ["     Spin-adapted spin-flip excitations", ""]
     for position, label in enumerate(labels):
@@ -1048,6 +1102,8 @@ def format_state_configurations(summary):
                 (energies[position] - base) * HARTREE_TO_EV)
         if position < len(spins) and spins[position] is not None:
             header += "     <S^2> = %7.4f" % spins[position]
+        if state_irreps.get(label):
+            header += "     Sym = %s" % _display_irrep(state_irreps[label])
         lines.append(header)
         lines.append("         #      Coeff        OCC       VIR")
         lines.append("       ----   ---------     -----     -----")
@@ -1090,17 +1146,19 @@ def format_excited_state_summary(summary):
     configurations_text = format_state_configurations(summary)
     if configurations_text:
         lines.extend([configurations_text, ""])
+    state_irreps = summary.get("state_irreps") or {}
     lines.extend(["     Summary table", ""])
-    lines.append("   State        Energy        Excitation   <S^2>"
+    lines.append("   State   Sym       Energy        Excitation   <S^2>"
                  "          Transition dipole (a.u.)        Oscillator")
-    lines.append("                Hartree           eV               "
+    lines.append("                     Hartree           eV               "
                  "      X          Y          Z       Abs.    strength")
-    rule = "   " + "-" * 100
+    rule = "   " + "-" * 108
     lines.append(rule)
     base = energies[0] if len(energies) else None
     for position, label in enumerate(labels):
         energy = energies[position] if position < len(energies) else None
-        row = "   %-6s" % label
+        row = "   %-6s%-8s" % (
+            label, _display_irrep(state_irreps.get(label, "")))
         row += ("%18.10f" % energy) if energy is not None else " " * 18
         if energy is not None and base is not None:
             row += "%12.6f" % ((energy - base) * HARTREE_TO_EV)

--- a/tests/test_dftb_trace.py
+++ b/tests/test_dftb_trace.py
@@ -347,6 +347,56 @@ def test_state_configurations_render_before_summary_table():
     assert "Spin-adapted" not in dftb_trace.format_excited_state_summary(summary)
 
 
+def test_mo_table_shows_occupations_labels_and_markers():
+    mo = {
+        "reference": "high-spin ROKS reference",
+        "energies": [-0.9, -0.5, -0.4, -0.3, -0.1],
+        "occupations": [2, 2, 1, 1, 0],
+        "labels": ["ag", "bu", "au", "bg", "ag"],
+        "noca": 4,
+        "nocb": 2,
+    }
+    text = dftb_trace.format_mo_table(mo)
+
+    assert "Molecular orbitals (high-spin ROKS reference)" in text
+    assert "Irrep" in text
+    lines = text.splitlines()
+    assert any("(SOMO)" in line and "Au" in line for line in lines)
+    assert any("(SOMO)" in line and "Bg" in line for line in lines)
+    assert any("(HOMO)" in line and "Bu" in line for line in lines)
+    assert any("(LUMO)" in line for line in lines)
+
+    # Without labels the Irrep column disappears but the table still renders.
+    mo["labels"] = None
+    text = dftb_trace.format_mo_table(mo)
+    assert "Irrep" not in text and "(SOMO)" in text
+
+
+def test_state_irreps_appear_in_headers_and_summary():
+    summary = {
+        "method": "mrsf",
+        "state_labels": ["S0", "S1"],
+        "state_energies": [-10.4, -10.2],
+        "spin_squares": [0.0, 0.0],
+        "oscillator": {},
+        "transitions": [],
+        "configurations": {
+            "S0": [{"index": 1, "coeff": 0.99, "occ": 12, "vir": 11}],
+            "S1": [{"index": 2, "coeff": 0.70, "occ": 11, "vir": 11}],
+        },
+        "state_irreps": {"S0": "ag", "S1": "bu"},
+        "reference_energy": -10.0,
+        "reference_label": "Reference: high-spin ROKS (internal)",
+    }
+    text = dftb_trace.format_excited_state_summary(summary)
+
+    assert "Sym = Ag" in text
+    assert "Sym = Bu" in text
+    summary_rows = [line for line in text.splitlines()
+                    if line.strip().startswith("S1")]
+    assert summary_rows and "Bu" in summary_rows[-1]
+
+
 def test_charge_block_lists_atoms_and_dipole():
     text = dftb_trace.format_charge_block(
         ["C", "H"], [-0.1, 0.1], [0.0, 0.2, 0.0],


### PR DESCRIPTION
## What

1. **MO table** after the SCC section for every DFTB run (MO energies come from the existing C API export): index, occupation (ROKS 2/1/0), energy in Ha and eV, HOMO/SOMO/LUMO markers.
2. **Symmetry labels** when `[symmetry] enabled=true`: MO irreps and per-state symmetry, reusing the metadata-only labeling machinery of the native path. DFTB-specific inputs:
   - minimal-SK shell list reconstructed from per-element basis sizes (accepted only when the size assignment matching nbf is unique; d elements declined until the SK d-component order is validated against the labeler),
   - AO overlap from the complete orthonormal MO set, S = (C Cᵀ)⁻¹ (no ABI change),
   - the DFTB s/p AO component order (p stored y, z, x) is exactly the labeler's CCA m-ascending spherical convention.
   State irreps follow from the dominant configuration: Γ(state) = Γ(ref, SOMO product) ⊗ Γ(hole) ⊗ Γ(particle). Shown in the configurations headers, a new `Sym` column of the Summary table, and the results JSON (`dftb_mo`, `dftb_excited_states.state_irreps`).

```
      MO   Occ      Energy (Ha)     Energy (eV)     Irrep
      10     2      -0.28465611        -7.7459        Ag   (HOMO)
      11     1      -0.22349861        -6.0817        Bg   (SOMO)
      12     1      -0.02634099        -0.7168        Au   (SOMO)
      13     0       0.13125809         3.5717        Bg   (LUMO)

   State S1      VEE =   6.951845 eV     <S^2> =  0.0000     Sym = Bu
```

## Verification

Planar butadiene (C2h) reproduces textbook symmetry: σ orbitals ag/bu, π ladder au < bg(SOMO) < au(SOMO) < bg, S0 = Ag (totally symmetric — a strong internal consistency check of the reference⊗hole⊗particle product), S1 = Bu (the bright ππ*), S2 = Au. Runs without `[symmetry]` are unchanged (table without the Irrep column); labeling failures are recorded under `symmetry_metadata['mo_labels']['dftb']` and never affect the run. 201 DFTB-related unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)