### PR TITLE
Modernize readable .oqp input

### DIFF
--- a/examples/DFT/H2O_RHF-DFT_ENERGY.oqp
+++ b/examples/DFT/H2O_RHF-DFT_ENERGY.oqp
@@ -1,1 +1,6 @@
-rks/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy guess(type=huckel) scf(pscreen=true) dftgrid(rad_type=becke)
+rks/bhhlyp/6-31g*
+energy
+guess(type=huckel)
+scf(pscreen=true)
+dftgrid(rad_type=becke)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/DFT/H2O_RHF-DFT_GRADIENT.oqp
+++ b/examples/DFT/H2O_RHF-DFT_GRADIENT.oqp
@@ -1,1 +1,5 @@
-rks/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 grad(S0) guess(type=huckel) dftgrid(rad_type=becke)
+rks/bhhlyp/6-31g*
+grad
+guess(type=huckel)
+dftgrid(rad_type=becke)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/DFT/H2O_ROHF-DFT_ENERGY.oqp
+++ b/examples/DFT/H2O_ROHF-DFT_ENERGY.oqp
@@ -1,1 +1,6 @@
-roks/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 energy guess(type=huckel) dftgrid(rad_type=becke)
+roks/bhhlyp/6-31g*
+mult=3
+energy
+guess(type=huckel)
+dftgrid(rad_type=becke)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/DFT/H2O_ROHF-DFT_GRADIENT.oqp
+++ b/examples/DFT/H2O_ROHF-DFT_GRADIENT.oqp
@@ -1,1 +1,6 @@
-roks/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 grad(S0) guess(type=huckel) dftgrid(rad_type=becke)
+roks/bhhlyp/6-31g*
+mult=3
+grad
+guess(type=huckel)
+dftgrid(rad_type=becke)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/DFT/H2O_UHF-DFT_ENERGY.oqp
+++ b/examples/DFT/H2O_UHF-DFT_ENERGY.oqp
@@ -1,1 +1,7 @@
-uks/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 energy guess(type=huckel) scf(stability=true) dftgrid(rad_type=becke)
+uks/bhhlyp/6-31g*
+mult=3
+energy
+guess(type=huckel)
+scf(stability=true)
+dftgrid(rad_type=becke)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/DFT/H2O_UHF-DFT_GRADIENT.oqp
+++ b/examples/DFT/H2O_UHF-DFT_GRADIENT.oqp
@@ -1,1 +1,7 @@
-uks/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 grad(S0) guess(type=huckel) scf(stability=true) dftgrid(rad_type=becke)
+uks/bhhlyp/6-31g*
+mult=3
+grad
+guess(type=huckel)
+scf(stability=true)
+dftgrid(rad_type=becke)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/DFTB/C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.inp
+++ b/examples/DFTB/C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.inp
@@ -29,7 +29,6 @@ nstate=3
 [dftb]
 backend=native
 type=mrsf
-parameter_path=
 lc_ground_state=true
 lc_gamma=erf
 omega=0.25

--- a/examples/DFTB/C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.oqp
+++ b/examples/DFTB/C2_LC-MRSF-TDDFTB_ERF-TUNED_ENERGY.oqp
@@ -1,1 +1,5 @@
-mrsf-tddftb(nstate=3) geom="../geometries/C2-d0affeda5215.xyz" charge=0 energy(S0) guess(type=huckel) dftb(backend=native,parameter_path="",lc_ground_state=true,lc_gamma=erf,omega=0.25,cam_beta=1.2,scc_mixer=trust)
+mrsf-tddftb(nstate=3)
+energy(S0)
+guess(type=huckel)
+dftb(lc_ground_state=true,lc_gamma=erf,omega=0.25,cam_beta=1.2,scc_mixer=trust)
+geom="../geometries/C2-d0affeda5215.xyz"

--- a/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.inp
+++ b/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.inp
@@ -38,7 +38,6 @@ nstate=3
 [dftb]
 backend=native
 type=mrsf
-parameter_path=
 
 [properties]
 grad=1

--- a/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.oqp
+++ b/examples/DFTB/H2CH2_MRSF-TDDFTB_GRADIENT.oqp
@@ -1,1 +1,4 @@
-mrsf-tddftb(nstate=3) geom="../geometries/CH2-e41258125cee.xyz" charge=0 grad(S0) guess(type=huckel) dftb(backend=native,parameter_path="")
+mrsf-tddftb(nstate=3)
+grad(S0)
+guess(type=huckel)
+geom="../geometries/CH2-e41258125cee.xyz"

--- a/examples/DTCAM-TB/BUTADIENE_DTCAMTB_ENERGY.oqp
+++ b/examples/DTCAM-TB/BUTADIENE_DTCAMTB_ENERGY.oqp
@@ -1,1 +1,4 @@
-mrsf-tddftb(nstate=3) geom="../geometries/C4H6-e783f4d884c7.xyz" charge=0 energy(S0) dftb(model=dtcam-tb,parameter_path="")
+mrsf-tddftb(nstate=3)
+energy(S0)
+dftb(model=dtcam-tb)
+geom="../geometries/C4H6-e783f4d884c7.xyz"

--- a/examples/DTCAM-TB/BUTADIENE_DTCAMTB_EXPLICIT_ENERGY.oqp
+++ b/examples/DTCAM-TB/BUTADIENE_DTCAMTB_EXPLICIT_ENERGY.oqp
@@ -1,1 +1,4 @@
-mrsf-tddftb(nstate=3) geom="../geometries/C4H6-e783f4d884c7.xyz" charge=0 energy(S0) dftb(parameter_path="",lc_ground_state=true,lc_gamma=erf,omega=0.3,cam_alpha=0.0,cam_beta=0.04,w_scale=1.0,response_w_scale=0.6375,response_omega=0.2625,response_cam_alpha=0.0,response_cam_beta=1.0125,spc_coco=1.025,spc_ovov=0.25,spc_coov=0.2625,onsite_pp=-0.0125,scc_mixer=broyden,scc_mixing=0.35,scc_history=12,scc_max_step=1.0,scc_tolerance=1e-08,max_scc_iterations=4000,response_solver=davidson)
+mrsf-tddftb(nstate=3)
+energy(S0)
+dftb(lc_ground_state=true,lc_gamma=erf,omega=0.3,cam_alpha=0.0,cam_beta=0.04,w_scale=1.0,response_w_scale=0.6375,response_omega=0.2625,response_cam_alpha=0.0,response_cam_beta=1.0125,spc_coco=1.025,spc_ovov=0.25,spc_coov=0.2625,onsite_pp=-0.0125,scc_mixer=broyden,scc_mixing=0.35,scc_history=12,scc_max_step=1.0,scc_tolerance=1e-08,max_scc_iterations=4000,response_solver=davidson)
+geom="../geometries/C4H6-e783f4d884c7.xyz"

--- a/examples/DTCAM-TB/BUTADIENE_DTCAMTB_S1_GRADIENT.oqp
+++ b/examples/DTCAM-TB/BUTADIENE_DTCAMTB_S1_GRADIENT.oqp
@@ -1,1 +1,4 @@
-mrsf-tddftb(nstate=3) geom="../geometries/C4H6-e783f4d884c7.xyz" charge=0 grad(S1) dftb(model=dtcam-tb,parameter_path="")
+mrsf-tddftb(nstate=3)
+grad(S1)
+dftb(model=dtcam-tb)
+geom="../geometries/C4H6-e783f4d884c7.xyz"

--- a/examples/DTCAM-TB/BUTADIENE_DTCAMTB_S1_OPTIMIZE.oqp
+++ b/examples/DTCAM-TB/BUTADIENE_DTCAMTB_S1_OPTIMIZE.oqp
@@ -1,1 +1,4 @@
-mrsf-tddftb(nstate=3) geom="../geometries/C4H6-e783f4d884c7.xyz" charge=0 opt(S1,maxit=100) dftb(model=dtcam-tb,parameter_path="")
+mrsf-tddftb(nstate=3)
+opt(S1,maxit=100)
+dftb(model=dtcam-tb)
+geom="../geometries/C4H6-e783f4d884c7.xyz"

--- a/examples/DTCAM-TB/ETHYLENE_DTCAMTB_S1S0_MECI.oqp
+++ b/examples/DTCAM-TB/ETHYLENE_DTCAMTB_S1S0_MECI.oqp
@@ -1,1 +1,4 @@
-mrsf-tddftb(nstate=3) geom="../geometries/C2H4-25af03d76164.xyz" charge=0 meci(S0,S1,algorithm=baeka,gap=0.0001,maxit=30) dftb(model=dtcam-tb,parameter_path="")
+mrsf-tddftb(nstate=3)
+meci(S0,S1,algorithm=baeka,gap=0.0001,maxit=30)
+dftb(model=dtcam-tb)
+geom="../geometries/C2H4-25af03d76164.xyz"

--- a/examples/ECP/C2H4_BHHLYP-MRSFTDDFT_Energy.oqp
+++ b/examples/ECP/C2H4_BHHLYP-MRSFTDDFT_Energy.oqp
@@ -1,1 +1,15 @@
-mrsf(nstate=10)/bhhlyp/library geom="C    1.6062782722   1.5141391221  -1.8538091464  c1\nC    1.8295756914   2.1530602256  -2.9302391911  c2\nH    0.7846511041   1.8564598303  -1.2260835006  h1\nH    2.0658311171   0.5858648490  -1.5523155830  h1\nH    1.3961209467   3.0492511400  -3.1437367515  h2\nH    2.3877626192   1.8783782433  -3.7562666130  h1" charge=0 library="c1 6-31g\nc2 cc-pvdz\nh1 6-31g*\nh2 3-21g" energy(S0) guess(type=huckel,save_mol=false) scf(maxit=30,save_molden=false,conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-10)
+mrsf(nstate=10)/bhhlyp/library
+library="c1 6-31g\nc2 cc-pvdz\nh1 6-31g*\nh2 3-21g"
+energy(S0)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,save_molden=false,conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-10)
+geom="""
+C    1.6062782722   1.5141391221  -1.8538091464  c1
+C    1.8295756914   2.1530602256  -2.9302391911  c2
+H    0.7846511041   1.8564598303  -1.2260835006  h1
+H    2.0658311171   0.5858648490  -1.5523155830  h1
+H    1.3961209467   3.0492511400  -3.1437367515  h2
+H    2.3877626192   1.8783782433  -3.7562666130  h1
+"""

--- a/examples/ECP/C2H4_BHHLYP-MRSFTDDFT_Grad.oqp
+++ b/examples/ECP/C2H4_BHHLYP-MRSFTDDFT_Grad.oqp
@@ -1,1 +1,15 @@
-mrsf(nstate=10)/bhhlyp/library geom="C    1.6062782722   1.5141391221  -1.8538091464  c1\nC    1.8295756914   2.1530602256  -2.9302391911  c2\nH    0.7846511041   1.8564598303  -1.2260835006  h1\nH    2.0658311171   0.5858648490  -1.5523155830  h1\nH    1.3961209467   3.0492511400  -3.1437367515  h2\nH    2.3877626192   1.8783782433  -3.7562666130  h1" charge=0 library="c1 6-31g\nc2 cc-pvdz\nh1 6-31g*\nh2 3-21g" grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,save_molden=false,conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-10)
+mrsf(nstate=10)/bhhlyp/library
+library="c1 6-31g\nc2 cc-pvdz\nh1 6-31g*\nh2 3-21g"
+grad(S0)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,save_molden=false,conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-10)
+geom="""
+C    1.6062782722   1.5141391221  -1.8538091464  c1
+C    1.8295756914   2.1530602256  -2.9302391911  c2
+H    0.7846511041   1.8564598303  -1.2260835006  h1
+H    2.0658311171   0.5858648490  -1.5523155830  h1
+H    1.3961209467   3.0492511400  -3.1437367515  h2
+H    2.3877626192   1.8783782433  -3.7562666130  h1
+"""

--- a/examples/ECP/Custom_Basis-Set/C2H4_Custom_Basis-Set-MRSFTDDFT_Energy.oqp
+++ b/examples/ECP/Custom_Basis-Set/C2H4_Custom_Basis-Set-MRSFTDDFT_Energy.oqp
@@ -1,1 +1,7 @@
-mrsf(nstate=10)/bhhlyp/file:custom_basis-set.json geom="../../geometries/C2H4-c7ec226122c3.xyz" charge=0 energy(S0) guess(type=huckel,save_mol=false) scf(maxit=30,save_molden=false,conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-10)
+mrsf(nstate=10)/bhhlyp/file:custom_basis-set.json
+energy(S0)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,save_molden=false,conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-10)
+geom="../../geometries/C2H4-c7ec226122c3.xyz"

--- a/examples/ECP/HBr_BHHLYP-MRSFTDDFT_ENERGY.oqp
+++ b/examples/ECP/HBr_BHHLYP-MRSFTDDFT_ENERGY.oqp
@@ -1,1 +1,4 @@
-mrsf(nstate=3)/bhhlyp/lanl2dz geom="../geometries/BrH-a6a9d6f6a6f3.xyz" charge=0 energy(S0) guess(type=huckel,save_mol=false)
+mrsf(nstate=3)/bhhlyp/lanl2dz
+energy(S0)
+guess(type=huckel,save_mol=false)
+geom="../geometries/BrH-a6a9d6f6a6f3.xyz"

--- a/examples/ECP/HBr_RHF-DFT_ENERGY.oqp
+++ b/examples/ECP/HBr_RHF-DFT_ENERGY.oqp
@@ -1,1 +1,5 @@
-rks/bhhlyp/aug-cc-pvdz-pp;aug-cc-pvdz geom="../geometries/BrH-a6a9d6f6a6f3.xyz" charge=0 mult=1 energy guess(type=huckel,save_mol=false) dftgrid(rad_type=becke)
+rks/bhhlyp/aug-cc-pvdz-pp;aug-cc-pvdz
+energy
+guess(type=huckel,save_mol=false)
+dftgrid(rad_type=becke)
+geom="../geometries/BrH-a6a9d6f6a6f3.xyz"

--- a/examples/ECP/HBr_RHF-DFT_GRADIENT.oqp
+++ b/examples/ECP/HBr_RHF-DFT_GRADIENT.oqp
@@ -1,1 +1,5 @@
-rks/bhhlyp/lanl2dz geom="../geometries/BrH-a6a9d6f6a6f3.xyz" charge=0 mult=1 grad(S0) guess(type=huckel,save_mol=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/bhhlyp/lanl2dz
+grad
+guess(type=huckel,save_mol=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/BrH-a6a9d6f6a6f3.xyz"

--- a/examples/ECP/Mg_RHF-DFT_ENERGY.oqp
+++ b/examples/ECP/Mg_RHF-DFT_ENERGY.oqp
@@ -1,1 +1,5 @@
-rhf/lanl2dz geom="../geometries/Mg-21a9b71503dd.xyz" charge=0 mult=1 energy guess(type=huckel,save_mol=true) dftgrid(rad_type=becke)
+rhf/lanl2dz
+energy
+guess(type=huckel,save_mol=true)
+dftgrid(rad_type=becke)
+geom="../geometries/Mg-21a9b71503dd.xyz"

--- a/examples/ECP/NaCl_BHHLYP-MRSFTDDFT_ENERGY.oqp
+++ b/examples/ECP/NaCl_BHHLYP-MRSFTDDFT_ENERGY.oqp
@@ -1,1 +1,6 @@
-mrsf(nstate=10)/bhhlyp/lanl2dz geom="../geometries/ClNa-0ed89ad56c59.xyz" charge=0 energy(S0) guess(type=huckel,save_mol=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-10)
+mrsf(nstate=10)/bhhlyp/lanl2dz
+energy(S0)
+guess(type=huckel,save_mol=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-10)
+geom="../geometries/ClNa-0ed89ad56c59.xyz"

--- a/examples/ECP/NaCl_RHF-DFT_GRADIENT.oqp
+++ b/examples/ECP/NaCl_RHF-DFT_GRADIENT.oqp
@@ -1,1 +1,5 @@
-rks/bhhlyp/lanl2dz geom="../geometries/ClNa-0ed89ad56c59.xyz" charge=0 mult=1 grad(S0) guess(type=huckel,save_mol=false) dftgrid(rad_type=becke)
+rks/bhhlyp/lanl2dz
+grad
+guess(type=huckel,save_mol=false)
+dftgrid(rad_type=becke)
+geom="../geometries/ClNa-0ed89ad56c59.xyz"

--- a/examples/HESS/H2O_BHHLYP-MRSFTDDFT_NUM_HESS.oqp
+++ b/examples/HESS/H2O_BHHLYP-MRSFTDDFT_NUM_HESS.oqp
@@ -1,1 +1,3 @@
-mrsf(nstate=2)/bhhlyp/6-31g* geom="../geometries/H2O-781cba5cd72b.xyz" charge=0 hess(S0,clean=true)
+mrsf(nstate=2)/bhhlyp/6-31g*
+hess(S0,clean=true)
+geom="../geometries/H2O-781cba5cd72b.xyz"

--- a/examples/HESS/H2O_RHF-DFT_ANA_HESS.oqp
+++ b/examples/HESS/H2O_RHF-DFT_ANA_HESS.oqp
@@ -1,1 +1,3 @@
-rks/bhhlyp/6-31g* geom="../geometries/H2O-781cba5cd72b.xyz" charge=0 mult=1 hess(S0,type=analytical,clean=true)
+rks/bhhlyp/6-31g*
+hess(S0,type=analytical,clean=true)
+geom="../geometries/H2O-781cba5cd72b.xyz"

--- a/examples/HESS/H2O_RHF-DFT_NUM_HESS.oqp
+++ b/examples/HESS/H2O_RHF-DFT_NUM_HESS.oqp
@@ -1,1 +1,3 @@
-rks/bhhlyp/6-31g* geom="../geometries/H2O-781cba5cd72b.xyz" charge=0 mult=1 hess(S0,clean=true)
+rks/bhhlyp/6-31g*
+hess(S0,clean=true)
+geom="../geometries/H2O-781cba5cd72b.xyz"

--- a/examples/HF/H2O_RHF-HF_ENERGY.oqp
+++ b/examples/HF/H2O_RHF-HF_ENERGY.oqp
@@ -1,1 +1,4 @@
-rhf/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy guess(type=huckel)
+rhf/6-31g*
+energy
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/HF/H2O_RHF-HF_GRADIENT.oqp
+++ b/examples/HF/H2O_RHF-HF_GRADIENT.oqp
@@ -1,1 +1,4 @@
-rhf/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 grad(S0) guess(type=huckel)
+rhf/6-31g*
+grad
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/HF/H2O_ROHF-HF_ENERGY.oqp
+++ b/examples/HF/H2O_ROHF-HF_ENERGY.oqp
@@ -1,1 +1,5 @@
-rohf/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 energy guess(type=huckel)
+rohf/6-31g*
+mult=3
+energy
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/HF/H2O_ROHF-HF_GRADIENT.oqp
+++ b/examples/HF/H2O_ROHF-HF_GRADIENT.oqp
@@ -1,1 +1,5 @@
-rohf/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 grad(S0) guess(type=huckel)
+rohf/6-31g*
+mult=3
+grad
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/HF/H2O_UHF-HF_ENERGY.oqp
+++ b/examples/HF/H2O_UHF-HF_ENERGY.oqp
@@ -1,1 +1,6 @@
-uhf/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 energy guess(type=huckel) scf(stability=true)
+uhf/6-31g*
+mult=3
+energy
+guess(type=huckel)
+scf(stability=true)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/HF/H2O_UHF-HF_GRADIENT.oqp
+++ b/examples/HF/H2O_UHF-HF_GRADIENT.oqp
@@ -1,1 +1,6 @@
-uhf/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 grad(S0) guess(type=huckel) scf(stability=true)
+uhf/6-31g*
+mult=3
+grad
+guess(type=huckel)
+scf(stability=true)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/ISPHER/H2O_BHHLYP-MRSFTDDFT_GRADIENT_F_SHELL_ISPHER.oqp
+++ b/examples/ISPHER/H2O_BHHLYP-MRSFTDDFT_GRADIENT_F_SHELL_ISPHER.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=3)/bhhlyp/cc-pvtz geom="../geometries/H2O-0381125c86f2.xyz" charge=0 ispher=true grad(S2) guess(type=huckel,save_mol=false) scf(conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(conv=1e-08,zvconv=1e-08)
+mrsf(nstate=3)/bhhlyp/cc-pvtz
+ispher=true
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/ISPHER/H2O_BHHLYP-MRSFTDDFT_GRADIENT_ISPHER.oqp
+++ b/examples/ISPHER/H2O_BHHLYP-MRSFTDDFT_GRADIENT_ISPHER.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=3)/bhhlyp/cc-pvdz geom="../geometries/H2O-0381125c86f2.xyz" charge=0 ispher=true grad(S2) guess(type=huckel,save_mol=false) scf(conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(conv=1e-08,zvconv=1e-08)
+mrsf(nstate=3)/bhhlyp/cc-pvdz
+ispher=true
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/ISPHER/H2O_RHF-BHHLYP_ANALYTIC_HESSIAN_ISPHER.oqp
+++ b/examples/ISPHER/H2O_RHF-BHHLYP_ANALYTIC_HESSIAN_ISPHER.oqp
@@ -1,1 +1,7 @@
-rks/bhhlyp/cc-pvdz geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 ispher=true hess(S0,type=analytical,clean=true) guess(type=huckel,save_mol=false) scf(conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/bhhlyp/cc-pvdz
+ispher=true
+hess(S0,type=analytical,clean=true)
+guess(type=huckel,save_mol=false)
+scf(conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/ISPHER/H2O_ROHF-MRSF-EKT_EA_ISPHER.oqp
+++ b/examples/ISPHER/H2O_ROHF-MRSF-EKT_EA_ISPHER.oqp
@@ -1,1 +1,9 @@
-mrsf(nstate=10)/bhhlyp/cc-pvdz geom="../geometries/H2O-0381125c86f2.xyz" charge=0 ispher=true d4=false ekt(ip=false,ea=true) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/bhhlyp/cc-pvdz
+ispher=true
+d4=false
+ekt(ip=false,ea=true)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/ISPHER/H2O_ROHF-MRSF-EKT_IP_ISPHER.oqp
+++ b/examples/ISPHER/H2O_ROHF-MRSF-EKT_IP_ISPHER.oqp
@@ -1,1 +1,9 @@
-mrsf(nstate=10)/bhhlyp/cc-pvdz geom="../geometries/H2O-0381125c86f2.xyz" charge=0 ispher=true d4=false ekt(ip=true,ea=false) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/bhhlyp/cc-pvdz
+ispher=true
+d4=false
+ekt(ip=true,ea=false)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/ISPHER/HBr_RHF-BHHLYP_ECP_GRADIENT_ISPHER.oqp
+++ b/examples/ISPHER/HBr_RHF-BHHLYP_ECP_GRADIENT_ISPHER.oqp
@@ -1,1 +1,7 @@
-rks/bhhlyp/lanl2dz geom="../geometries/BrH-a6a9d6f6a6f3.xyz" charge=0 mult=1 ispher=true grad(S0) guess(type=huckel,save_mol=false) scf(conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/bhhlyp/lanl2dz
+ispher=true
+grad
+guess(type=huckel,save_mol=false)
+scf(conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/BrH-a6a9d6f6a6f3.xyz"

--- a/examples/MP2/h2o_ump2_6-31g.oqp
+++ b/examples/MP2/h2o_ump2_6-31g.oqp
@@ -1,1 +1,5 @@
-mp2(reference=uhf)/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy guess(type=huckel,save_mol=false) scf(maxit=50,conv=1e-10,save_molden=false)
+mp2(reference=uhf)/6-31g
+energy
+guess(type=huckel,save_mol=false)
+scf(maxit=50,conv=1e-10,save_molden=false)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/MRSF-TDDFT/H2O_BHHLYP-MRSFTDDFT_ENERGY.oqp
+++ b/examples/MRSF-TDDFT/H2O_BHHLYP-MRSFTDDFT_ENERGY.oqp
@@ -1,1 +1,4 @@
-mrsf(nstate=3)/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 energy(S0) guess(type=huckel)
+mrsf(nstate=3)/bhhlyp/6-31g*
+energy(S0)
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/MRSF-TDDFT/H2O_BHHLYP-MRSFTDDFT_GRADIENT.oqp
+++ b/examples/MRSF-TDDFT/H2O_BHHLYP-MRSFTDDFT_GRADIENT.oqp
@@ -1,1 +1,4 @@
-mrsf(nstate=3)/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 grad(S2) guess(type=huckel)
+mrsf(nstate=3)/bhhlyp/6-31g*
+grad(S2)
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/NMR/CH3_ROHF-DFT-PBE0-GIAO-NMR.oqp
+++ b/examples/NMR/CH3_ROHF-DFT-PBE0-GIAO-NMR.oqp
@@ -1,1 +1,7 @@
-roks/pbe0/sto-3g geom="../geometries/CH3-0b060bed6a1d.xyz" charge=0 mult=2 energy guess(type=huckel) dftgrid(rad_type=mhl,rad_npts=99,ang_npts=302) properties(scf_prop=nmr,nmr_gauge=giao)
+roks/pbe0/sto-3g
+mult=2
+energy
+guess(type=huckel)
+dftgrid(rad_type=mhl,rad_npts=99,ang_npts=302)
+properties(scf_prop=nmr,nmr_gauge=giao)
+geom="../geometries/CH3-0b060bed6a1d.xyz"

--- a/examples/NMR/CH3_ROHF-GIAO-NMR.oqp
+++ b/examples/NMR/CH3_ROHF-GIAO-NMR.oqp
@@ -1,1 +1,6 @@
-rohf/sto-3g geom="../geometries/CH3-0b060bed6a1d.xyz" charge=0 mult=2 energy guess(type=huckel) properties(scf_prop=nmr,nmr_gauge=giao)
+rohf/sto-3g
+mult=2
+energy
+guess(type=huckel)
+properties(scf_prop=nmr,nmr_gauge=giao)
+geom="../geometries/CH3-0b060bed6a1d.xyz"

--- a/examples/NMR/CH3_UHF-DFT-PBE0-GIAO-NMR.oqp
+++ b/examples/NMR/CH3_UHF-DFT-PBE0-GIAO-NMR.oqp
@@ -1,1 +1,7 @@
-uks/pbe0/sto-3g geom="../geometries/CH3-0b060bed6a1d.xyz" charge=0 mult=2 energy guess(type=huckel) dftgrid(rad_type=mhl,rad_npts=99,ang_npts=302) properties(scf_prop=nmr,nmr_gauge=giao)
+uks/pbe0/sto-3g
+mult=2
+energy
+guess(type=huckel)
+dftgrid(rad_type=mhl,rad_npts=99,ang_npts=302)
+properties(scf_prop=nmr,nmr_gauge=giao)
+geom="../geometries/CH3-0b060bed6a1d.xyz"

--- a/examples/NMR/CH3_UHF-GIAO-NMR.oqp
+++ b/examples/NMR/CH3_UHF-GIAO-NMR.oqp
@@ -1,1 +1,6 @@
-uhf/sto-3g geom="../geometries/CH3-0b060bed6a1d.xyz" charge=0 mult=2 energy guess(type=huckel) properties(scf_prop=nmr,nmr_gauge=giao)
+uhf/sto-3g
+mult=2
+energy
+guess(type=huckel)
+properties(scf_prop=nmr,nmr_gauge=giao)
+geom="../geometries/CH3-0b060bed6a1d.xyz"

--- a/examples/NMR/H2O_RHF-DFT-PBE0-GIAO-NMR.oqp
+++ b/examples/NMR/H2O_RHF-DFT-PBE0-GIAO-NMR.oqp
@@ -1,1 +1,6 @@
-rks/pbe0/sto-3g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy guess(type=huckel) dftgrid(rad_type=mhl,rad_npts=99,ang_npts=302) properties(scf_prop=nmr,nmr_gauge=giao)
+rks/pbe0/sto-3g
+energy
+guess(type=huckel)
+dftgrid(rad_type=mhl,rad_npts=99,ang_npts=302)
+properties(scf_prop=nmr,nmr_gauge=giao)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/NMR/H2O_RHF-GIAO-NMR.oqp
+++ b/examples/NMR/H2O_RHF-GIAO-NMR.oqp
@@ -1,1 +1,5 @@
-rhf/sto-3g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy guess(type=huckel) properties(scf_prop=nmr,nmr_gauge=giao)
+rhf/sto-3g
+energy
+guess(type=huckel)
+properties(scf_prop=nmr,nmr_gauge=giao)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/NMR/H2O_RHF-NMR.oqp
+++ b/examples/NMR/H2O_RHF-NMR.oqp
@@ -1,1 +1,5 @@
-rhf/sto-3g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy guess(type=huckel) properties(scf_prop=nmr)
+rhf/sto-3g
+energy
+guess(type=huckel)
+properties(scf_prop=nmr)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_BAEKA_OQP.oqp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_BAEKA_OQP.oqp
@@ -1,1 +1,5 @@
-mrsf(nstate=5)/bhhlyp/6-31g* geom="../geometries/C2H4-41911fceceb6.xyz" charge=0 meci(S0,S1,S2,maxit=1,algorithm=baeka,sigma=1.0,alpha=0.02,delta_beta=0.025,beta_schedule="10,10,25,25,100,100,1000,1000,3000",gap=0.0001,energy_shift=1e-06,rmsd_grad=0.002,coordsys=auto,trust=0.15,trust_max=0.5) scf(maxit=30) tdhf(maxit=30)
+mrsf(nstate=5)/bhhlyp/6-31g*
+meci(S0,S1,S2,maxit=1,algorithm=baeka,sigma=1.0,alpha=0.02,delta_beta=0.025,beta_schedule="10,10,25,25,100,100,1000,1000,3000",gap=0.0001,energy_shift=1e-06,rmsd_grad=0.002,coordsys=auto,trust=0.15,trust_max=0.5)
+scf(maxit=30)
+tdhf(maxit=30)
+geom="../geometries/C2H4-41911fceceb6.xyz"

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECI.oqp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECI.oqp
@@ -1,1 +1,5 @@
-mrsf(nstate=5)/bhhlyp/6-31g* geom="../geometries/C2H4-41911fceceb6.xyz" charge=0 meci(S0,S1,maxit=1,energy_shift=1,gap=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1) scf(maxit=30) tdhf(maxit=30)
+mrsf(nstate=5)/bhhlyp/6-31g*
+meci(S0,S1,maxit=1,energy_shift=1,gap=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1)
+scf(maxit=30)
+tdhf(maxit=30)
+geom="../geometries/C2H4-41911fceceb6.xyz"

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECP_OQP.oqp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECP_OQP.oqp
@@ -1,1 +1,5 @@
-mrsf(nstate=5)/bhhlyp/6-31g* geom="../geometries/C2H4-41911fceceb6.xyz" charge=0 mecp(S0,T0,maxit=2,energy_shift=1,energy_gap=0.0001,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=tric,trust=0.1,trust_max=0.3) scf(maxit=30) tdhf(maxit=30)
+mrsf(nstate=5)/bhhlyp/6-31g*
+mecp(S0,T0,maxit=2,energy_shift=1,energy_gap=0.0001,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=tric,trust=0.1,trust_max=0.3)
+scf(maxit=30)
+tdhf(maxit=30)
+geom="../geometries/C2H4-41911fceceb6.xyz"

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MEP.oqp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MEP.oqp
@@ -1,1 +1,5 @@
-mrsf(nstate=5)/bhhlyp/6-31g* geom="../geometries/C2H4-5ec6cdbfac9d.xyz" charge=0 mep(S1,maxit=2,step=0.1,gtol=0.003) scf(maxit=30) tdhf(maxit=30)
+mrsf(nstate=5)/bhhlyp/6-31g*
+mep(S1,maxit=2,step=0.1,gtol=0.003)
+scf(maxit=30)
+tdhf(maxit=30)
+geom="../geometries/C2H4-5ec6cdbfac9d.xyz"

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_TCI_OQP.oqp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_TCI_OQP.oqp
@@ -1,1 +1,5 @@
-mrsf(nstate=5)/bhhlyp/6-31g* geom="../geometries/C2H4-41911fceceb6.xyz" charge=0 tci(S0,S1,S2,maxit=1,pen_sigma=2.0,pen_incre=1.2,energy_gap=0.002,rmsd_grad=0.002,max_grad=0.004,rmsd_step=0.004,max_step=0.008,coordsys=auto,trust=0.15) scf(maxit=30) tdhf(maxit=30)
+mrsf(nstate=5)/bhhlyp/6-31g*
+tci(S0,S1,S2,maxit=1,pen_sigma=2.0,pen_incre=1.2,energy_gap=0.002,rmsd_grad=0.002,max_grad=0.004,rmsd_step=0.004,max_step=0.008,coordsys=auto,trust=0.15)
+scf(maxit=30)
+tdhf(maxit=30)
+geom="../geometries/C2H4-41911fceceb6.xyz"

--- a/examples/OPT/H2O_BHHLYP-MRSFTDDFT_OPTIMIZE.oqp
+++ b/examples/OPT/H2O_BHHLYP-MRSFTDDFT_OPTIMIZE.oqp
@@ -1,1 +1,4 @@
-mrsf(nstate=2)/bhhlyp/6-31g* geom="../geometries/H2O-781cba5cd72b.xyz" charge=0 opt(S0,maxit=1,energy_shift=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1) tdhf(maxit=30)
+mrsf(nstate=2)/bhhlyp/6-31g*
+opt(S0,maxit=1,energy_shift=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1)
+tdhf(maxit=30)
+geom="../geometries/H2O-781cba5cd72b.xyz"

--- a/examples/OPT/H2O_RHF-DFT_OPTIMIZE.oqp
+++ b/examples/OPT/H2O_RHF-DFT_OPTIMIZE.oqp
@@ -1,1 +1,3 @@
-rks/bhhlyp/6-31g* geom="../geometries/H2O-781cba5cd72b.xyz" charge=0 mult=1 opt(S0,maxit=1)
+rks/bhhlyp/6-31g*
+opt(maxit=1)
+geom="../geometries/H2O-781cba5cd72b.xyz"

--- a/examples/OPT/H2O_RHF-DFT_OPTIMIZE_OQP.oqp
+++ b/examples/OPT/H2O_RHF-DFT_OPTIMIZE_OQP.oqp
@@ -1,1 +1,3 @@
-rks/bhhlyp/6-31g* geom="../geometries/H2O-781cba5cd72b.xyz" charge=0 mult=1 opt(S0,maxit=10,coordsys=tric,trust=0.2)
+rks/bhhlyp/6-31g*
+opt(maxit=10,coordsys=tric,trust=0.2)
+geom="../geometries/H2O-781cba5cd72b.xyz"

--- a/examples/OPT/HCN_BHHLYP-MRSFTDDFT_TS_OQP.oqp
+++ b/examples/OPT/HCN_BHHLYP-MRSFTDDFT_TS_OQP.oqp
@@ -1,1 +1,5 @@
-mrsf(nstate=2)/bhhlyp/3-21g geom="../geometries/CHN-d957be87de22.xyz" charge=0 ts(S0,maxit=2,energy_shift=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=dlc,trust=0.05,trust_max=0.1,hessian=model) scf(maxit=30) tdhf(maxit=30)
+mrsf(nstate=2)/bhhlyp/3-21g
+ts(S0,maxit=2,energy_shift=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=dlc,trust=0.05,trust_max=0.1,hessian=model)
+scf(maxit=30)
+tdhf(maxit=30)
+geom="../geometries/CHN-d957be87de22.xyz"

--- a/examples/OPT/HCN_RHF-DFT_CONSTRAINED_OQP.oqp
+++ b/examples/OPT/HCN_RHF-DFT_CONSTRAINED_OQP.oqp
@@ -1,1 +1,4 @@
-rks/bhhlyp/3-21g geom="../geometries/CHN-d957be87de22.xyz" charge=0 mult=1 opt(S0,maxit=3,energy_shift=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=dlc,trust=0.05,trust_max=0.05,freeze="distance(1,2)") scf(maxit=30)
+rks/bhhlyp/3-21g
+opt(maxit=3,energy_shift=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=dlc,trust=0.05,trust_max=0.05,freeze="distance(1,2)")
+scf(maxit=30)
+geom="../geometries/CHN-d957be87de22.xyz"

--- a/examples/OPT/HCN_RHF-DFT_IRC_OQP.oqp
+++ b/examples/OPT/HCN_RHF-DFT_IRC_OQP.oqp
@@ -1,1 +1,3 @@
-rks/bhhlyp/6-31g* geom="../geometries/CHN-825a4a518dc8.xyz" charge=0 mult=1 irc(S0,maxit=10,step=0.15,direction=forward,hessian=analytical)
+rks/bhhlyp/6-31g*
+irc(S0,maxit=10,step=0.15,direction=forward,hessian=analytical)
+geom="../geometries/CHN-825a4a518dc8.xyz"

--- a/examples/OPT/HCN_RHF-DFT_NEB_OQP.oqp
+++ b/examples/OPT/HCN_RHF-DFT_NEB_OQP.oqp
@@ -1,1 +1,3 @@
-rks/bhhlyp/6-31g* geom="../geometries/CHN-682f5d7d753a.xyz" charge=0 mult=1 neb(S0,maxit=10,product="HCN_RHF-DFT_NEB_OQP_product.xyz",nimage=7,spring=0.1,climb=true,fmax=0.005)
+rks/bhhlyp/6-31g*
+neb(S0,maxit=10,product="HCN_RHF-DFT_NEB_OQP_product.xyz",nimage=7,spring=0.1,climb=true,fmax=0.005)
+geom="../geometries/CHN-682f5d7d753a.xyz"

--- a/examples/OPT/HCN_RHF-DFT_TS_OQP.oqp
+++ b/examples/OPT/HCN_RHF-DFT_TS_OQP.oqp
@@ -1,1 +1,4 @@
-rks/bhhlyp/3-21g geom="../geometries/CHN-d957be87de22.xyz" charge=0 mult=1 ts(S0,maxit=2,energy_shift=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=dlc,trust=0.05,trust_max=0.1,hessian=model) scf(maxit=30)
+rks/bhhlyp/3-21g
+ts(S0,maxit=2,energy_shift=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=dlc,trust=0.05,trust_max=0.1,hessian=model)
+scf(maxit=30)
+geom="../geometries/CHN-d957be87de22.xyz"

--- a/examples/PCM/H2O_RHF-HF_DDPCM_ENERGY_ISPHER.oqp
+++ b/examples/PCM/H2O_RHF-HF_DDPCM_ENERGY_ISPHER.oqp
@@ -1,1 +1,7 @@
-rhf/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 ispher=true energy guess(type=huckel,save_mol=false) pcm(enabled=true,backend=ddx,mode=reference_scf,model=ddpcm,epsilon=78.3553) scf(conv=1e-06)
+rhf/6-31g*
+ispher=true
+energy
+guess(type=huckel,save_mol=false)
+pcm(enabled=true,backend=ddx,mode=reference_scf,model=ddpcm,epsilon=78.3553)
+scf(conv=1e-06)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/PCM/OH_ROHF-HF_DDPCM_ENERGY.oqp
+++ b/examples/PCM/OH_ROHF-HF_DDPCM_ENERGY.oqp
@@ -1,1 +1,7 @@
-rohf/6-31g* geom="../geometries/HO-0e90d87efea2.xyz" charge=0 mult=2 energy guess(type=huckel,save_mol=false) pcm(enabled=true,backend=ddx,mode=reference_scf,model=ddpcm,epsilon=78.3553) scf(conv=1e-06)
+rohf/6-31g*
+mult=2
+energy
+guess(type=huckel,save_mol=false)
+pcm(enabled=true,backend=ddx,mode=reference_scf,model=ddpcm,epsilon=78.3553)
+scf(conv=1e-06)
+geom="../geometries/HO-0e90d87efea2.xyz"

--- a/examples/PERF/H2O_DFT_perf1.oqp
+++ b/examples/PERF/H2O_DFT_perf1.oqp
@@ -1,1 +1,6 @@
-rks/b3lypv5/6-31g* geom="../geometries/H2O-95fa99c614ed.xyz" charge=0 mult=1 perf=1 energy guess(type=huckel) scf(maxit=100,conv=1e-06)
+rks/b3lypv5/6-31g*
+perf=1
+energy
+guess(type=huckel)
+scf(maxit=100,conv=1e-06)
+geom="../geometries/H2O-95fa99c614ed.xyz"

--- a/examples/PERF/H2O_MRSF_perf1.oqp
+++ b/examples/PERF/H2O_MRSF_perf1.oqp
@@ -1,1 +1,6 @@
-mrsf(nstate=3)/bhhlyp/cc-pvdz geom="../geometries/H2O-95fa99c614ed.xyz" charge=0 perf=1 energy(S0) guess(type=huckel) scf(conv=1e-08,maxit=100)
+mrsf(nstate=3)/bhhlyp/cc-pvdz
+perf=1
+energy(S0)
+guess(type=huckel)
+scf(conv=1e-08,maxit=100)
+geom="../geometries/H2O-95fa99c614ed.xyz"

--- a/examples/PERF/H2O_MRSF_perf2_override.oqp
+++ b/examples/PERF/H2O_MRSF_perf2_override.oqp
@@ -1,1 +1,7 @@
-mrsf(nstate=2)/bhhlyp/cc-pvdz geom="../geometries/H2O-95fa99c614ed.xyz" charge=0 perf=2 grad(S0) guess(type=huckel) scf(conv=1e-09,maxit=100,xc_c2f=off) tdhf(zvconv=1e-10,resp_cutoff=5e-11)
+mrsf(nstate=2)/bhhlyp/cc-pvdz
+perf=2
+grad(S0)
+guess(type=huckel)
+scf(conv=1e-09,maxit=100,xc_c2f=off)
+tdhf(zvconv=1e-10,resp_cutoff=5e-11)
+geom="../geometries/H2O-95fa99c614ed.xyz"

--- a/examples/PROP/H2O_BHHLYP_PROPERTIES.oqp
+++ b/examples/PROP/H2O_BHHLYP_PROPERTIES.oqp
@@ -1,1 +1,6 @@
-rks/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy guess(type=huckel) dftgrid(rad_type=becke) properties(scf_prop="el_mom,mulliken,lowdin,resp")
+rks/bhhlyp/6-31g*
+energy
+guess(type=huckel)
+dftgrid(rad_type=becke)
+properties(scf_prop="el_mom,mulliken,lowdin,resp")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/PROP/H2O_CATION_UHF_PROPERTIES.oqp
+++ b/examples/PROP/H2O_CATION_UHF_PROPERTIES.oqp
@@ -1,1 +1,7 @@
-uhf/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=1 mult=2 energy guess(type=huckel) properties(scf_prop="el_mom,mulliken,lowdin,resp")
+uhf/6-31g*
+charge=1
+mult=2
+energy
+guess(type=huckel)
+properties(scf_prop="el_mom,mulliken,lowdin,resp")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/PROP/H2O_RHF_PROPERTIES.oqp
+++ b/examples/PROP/H2O_RHF_PROPERTIES.oqp
@@ -1,1 +1,5 @@
-rhf/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy guess(type=huckel) properties(scf_prop="el_mom,mulliken,lowdin,resp")
+rhf/6-31g*
+energy
+guess(type=huckel)
+properties(scf_prop="el_mom,mulliken,lowdin,resp")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/QMMM/2E4E_RHF-DFT-QMMM_energy.oqp
+++ b/examples/QMMM/2E4E_RHF-DFT-QMMM_energy.oqp
@@ -1,1 +1,7 @@
-rks/bhhlyp/6-31gs geom="2E4E.pdb 1 2 5 6 7 8 9 3 4 10 22 11 23" charge=1 mult=1 qmmm_flag=true energy guess(type=huckel) dftgrid(rad_type=becke)
+rks/bhhlyp/6-31gs
+charge=1
+qmmm_flag=true
+energy
+guess(type=huckel)
+dftgrid(rad_type=becke)
+geom="2E4E.pdb 1 2 5 6 7 8 9 3 4 10 22 11 23"

--- a/examples/QMMM/H2CO-water_BHHLYP-MRSF-NAMD-QMMM.oqp
+++ b/examples/QMMM/H2CO-water_BHHLYP-MRSF-NAMD-QMMM.oqp
@@ -1,1 +1,5 @@
-mrsf(nstate=2)/bhhlyp/6-31g* geom="../geometries/CH2O-2bc62dda4b8a.xyz" charge=0 namd(T0,nstep=1,dt=0.5,substep=50,init_temp=300,velocity=maxwell,seed=3,decoherence=edc,trivial=true,soc=false) guess(type=huckel) qmmm(pdb_file="formaldehyde_water.pdb",forcefield_files="formaldehyde.xml tip3p.xml",qm_atoms="0-3",cutoff=NoCutoff,embedding=electrostatic)
+mrsf(nstate=2)/bhhlyp/6-31g*
+namd(T0,nstep=1,dt=0.5,substep=50,init_temp=300,velocity=maxwell,seed=3,decoherence=edc,trivial=true,soc=false)
+guess(type=huckel)
+qmmm(pdb_file="formaldehyde_water.pdb",forcefield_files="formaldehyde.xml tip3p.xml",qm_atoms="0-3",cutoff=NoCutoff,embedding=electrostatic)
+geom="../geometries/CH2O-2bc62dda4b8a.xyz"

--- a/examples/QMMM/H2CO-water_BHHLYP-SOC-NAMD-QMMM.oqp
+++ b/examples/QMMM/H2CO-water_BHHLYP-SOC-NAMD-QMMM.oqp
@@ -1,1 +1,5 @@
-mrsf(nstate=2)/bhhlyp/6-31g* geom="../geometries/CH2O-2bc62dda4b8a.xyz" charge=0 namd(active=5,nstep=1,dt=0.25,substep=50,init_temp=300,velocity=maxwell,seed=3,decoherence=edc,trivial=true,soc=true,thrshe=0.1) guess(type=huckel) qmmm(pdb_file="formaldehyde_water.pdb",forcefield_files="formaldehyde.xml tip3p.xml",qm_atoms="0-3",cutoff=NoCutoff,embedding=electrostatic)
+mrsf(nstate=2)/bhhlyp/6-31g*
+namd(active=5,nstep=1,dt=0.25,substep=50,init_temp=300,velocity=maxwell,seed=3,decoherence=edc,trivial=true,soc=true,thrshe=0.1)
+guess(type=huckel)
+qmmm(pdb_file="formaldehyde_water.pdb",forcefield_files="formaldehyde.xml tip3p.xml",qm_atoms="0-3",cutoff=NoCutoff,embedding=electrostatic)
+geom="../geometries/CH2O-2bc62dda4b8a.xyz"

--- a/examples/QMMM/ala-dipeptide_BHHLYP-QMMM-MD-RCD.oqp
+++ b/examples/QMMM/ala-dipeptide_BHHLYP-QMMM-MD-RCD.oqp
@@ -1,1 +1,4 @@
-rks/bhhlyp/6-31g geom="ala.pdb" charge=0 mult=1 md(S0) qmmm(pdb_file="ala.pdb",forcefield_files="amber14-all.xml",qm_atoms="8,9,16,17,18",cutoff=NoCutoff,embedding=electrostatic,frontier_scheme=rcd,n_steps=2,timestep=0.5,ensemble=nve,temperature=300.0)
+rks/bhhlyp/6-31g
+md(S0)
+qmmm(pdb_file="ala.pdb",forcefield_files="amber14-all.xml",qm_atoms="8,9,16,17,18",cutoff=NoCutoff,embedding=electrostatic,frontier_scheme=rcd,n_steps=2,timestep=0.5,ensemble=nve,temperature=300.0)
+geom="ala.pdb"

--- a/examples/QMMM/ala.oqp
+++ b/examples/QMMM/ala.oqp
@@ -1,1 +1,6 @@
-rks/bhhlyp/6-31gs geom="ala.pdb 9 10 17 18 19" charge=0 mult=1 qmmm_flag=true energy guess(type=huckel) dftgrid(rad_type=becke)
+rks/bhhlyp/6-31gs
+qmmm_flag=true
+energy
+guess(type=huckel)
+dftgrid(rad_type=becke)
+geom="ala.pdb 9 10 17 18 19"

--- a/examples/QMMM/run.oqp
+++ b/examples/QMMM/run.oqp
@@ -1,1 +1,5 @@
-rks/bhhlyp/6-31g geom="water_dimer.pdb" charge=0 mult=1 md(S0) scf(maxit=100) qmmm(pdb_file="water_dimer.pdb",forcefield_files="tip3p.xml",qm_atoms="0-2",cutoff=PME,embedding=electrostatic,n_steps=1000,timestep=0.1,temperature=300.0)
+rks/bhhlyp/6-31g
+md(S0)
+scf(maxit=100)
+qmmm(pdb_file="water_dimer.pdb",forcefield_files="tip3p.xml",qm_atoms="0-2",cutoff=PME,embedding=electrostatic,n_steps=1000,timestep=0.1,temperature=300.0)
+geom="water_dimer.pdb"

--- a/examples/QUANTUM/h2.oqp
+++ b/examples/QUANTUM/h2.oqp
@@ -1,1 +1,4 @@
-rhf/sto-3g geom="../geometries/H2-069e977a383f.xyz" charge=0 mult=1 energy guess(type=huckel)
+rhf/sto-3g
+energy
+guess(type=huckel)
+geom="../geometries/H2-069e977a383f.xyz"

--- a/examples/SCF/h2o_rhf_6-31g_pbe_adiis.oqp
+++ b/examples/SCF/h2o_rhf_6-31g_pbe_adiis.oqp
@@ -1,1 +1,7 @@
-rks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=adiis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=adiis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rhf_6-31g_pbe_basic.oqp
+++ b/examples/SCF/h2o_rhf_6-31g_pbe_basic.oqp
@@ -1,1 +1,7 @@
-rks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=cdiis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=cdiis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rhf_6-31g_pbe_diis-reset.oqp
+++ b/examples/SCF/h2o_rhf_6-31g_pbe_diis-reset.oqp
@@ -1,1 +1,7 @@
-rks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_reset_mod=5,diis_reset_conv=0.005,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_reset_mod=5,diis_reset_conv=0.005,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rhf_6-31g_pbe_ediis.oqp
+++ b/examples/SCF/h2o_rhf_6-31g_pbe_ediis.oqp
@@ -1,1 +1,7 @@
-rks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=200,maxdiis=7,diis_type=ediis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=200,maxdiis=7,diis_type=ediis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rhf_6-31g_pbe_mom.oqp
+++ b/examples/SCF/h2o_rhf_6-31g_pbe_mom.oqp
@@ -1,1 +1,7 @@
-rks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,mom=true,mom_switch=0.003,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,mom=true,mom_switch=0.003,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rhf_6-31g_pbe_pfon.oqp
+++ b/examples/SCF/h2o_rhf_6-31g_pbe_pfon.oqp
@@ -1,1 +1,7 @@
-rks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,pfon=true,pfon_start_temp=2000.0,pfon_cooling_rate=50.0,pfon_nsmear=5.0,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,pfon=true,pfon_start_temp=2000.0,pfon_cooling_rate=50.0,pfon_nsmear=5.0,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rhf_6-31g_pbe_soscf.oqp
+++ b/examples/SCF/h2o_rhf_6-31g_pbe_soscf.oqp
@@ -1,1 +1,7 @@
-rks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(converger_type=soscf,maxit=60,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(converger_type=soscf,maxit=60,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rhf_6-31g_pbe_vdiis.oqp
+++ b/examples/SCF/h2o_rhf_6-31g_pbe_vdiis.oqp
@@ -1,1 +1,7 @@
-rks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=vdiis,cdiis_switch=0.3,vdiis_vshift_switch=0.003,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=vdiis,cdiis_switch=0.3,vdiis_vshift_switch=0.003,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rohf_6-31g_pbe_adiis.oqp
+++ b/examples/SCF/h2o_rohf_6-31g_pbe_adiis.oqp
@@ -1,1 +1,8 @@
-roks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=adiis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=adiis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rohf_6-31g_pbe_basic.oqp
+++ b/examples/SCF/h2o_rohf_6-31g_pbe_basic.oqp
@@ -1,1 +1,8 @@
-roks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=cdiis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=cdiis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rohf_6-31g_pbe_diis-reset.oqp
+++ b/examples/SCF/h2o_rohf_6-31g_pbe_diis-reset.oqp
@@ -1,1 +1,8 @@
-roks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_reset_mod=5,diis_reset_conv=0.005,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_reset_mod=5,diis_reset_conv=0.005,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rohf_6-31g_pbe_ediis.oqp
+++ b/examples/SCF/h2o_rohf_6-31g_pbe_ediis.oqp
@@ -1,1 +1,8 @@
-roks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=40,maxdiis=7,diis_type=ediis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=40,maxdiis=7,diis_type=ediis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rohf_6-31g_pbe_mom.oqp
+++ b/examples/SCF/h2o_rohf_6-31g_pbe_mom.oqp
@@ -1,1 +1,8 @@
-roks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,mom=true,mom_switch=0.003,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,mom=true,mom_switch=0.003,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rohf_6-31g_pbe_pfon.oqp
+++ b/examples/SCF/h2o_rohf_6-31g_pbe_pfon.oqp
@@ -1,1 +1,8 @@
-roks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=200,maxdiis=7,pfon=true,pfon_start_temp=2000.0,pfon_cooling_rate=50.0,pfon_nsmear=5.0,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=200,maxdiis=7,pfon=true,pfon_start_temp=2000.0,pfon_cooling_rate=50.0,pfon_nsmear=5.0,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rohf_6-31g_pbe_soscf.oqp
+++ b/examples/SCF/h2o_rohf_6-31g_pbe_soscf.oqp
@@ -1,1 +1,8 @@
-roks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(converger_type=soscf,maxit=60,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(converger_type=soscf,maxit=60,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_rohf_6-31g_pbe_vshift.oqp
+++ b/examples/SCF/h2o_rohf_6-31g_pbe_vshift.oqp
@@ -1,1 +1,8 @@
-roks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,vshift=0.1,cdiis_switch=0.3,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,vshift=0.1,cdiis_switch=0.3,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-s_6-31g_pbe_adiis.oqp
+++ b/examples/SCF/h2o_uhf-s_6-31g_pbe_adiis.oqp
@@ -1,1 +1,7 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=adiis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=adiis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-s_6-31g_pbe_basic.oqp
+++ b/examples/SCF/h2o_uhf-s_6-31g_pbe_basic.oqp
@@ -1,1 +1,7 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=cdiis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=cdiis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-s_6-31g_pbe_diis-reset.oqp
+++ b/examples/SCF/h2o_uhf-s_6-31g_pbe_diis-reset.oqp
@@ -1,1 +1,7 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_reset_mod=5,diis_reset_conv=0.005,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_reset_mod=5,diis_reset_conv=0.005,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-s_6-31g_pbe_ediis.oqp
+++ b/examples/SCF/h2o_uhf-s_6-31g_pbe_ediis.oqp
@@ -1,1 +1,7 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=ediis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=ediis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-s_6-31g_pbe_mom.oqp
+++ b/examples/SCF/h2o_uhf-s_6-31g_pbe_mom.oqp
@@ -1,1 +1,7 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,mom=true,mom_switch=0.003,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,mom=true,mom_switch=0.003,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-s_6-31g_pbe_pfon.oqp
+++ b/examples/SCF/h2o_uhf-s_6-31g_pbe_pfon.oqp
@@ -1,1 +1,7 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,pfon=true,pfon_start_temp=2000.0,pfon_cooling_rate=50.0,pfon_nsmear=5.0,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,pfon=true,pfon_start_temp=2000.0,pfon_cooling_rate=50.0,pfon_nsmear=5.0,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-s_6-31g_pbe_vdiis.oqp
+++ b/examples/SCF/h2o_uhf-s_6-31g_pbe_vdiis.oqp
@@ -1,1 +1,7 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=vdiis,cdiis_switch=0.3,vdiis_vshift_switch=0.003,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=vdiis,cdiis_switch=0.3,vdiis_vshift_switch=0.003,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-t_6-31g_pbe_adiis.oqp
+++ b/examples/SCF/h2o_uhf-t_6-31g_pbe_adiis.oqp
@@ -1,1 +1,8 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=adiis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=adiis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-t_6-31g_pbe_basic.oqp
+++ b/examples/SCF/h2o_uhf-t_6-31g_pbe_basic.oqp
@@ -1,1 +1,8 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=cdiis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=cdiis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-t_6-31g_pbe_diis-reset.oqp
+++ b/examples/SCF/h2o_uhf-t_6-31g_pbe_diis-reset.oqp
@@ -1,1 +1,8 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_reset_mod=5,diis_reset_conv=0.005,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_reset_mod=5,diis_reset_conv=0.005,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-t_6-31g_pbe_ediis.oqp
+++ b/examples/SCF/h2o_uhf-t_6-31g_pbe_ediis.oqp
@@ -1,1 +1,8 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=ediis,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=ediis,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-t_6-31g_pbe_mom.oqp
+++ b/examples/SCF/h2o_uhf-t_6-31g_pbe_mom.oqp
@@ -1,1 +1,8 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,mom=true,mom_switch=0.003,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,mom=true,mom_switch=0.003,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-t_6-31g_pbe_pfon.oqp
+++ b/examples/SCF/h2o_uhf-t_6-31g_pbe_pfon.oqp
@@ -1,1 +1,8 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,pfon=true,pfon_start_temp=2000.0,pfon_cooling_rate=50.0,pfon_nsmear=5.0,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,pfon=true,pfon_start_temp=2000.0,pfon_cooling_rate=50.0,pfon_nsmear=5.0,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf-t_6-31g_pbe_vdiis.oqp
+++ b/examples/SCF/h2o_uhf-t_6-31g_pbe_vdiis.oqp
@@ -1,1 +1,8 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(maxit=30,maxdiis=7,diis_type=vdiis,cdiis_switch=0.3,vdiis_vshift_switch=0.003,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(maxit=30,maxdiis=7,diis_type=vdiis,cdiis_switch=0.3,vdiis_vshift_switch=0.003,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SCF/h2o_uhf_6-31g_pbe_soscf.oqp
+++ b/examples/SCF/h2o_uhf_6-31g_pbe_soscf.oqp
@@ -1,1 +1,8 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false energy guess(type=huckel,save_mol=true) scf(converger_type=soscf,maxit=60,conv=1e-06) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+mult=3
+d4=false
+energy
+guess(type=huckel,save_mol=true)
+scf(converger_type=soscf,maxit=60,conv=1e-06)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SF-TDDFT/H2O_BHHLYP-SFTDDFT_ENERGY.oqp
+++ b/examples/SF-TDDFT/H2O_BHHLYP-SFTDDFT_ENERGY.oqp
@@ -1,1 +1,4 @@
-sf(nstate=3)/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 energy guess(type=huckel)
+sf(nstate=3)/bhhlyp/6-31g*
+energy
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SF-TDDFT/H2O_BHHLYP-SFTDDFT_GRADIENT.oqp
+++ b/examples/SF-TDDFT/H2O_BHHLYP-SFTDDFT_GRADIENT.oqp
@@ -1,1 +1,4 @@
-sf(nstate=3)/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 grad(root=3) guess(type=huckel)
+sf(nstate=3)/bhhlyp/6-31g*
+grad(root=3)
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/SOC/CH3Br-BHHLYP-SOC.oqp
+++ b/examples/SOC/CH3Br-BHHLYP-SOC.oqp
@@ -1,1 +1,6 @@
-mrsf(nstate=6)/bhhlyp/6-31g* geom="../geometries/CH3Br-82fdf47b3e2c.xyz" charge=0 soc(soc_2e=1) guess(save_mol=true) scf(maxit=200,conv=1e-07,scal_rel=0) tdhf(conv=1e-07)
+mrsf(nstate=6)/bhhlyp/6-31g*
+soc(soc_2e=1)
+guess(save_mol=true)
+scf(maxit=200,conv=1e-07,scal_rel=0)
+tdhf(conv=1e-07)
+geom="../geometries/CH3Br-82fdf47b3e2c.xyz"

--- a/examples/SOC/H2O_BHHLYP_SOC.oqp
+++ b/examples/SOC/H2O_BHHLYP_SOC.oqp
@@ -1,1 +1,7 @@
-mrsf(nstate=12)/bhhlyp/6-31g(2df,p) geom="../geometries/H2O-a5185d3fce44.xyz" charge=0 ispher=false soc guess(save_mol=true) scf(converger_type=diis,maxit=200) dftgrid(rad_npts=90,ang_npts=302)
+mrsf(nstate=12)/bhhlyp/6-31g(2df,p)
+ispher=false
+soc
+guess(save_mol=true)
+scf(converger_type=diis,maxit=200)
+dftgrid(rad_npts=90,ang_npts=302)
+geom="../geometries/H2O-a5185d3fce44.xyz"

--- a/examples/TDDFT/H2O_B3LYP5-TDDFT_ENERGY.oqp
+++ b/examples/TDDFT/H2O_B3LYP5-TDDFT_ENERGY.oqp
@@ -1,1 +1,4 @@
-tddft(nstate=3)/b3lyp5/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy(S0) guess(type=huckel)
+tddft(nstate=3)/b3lyp5/6-31g*
+energy(S0)
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/TDDFT/H2O_B3LYP5-TDDFT_GRADIENT.oqp
+++ b/examples/TDDFT/H2O_B3LYP5-TDDFT_GRADIENT.oqp
@@ -1,1 +1,4 @@
-tddft(nstate=3)/b3lyp5/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 grad(S3) guess(type=huckel)
+tddft(nstate=3)/b3lyp5/6-31g*
+grad(S3)
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/TDHF/H2O_TDHF_ENERGY.oqp
+++ b/examples/TDHF/H2O_TDHF_ENERGY.oqp
@@ -1,1 +1,4 @@
-tdhf(nstate=3)/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 energy(S0) guess(type=huckel)
+tdhf(nstate=3)/6-31g*
+energy(S0)
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/TDHF/H2O_TDHF_GRADIENT.oqp
+++ b/examples/TDHF/H2O_TDHF_GRADIENT.oqp
@@ -1,1 +1,4 @@
-tdhf(nstate=3)/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 grad(S3) guess(type=huckel)
+tdhf(nstate=3)/6-31g*
+grad(S3)
+guess(type=huckel)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/TRAH/H2O_RHF-DFT_GRAD_TRAH.oqp
+++ b/examples/TRAH/H2O_RHF-DFT_GRAD_TRAH.oqp
@@ -1,1 +1,6 @@
-rks/bhhlyp/6-31g* geom="../geometries/H2O-7c17dce6a2e9.xyz" charge=0 mult=1 grad(S0) guess(type=huckel,save_mol=true) scf(converger_type=trah,conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/bhhlyp/6-31g*
+grad
+guess(type=huckel,save_mol=true)
+scf(converger_type=trah,conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-7c17dce6a2e9.xyz"

--- a/examples/TRAH/H2O_ROHF-DFT_GRAD_TRAH.oqp
+++ b/examples/TRAH/H2O_ROHF-DFT_GRAD_TRAH.oqp
@@ -1,1 +1,6 @@
-mrsf(nstate=3)/bhhlyp/6-31g* geom="../geometries/H2O-7c17dce6a2e9.xyz" charge=0 grad(S2) guess(type=huckel,save_mol=true) scf(converger_type=trah,conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+mrsf(nstate=3)/bhhlyp/6-31g*
+grad(S2)
+guess(type=huckel,save_mol=true)
+scf(converger_type=trah,conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-7c17dce6a2e9.xyz"

--- a/examples/TRAH/H2O_UHF-DFT_GRAD_TRAH.oqp
+++ b/examples/TRAH/H2O_UHF-DFT_GRAD_TRAH.oqp
@@ -1,1 +1,7 @@
-uks/b3lypv1r/cc-pvdz geom="../geometries/H2O-7c17dce6a2e9.xyz" charge=0 mult=3 grad(S0) guess(type=huckel,save_mol=true) scf(converger_type=trah,conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/b3lypv1r/cc-pvdz
+mult=3
+grad
+guess(type=huckel,save_mol=true)
+scf(converger_type=trah,conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-7c17dce6a2e9.xyz"

--- a/examples/TRAH/h2o_rohf_mrsf-t_6-31g_prop.oqp
+++ b/examples/TRAH/h2o_rohf_mrsf-t_6-31g_prop.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=2)/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 prop(S1) guess(type=huckel,save_mol=false) scf(maxit=200,converger_type=trah,conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=100,maxit_zv=100,nvdav=100,zvconv=1e-10) properties(export=true,nac=nacme,back_door=true)
+mrsf(nstate=2)/bhhlyp/6-31g*
+prop(S1)
+guess(type=huckel,save_mol=false)
+scf(maxit=200,converger_type=trah,conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=100,maxit_zv=100,nvdav=100,zvconv=1e-10)
+properties(export=true,nac=nacme,back_door=true)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/UMRSF-TDDFT/C4H6_BHHLYP_UMRSFTDDFT_ENERGY.oqp
+++ b/examples/UMRSF-TDDFT/C4H6_BHHLYP_UMRSFTDDFT_ENERGY.oqp
@@ -1,1 +1,6 @@
-umrsf(nstate=10)/bhhlyp/6-31g* geom="../geometries/C4H6-0a0dabfd2a8a.xyz" charge=0 energy(S0) guess(save_mol=false) scf(converger_type=diis,maxit=200) dftgrid(rad_npts=90,ang_npts=302)
+umrsf(nstate=10)/bhhlyp/6-31g*
+energy(S0)
+guess(save_mol=false)
+scf(converger_type=diis,maxit=200)
+dftgrid(rad_npts=90,ang_npts=302)
+geom="../geometries/C4H6-0a0dabfd2a8a.xyz"

--- a/examples/XAS/MRSF/HCN_MRSF.oqp
+++ b/examples/XAS/MRSF/HCN_MRSF.oqp
@@ -1,1 +1,6 @@
-mrsf(nstate=70)/bhhlyp/6-31g* geom="../../geometries/CHN-cef1bbffc7f3.xyz" charge=0 energy(S0) guess(type=huckel,save_mol=false,continue_geom=false) dftgrid(rad_npts=96,ang_npts=302) tdhf(ixcore=2)
+mrsf(nstate=70)/bhhlyp/6-31g*
+energy(S0)
+guess(type=huckel,save_mol=false,continue_geom=false)
+dftgrid(rad_npts=96,ang_npts=302)
+tdhf(ixcore=2)
+geom="../../geometries/CHN-cef1bbffc7f3.xyz"

--- a/examples/XAS/delta-CHP-MRSF/HCN_CHP-MRSF_v2.oqp
+++ b/examples/XAS/delta-CHP-MRSF/HCN_CHP-MRSF_v2.oqp
@@ -1,1 +1,7 @@
-mrsf(nstate=25)/bhhlyp/6-31g* geom="../../geometries/CHN-cef1bbffc7f3.xyz" charge=0 energy(S0) guess(type=huckel,save_mol=false,continue_geom=false,swapmo="2,7,8,21") scf(save_molden=true,rstctmo=true) dftgrid(rad_npts=96,ang_npts=302) tdhf(ixcore=7)
+mrsf(nstate=25)/bhhlyp/6-31g*
+energy(S0)
+guess(type=huckel,save_mol=false,continue_geom=false,swapmo="2,7,8,21")
+scf(save_molden=true,rstctmo=true)
+dftgrid(rad_npts=96,ang_npts=302)
+tdhf(ixcore=7)
+geom="../../geometries/CHN-cef1bbffc7f3.xyz"

--- a/examples/XAS/delta-CHP-MRSF/HCN_DFT.oqp
+++ b/examples/XAS/delta-CHP-MRSF/HCN_DFT.oqp
@@ -1,1 +1,5 @@
-rks/bhhlyp/6-31g* geom="../../geometries/CHN-cef1bbffc7f3.xyz" charge=0 mult=1 energy guess(type=huckel,save_mol=false) dftgrid(rad_npts=96,ang_npts=302)
+rks/bhhlyp/6-31g*
+energy
+guess(type=huckel,save_mol=false)
+dftgrid(rad_npts=96,ang_npts=302)
+geom="../../geometries/CHN-cef1bbffc7f3.xyz"

--- a/examples/other/h2o-2_rhf_cc-pvtz_hf.oqp
+++ b/examples/other/h2o-2_rhf_cc-pvtz_hf.oqp
@@ -1,1 +1,7 @@
-rhf/6-31g* geom="../geometries/H4O2-6c06eba36ab5.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rhf/6-31g*
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H4O2-6c06eba36ab5.xyz"

--- a/examples/other/h2o-2_rohf_cc-pvtz_hf.oqp
+++ b/examples/other/h2o-2_rohf_cc-pvtz_hf.oqp
@@ -1,1 +1,8 @@
-rohf/6-31g* geom="../geometries/H4O2-6c06eba36ab5.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=50,conv=1e-06,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rohf/6-31g*
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=50,conv=1e-06,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H4O2-6c06eba36ab5.xyz"

--- a/examples/other/h2o-2_uhf-s_cc-pvtz_hf.oqp
+++ b/examples/other/h2o-2_uhf-s_cc-pvtz_hf.oqp
@@ -1,1 +1,7 @@
-uhf/6-31g* geom="../geometries/H4O2-6c06eba36ab5.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=40,maxdiis=5,conv=1e-06,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uhf/6-31g*
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=40,maxdiis=5,conv=1e-06,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H4O2-6c06eba36ab5.xyz"

--- a/examples/other/h2o_nacme_rohf_mrsf-s_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_nacme_rohf_mrsf-s_6-31g_bhhlyp.oqp
@@ -1,1 +1,9 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" geom2="../geometries/H2O-1bdadad53a3a.xyz" charge=0 d4=false nacme(S0,S1) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+nacme(S0,S1)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"
+geom2="../geometries/H2O-1bdadad53a3a.xyz"

--- a/examples/other/h2o_rhf_3-21g_minao.oqp
+++ b/examples/other/h2o_rhf_3-21g_minao.oqp
@@ -1,1 +1,7 @@
-rhf/3-21g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=minao,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rhf/3-21g
+d4=false
+energy
+guess(type=minao,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_3-21g_modhuckel.oqp
+++ b/examples/other/h2o_rhf_3-21g_modhuckel.oqp
@@ -1,1 +1,7 @@
-rhf/3-21g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=modhuckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rhf/3-21g
+d4=false
+energy
+guess(type=modhuckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_3-21g_sap.oqp
+++ b/examples/other/h2o_rhf_3-21g_sap.oqp
@@ -1,1 +1,7 @@
-rhf/3-21g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false energy guess(type=sap,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rhf/3-21g
+d4=false
+energy
+guess(type=sap,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rhf_6-31g_b3lypv5.oqp
@@ -1,1 +1,7 @@
-rks/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/b3lypv5/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rhf_6-31g_bhhlyp.oqp
@@ -1,1 +1,7 @@
-rks/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/bhhlyp/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rhf_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,7 @@
-rks/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/cam-b3lyp/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_6-31g_hf.oqp
+++ b/examples/other/h2o_rhf_6-31g_hf.oqp
@@ -1,1 +1,7 @@
-rhf/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rhf/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rhf_6-31g_m06-2x.oqp
@@ -1,1 +1,7 @@
-rks/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/m06-2x/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_6-31g_pbe.oqp
+++ b/examples/other/h2o_rhf_6-31g_pbe.oqp
@@ -1,1 +1,7 @@
-rks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/pbe/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_6-31g_slater.oqp
+++ b/examples/other/h2o_rhf_6-31g_slater.oqp
@@ -1,1 +1,7 @@
-rks/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/slater/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_cc-pvtz_b3lypv5.oqp
+++ b/examples/other/h2o_rhf_cc-pvtz_b3lypv5.oqp
@@ -1,1 +1,7 @@
-rks/b3lypv5/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rks/b3lypv5/6-31g*
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-s_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rhf_rpa-s_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/b3lypv5/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-s_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rhf_rpa-s_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-s_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rhf_rpa-s_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/cam-b3lyp/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-s_6-31g_hf.oqp
+++ b/examples/other/h2o_rhf_rpa-s_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-tdhf(nstate=6)/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+tdhf(nstate=6)/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-s_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rhf_rpa-s_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/m06-2x/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-s_6-31g_pbe.oqp
+++ b/examples/other/h2o_rhf_rpa-s_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/pbe/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-s_6-31g_slater.oqp
+++ b/examples/other/h2o_rhf_rpa-s_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/slater/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-t_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rhf_rpa-t_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/b3lypv5/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-t_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rhf_rpa-t_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-t_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rhf_rpa-t_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/cam-b3lyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-t_6-31g_hf.oqp
+++ b/examples/other/h2o_rhf_rpa-t_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-tdhf(nstate=6)/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+tdhf(nstate=6)/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-t_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rhf_rpa-t_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/m06-2x/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-t_6-31g_pbe.oqp
+++ b/examples/other/h2o_rhf_rpa-t_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/pbe/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_rpa-t_6-31g_slater.oqp
+++ b/examples/other/h2o_rhf_rpa-t_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-tddft(nstate=10)/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tddft(nstate=10)/slater/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-s_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rhf_tda-s_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/b3lypv5/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-s_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rhf_tda-s_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-s_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rhf_tda-s_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/cam-b3lyp/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-s_6-31g_hf.oqp
+++ b/examples/other/h2o_rhf_tda-s_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-tda-tdhf(nstate=6)/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+tda-tdhf(nstate=6)/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-s_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rhf_tda-s_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/m06-2x/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-s_6-31g_pbe.oqp
+++ b/examples/other/h2o_rhf_tda-s_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/pbe/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-s_6-31g_slater.oqp
+++ b/examples/other/h2o_rhf_tda-s_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/slater/6-31g
+d4=false
+grad(S3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-t_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rhf_tda-t_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/b3lypv5/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-t_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rhf_tda-t_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-t_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rhf_tda-t_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/cam-b3lyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-t_6-31g_hf.oqp
+++ b/examples/other/h2o_rhf_tda-t_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-tda-tdhf(nstate=6)/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+tda-tdhf(nstate=6)/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-t_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rhf_tda-t_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/m06-2x/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-t_6-31g_pbe.oqp
+++ b/examples/other/h2o_rhf_tda-t_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/pbe/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rhf_tda-t_6-31g_slater.oqp
+++ b/examples/other/h2o_rhf_tda-t_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-tda(nstate=10)/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+tda(nstate=10)/slater/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf-dft_energy_init_scf.oqp
+++ b/examples/other/h2o_rohf-dft_energy_init_scf.oqp
@@ -1,1 +1,7 @@
-roks/bhhlyp/aug-cc-pvdz geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 energy guess(type=huckel,save_mol=false) scf(init_basis="6-31g",init_scf=rhf,init_it=3,save_molden=true) dftgrid(rad_type=becke)
+roks/bhhlyp/aug-cc-pvdz
+mult=3
+energy
+guess(type=huckel,save_mol=false)
+scf(init_basis="6-31g",init_scf=rhf,init_it=3,save_molden=true)
+dftgrid(rad_type=becke)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf-dft_energy_init_scf_basis_library.oqp
+++ b/examples/other/h2o_rohf-dft_energy_init_scf_basis_library.oqp
@@ -1,1 +1,15 @@
-roks/bhhlyp/library geom="C    1.6062782722   1.5141391221  -1.8538091464  c1\nC    1.8295756914   2.1530602256  -2.9302391911  c2\nH    0.7846511041   1.8564598303  -1.2260835006  h1\nH    2.0658311171   0.5858648490  -1.5523155830  h1\nH    1.3961209467   3.0492511400  -3.1437367515  h2\nH    2.3877626192   1.8783782433  -3.7562666130  h1" charge=0 mult=3 library="c1 aug-cc-pVDZ\nc2 aug-cc-pVDZ\nh1 cc-pvdz\nh2 cc-pvdz" energy guess(type=huckel,save_mol=true) scf(init_basis=library,init_library="c1 6-31g\nc2 cc-pvdz\nh1 6-31g*\nh2 3-21g",init_scf=rhf,init_it=3,save_molden=true) dftgrid(rad_type=becke)
+roks/bhhlyp/library
+mult=3
+library="c1 aug-cc-pVDZ\nc2 aug-cc-pVDZ\nh1 cc-pvdz\nh2 cc-pvdz"
+energy
+guess(type=huckel,save_mol=true)
+scf(init_basis=library,init_library="c1 6-31g\nc2 cc-pvdz\nh1 6-31g*\nh2 3-21g",init_scf=rhf,init_it=3,save_molden=true)
+dftgrid(rad_type=becke)
+geom="""
+C    1.6062782722   1.5141391221  -1.8538091464  c1
+C    1.8295756914   2.1530602256  -2.9302391911  c2
+H    0.7846511041   1.8564598303  -1.2260835006  h1
+H    2.0658311171   0.5858648490  -1.5523155830  h1
+H    1.3961209467   3.0492511400  -3.1437367515  h2
+H    2.3877626192   1.8783782433  -3.7562666130  h1
+"""

--- a/examples/other/h2o_rohf_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rohf_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-roks/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/b3lypv5/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rohf_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-roks/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/bhhlyp/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rohf_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-roks/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/cam-b3lyp/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_6-31g_hf.oqp
+++ b/examples/other/h2o_rohf_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-rohf/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+rohf/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rohf_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-roks/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/m06-2x/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_6-31g_pbe.oqp
+++ b/examples/other/h2o_rohf_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-roks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/pbe/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_6-31g_slater.oqp
+++ b/examples/other/h2o_rohf_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-roks/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/slater/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_cc-pvtz_b3lypv5.oqp
+++ b/examples/other/h2o_rohf_cc-pvtz_b3lypv5.oqp
@@ -1,1 +1,8 @@
-roks/b3lypv5/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+roks/b3lypv5/6-31g*
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/b3lypv5/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/cam-b3lyp/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dt-bhhlyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dt-bhhlyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dt-vee.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dt-vee.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.3) tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.3)
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-aee.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-aee.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-aee/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-aee/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-b3lyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-b3lyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/camh-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,cam_alpha=0.15,cam_beta=0.95)
+mrsf(nstate=10)/camh-b3lyp/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,cam_alpha=0.15,cam_beta=0.95)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-stg.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-stg.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-stg/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-stg/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-tune.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-tune.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-tune/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="",cam_flag=true,cam_alpha=0.23,cam_beta=0.45,cam_mu=0.44) tdhf(maxit=15,conv=1e-10,zvconv=1e-10,cam_alpha=0.62,cam_beta=0.32)
+mrsf(nstate=6)/dtcam-tune/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="",cam_flag=true,cam_alpha=0.23,cam_beta=0.45,cam_mu=0.44)
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10,cam_alpha=0.62,cam_beta=0.32)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-vaee.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-vaee.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-vaee/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-vaee/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-vee.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-vee.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-vee/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-vee/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-xi.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-xi.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-xi/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-xi/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-xiv.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_dtcam-xiv.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-xiv/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-xiv/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_hf.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-mrsf-tdhf(nstate=6)/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf-tdhf(nstate=6)/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/m06-2x/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_pbe.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/pbe/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-q_6-31g_slater.oqp
+++ b/examples/other/h2o_rohf_mrsf-q_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(Q2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/slater/6-31g
+d4=false
+grad(Q2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/b3lypv5/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_bhhlyp-spc-coco.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_bhhlyp-spc-coco.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,spc_coco=0.4,spc_ovov=0.0,spc_coov=0.0)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,spc_coco=0.4,spc_ovov=0.0,spc_coov=0.0)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_bhhlyp-spc-coov.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_bhhlyp-spc-coov.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,spc_coco=0.0,spc_ovov=0.0,spc_coov=0.4)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,spc_coco=0.0,spc_ovov=0.0,spc_coov=0.4)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_bhhlyp-spc-ovov.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_bhhlyp-spc-ovov.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,spc_coco=0.0,spc_ovov=0.4,spc_coov=0.0)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,spc_coco=0.0,spc_ovov=0.4,spc_coov=0.0)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/cam-b3lyp/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dt-bhhlyp-spc.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dt-bhhlyp-spc.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.45) tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.75,spc_coco=0.2,spc_ovov=0.3,spc_coov=0.4)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.45)
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.75,spc_coco=0.2,spc_ovov=0.3,spc_coov=0.4)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dt-bhhlyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dt-bhhlyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dt-vee.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dt-vee.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.3) tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.3)
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-aee.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-aee.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-aee/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-aee/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-b3lyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-b3lyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/camh-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,cam_alpha=0.5,cam_beta=0.9,cam_mu=0.33)
+mrsf(nstate=10)/camh-b3lyp/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,cam_alpha=0.5,cam_beta=0.9,cam_mu=0.33)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-stg.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-stg.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-stg/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-stg/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-tune.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-tune.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-tune/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="",cam_flag=true,cam_alpha=0.23,cam_beta=0.45,cam_mu=0.44) tdhf(maxit=15,conv=1e-10,zvconv=1e-10,cam_alpha=0.62,cam_beta=0.32)
+mrsf(nstate=6)/dtcam-tune/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="",cam_flag=true,cam_alpha=0.23,cam_beta=0.45,cam_mu=0.44)
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10,cam_alpha=0.62,cam_beta=0.32)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-vaee.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-vaee.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-vaee/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-vaee/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-vee.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-vee.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-vee/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-vee/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-xi.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-xi.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-xi/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-xi/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-xiv.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_dtcam-xiv.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/dtcam-xiv/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/dtcam-xiv/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_hf.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-mrsf-tdhf(nstate=6)/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf-tdhf(nstate=6)/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/m06-2x/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_pbe.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/pbe/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_prop.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_prop.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=2)/bhhlyp/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 prop(S1) guess(type=huckel,save_mol=false) scf(maxit=200,converger_type=soscf,conv=1e-08) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=100,maxit_zv=100,nvdav=100,zvconv=1e-10) properties(export=true,nac=nacme,back_door=true)
+mrsf(nstate=2)/bhhlyp/6-31g*
+prop(S1)
+guess(type=huckel,save_mol=false)
+scf(maxit=200,converger_type=soscf,conv=1e-08)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=100,maxit_zv=100,nvdav=100,zvconv=1e-10)
+properties(export=true,nac=nacme,back_door=true)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-s_6-31g_slater.oqp
+++ b/examples/other/h2o_rohf_mrsf-s_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(S2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/slater/6-31g
+d4=false
+grad(S2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/b3lypv5/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/cam-b3lyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_dt-bhhlyp-spc.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_dt-bhhlyp-spc.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.45) tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.75,spc_coco=0.2,spc_ovov=0.3,spc_coov=0.4)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.45)
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.75,spc_coco=0.2,spc_ovov=0.3,spc_coov=0.4)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_dt-bhhlyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_dt-bhhlyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_dt-vee.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_dt-vee.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.3) tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="",hfscale=0.3)
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_dtcam-b3lyp.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_dtcam-b3lyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/camh-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,cam_alpha=0.5,cam_beta=0.9,cam_mu=0.33)
+mrsf(nstate=10)/camh-b3lyp/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,cam_alpha=0.5,cam_beta=0.9,cam_mu=0.33)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_hf.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-mrsf-tdhf(nstate=6)/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf-tdhf(nstate=6)/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/m06-2x/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_pbe.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/pbe/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_slater.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/slater/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf-t_6-31g_stg1x.oqp
+++ b/examples/other/h2o_rohf_mrsf-t_6-31g_stg1x.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=6)/stg1x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(T2) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+mrsf(nstate=6)/stg1x/6-31g
+d4=false
+grad(T2)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf_ekt_ea_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rohf_mrsf_ekt_ea_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false ekt(ip=false,ea=true) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+ekt(ip=false,ea=true)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_mrsf_ekt_ip_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rohf_mrsf_ekt_ip_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-mrsf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false ekt(ip=true,ea=false) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+mrsf(nstate=10)/bhhlyp/6-31g
+d4=false
+ekt(ip=true,ea=false)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_sf_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_rohf_sf_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-sf(nstate=10)/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(root=3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+sf(nstate=10)/b3lypv5/6-31g
+d4=false
+grad(root=3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_sf_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_rohf_sf_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-sf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(root=3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+sf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(root=3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_sf_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_rohf_sf_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-sf(nstate=10)/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(root=3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+sf(nstate=10)/cam-b3lyp/6-31g
+d4=false
+grad(root=3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_sf_6-31g_dt-bhhlyp.oqp
+++ b/examples/other/h2o_rohf_sf_6-31g_dt-bhhlyp.oqp
@@ -1,1 +1,8 @@
-sf(nstate=10)/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(root=3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+sf(nstate=10)/bhhlyp/6-31g
+d4=false
+grad(root=3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,hfscale=0.7)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_sf_6-31g_dtcam-b3lyp.oqp
+++ b/examples/other/h2o_rohf_sf_6-31g_dtcam-b3lyp.oqp
@@ -1,1 +1,8 @@
-sf(nstate=10)/camh-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(root=3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08,cam_alpha=0.5,cam_beta=0.9,cam_mu=0.33)
+sf(nstate=10)/camh-b3lyp/6-31g
+d4=false
+grad(root=3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08,cam_alpha=0.5,cam_beta=0.9,cam_mu=0.33)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_sf_6-31g_hf.oqp
+++ b/examples/other/h2o_rohf_sf_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-sf-tdhf(nstate=6)/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(root=3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+sf-tdhf(nstate=6)/6-31g
+d4=false
+grad(root=3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=15,conv=1e-10,zvconv=1e-10)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_sf_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_rohf_sf_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-sf(nstate=10)/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(root=3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+sf(nstate=10)/m06-2x/6-31g
+d4=false
+grad(root=3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_sf_6-31g_pbe.oqp
+++ b/examples/other/h2o_rohf_sf_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-sf(nstate=10)/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(root=3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+sf(nstate=10)/pbe/6-31g
+d4=false
+grad(root=3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_rohf_sf_6-31g_slater.oqp
+++ b/examples/other/h2o_rohf_sf_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-sf(nstate=10)/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 d4=false grad(root=3) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="") tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+sf(nstate=10)/slater/6-31g
+d4=false
+grad(root=3)
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+tdhf(maxit=30,conv=1e-08,zvconv=1e-08)
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-s_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_uhf-s_6-31g_b3lypv5.oqp
@@ -1,1 +1,7 @@
-uks/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/b3lypv5/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-s_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_uhf-s_6-31g_bhhlyp.oqp
@@ -1,1 +1,7 @@
-uks/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/bhhlyp/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-s_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_uhf-s_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,7 @@
-uks/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/cam-b3lyp/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-s_6-31g_hf.oqp
+++ b/examples/other/h2o_uhf-s_6-31g_hf.oqp
@@ -1,1 +1,7 @@
-uhf/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uhf/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-s_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_uhf-s_6-31g_m06-2x.oqp
@@ -1,1 +1,7 @@
-uks/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/m06-2x/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-s_6-31g_pbe.oqp
+++ b/examples/other/h2o_uhf-s_6-31g_pbe.oqp
@@ -1,1 +1,7 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-s_6-31g_slater.oqp
+++ b/examples/other/h2o_uhf-s_6-31g_slater.oqp
@@ -1,1 +1,7 @@
-uks/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/slater/6-31g
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-s_cc-pvtz_b3lypv5.oqp
+++ b/examples/other/h2o_uhf-s_cc-pvtz_b3lypv5.oqp
@@ -1,1 +1,7 @@
-uks/b3lypv5/6-31g* geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=1 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/b3lypv5/6-31g*
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-t_6-31g_b3lypv5.oqp
+++ b/examples/other/h2o_uhf-t_6-31g_b3lypv5.oqp
@@ -1,1 +1,8 @@
-uks/b3lypv5/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/b3lypv5/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-t_6-31g_bhhlyp.oqp
+++ b/examples/other/h2o_uhf-t_6-31g_bhhlyp.oqp
@@ -1,1 +1,8 @@
-uks/bhhlyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(stability=true,maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/bhhlyp/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(stability=true,maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-t_6-31g_cam-b3lyp.oqp
+++ b/examples/other/h2o_uhf-t_6-31g_cam-b3lyp.oqp
@@ -1,1 +1,8 @@
-uks/cam-b3lyp/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(stability=true,maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/cam-b3lyp/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(stability=true,maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-t_6-31g_hf.oqp
+++ b/examples/other/h2o_uhf-t_6-31g_hf.oqp
@@ -1,1 +1,8 @@
-uhf/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(stability=true,maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uhf/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(stability=true,maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-t_6-31g_m06-2x.oqp
+++ b/examples/other/h2o_uhf-t_6-31g_m06-2x.oqp
@@ -1,1 +1,8 @@
-uks/m06-2x/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(stability=true,maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/m06-2x/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(stability=true,maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-t_6-31g_pbe.oqp
+++ b/examples/other/h2o_uhf-t_6-31g_pbe.oqp
@@ -1,1 +1,8 @@
-uks/pbe/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/pbe/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/examples/other/h2o_uhf-t_6-31g_slater.oqp
+++ b/examples/other/h2o_uhf-t_6-31g_slater.oqp
@@ -1,1 +1,8 @@
-uks/slater/6-31g geom="../geometries/H2O-0381125c86f2.xyz" charge=0 mult=3 d4=false grad(S0) guess(type=huckel,save_mol=false) scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false) dftgrid(rad_npts=96,ang_npts=302,pruned="")
+uks/slater/6-31g
+mult=3
+d4=false
+grad
+guess(type=huckel,save_mol=false)
+scf(maxit=30,maxdiis=5,conv=1e-08,save_molden=false)
+dftgrid(rad_npts=96,ang_npts=302,pruned="")
+geom="../geometries/H2O-0381125c86f2.xyz"

--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -115,6 +115,17 @@ def _bundled_parameter_path() -> str | None:
 
 
 
+def _bundled_parameter_path() -> str | None:
+    """Return the installed openqp-dftb default parameter set, if available."""
+
+    try:
+        import openqp_dftb  # noqa: PLC0415
+
+        return openqp_dftb.default_parameter_path()
+    except (ImportError, AttributeError, FileNotFoundError):
+        return None
+
+
 @dataclass(frozen=True)
 class _StateResult:
     state: int

--- a/pyoqp/oqp/openqp.py
+++ b/pyoqp/oqp/openqp.py
@@ -473,9 +473,9 @@ class OpenQP:
         """Enable ESPF QM/MM embedding and configure the ``[qmmm]`` section.
 
         Sets ``[input] qmmm_flag=true`` and populates ``[qmmm]``. The QM geometry
-        and atom selection come from ``job.molecule("file.pdb <indices>")`` for a
-        single-point QM/MM energy; QM/MM molecular dynamics (``runtype=namd``)
-        additionally reads ``pdb_file``/``forcefield``/``qm_atoms`` here. Combine
+        and atom selection come from ``job.molecule("file.pdb <indices>")``.
+        When ``pdb_file`` is omitted, it is inferred from that molecular-system
+        value for both single-point and molecular-dynamics workflows. Combine
         with ``job.workflow.namd(...)`` for (SOC-)NAMD-QMMM dynamics.
 
         ``forcefield`` is an alias for the ``[qmmm] forcefield_files`` list.
@@ -500,6 +500,9 @@ class OpenQP:
             ff = ",".join(str(item) for item in ff)
         if isinstance(qm_atoms, (list, tuple)):
             qm_atoms = " ".join(str(index) for index in qm_atoms)
+        if pdb_file is None:
+            system = self.config_str.get("input", {}).get("system")
+            pdb_file = self._pdb_file_from_system(system)
 
         self.set(**{"input.qmmm_flag": True})
         updates = {}
@@ -521,6 +524,20 @@ class OpenQP:
         if updates:
             self.section("qmmm", **updates)
         return self
+
+    @staticmethod
+    def _pdb_file_from_system(system):
+        """Return the PDB prefix from ``input.system`` when one is present."""
+        if not isinstance(system, str):
+            return None
+        first_line = next(
+            (line.strip() for line in system.splitlines() if line.strip()),
+            "",
+        )
+        if not first_line:
+            return None
+        candidate = first_line.split()[0]
+        return candidate if candidate.lower().endswith(".pdb") else None
 
     @staticmethod
     def _looks_like_basis(value):

--- a/pyoqp/oqp/openqp.py
+++ b/pyoqp/oqp/openqp.py
@@ -474,9 +474,10 @@ class OpenQP:
 
         Sets ``[input] qmmm_flag=true`` and populates ``[qmmm]``. The QM geometry
         and atom selection come from ``job.molecule("file.pdb <indices>")``.
-        When ``pdb_file`` is omitted, it is inferred from that molecular-system
-        value for both single-point and molecular-dynamics workflows. Combine
-        with ``job.workflow.namd(...)`` for (SOC-)NAMD-QMMM dynamics.
+        When ``pdb_file`` or ``qm_atoms`` is omitted, it is inferred from that
+        molecular-system value for both single-point and molecular-dynamics
+        workflows. Combine with ``job.workflow.namd(...)`` for
+        (SOC-)NAMD-QMMM dynamics.
 
         ``forcefield`` is an alias for the ``[qmmm] forcefield_files`` list.
         ``qm_atoms`` accepts a string (``"0-2"`` / ``"0 1 2"``) or a list of
@@ -500,9 +501,12 @@ class OpenQP:
             ff = ",".join(str(item) for item in ff)
         if isinstance(qm_atoms, (list, tuple)):
             qm_atoms = " ".join(str(index) for index in qm_atoms)
+        system = self.config_str.get("input", {}).get("system")
+        inferred_pdb, inferred_qm_atoms = self._qmmm_selection_from_system(system)
         if pdb_file is None:
-            system = self.config_str.get("input", {}).get("system")
-            pdb_file = self._pdb_file_from_system(system)
+            pdb_file = inferred_pdb
+        if qm_atoms is None:
+            qm_atoms = inferred_qm_atoms
 
         self.set(**{"input.qmmm_flag": True})
         updates = {}
@@ -526,18 +530,21 @@ class OpenQP:
         return self
 
     @staticmethod
-    def _pdb_file_from_system(system):
-        """Return the PDB prefix from ``input.system`` when one is present."""
+    def _qmmm_selection_from_system(system):
+        """Return the PDB path and atom selector from ``input.system``."""
         if not isinstance(system, str):
-            return None
+            return None, None
         first_line = next(
             (line.strip() for line in system.splitlines() if line.strip()),
             "",
         )
         if not first_line:
-            return None
-        candidate = first_line.split()[0]
-        return candidate if candidate.lower().endswith(".pdb") else None
+            return None, None
+        fields = first_line.split()
+        if not fields[0].lower().endswith(".pdb"):
+            return None, None
+        selector = " ".join(fields[1:]) or None
+        return fields[0], selector
 
     @staticmethod
     def _looks_like_basis(value):

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -285,7 +285,7 @@ class Runner:
             if input_metadata["was_natural"]:
                 raise ValueError(
                     "Free-form text is not a runnable .oqp input. Review the corrected "
-                    "one-line file at %s and run that file instead."
+                    "canonical file at %s and run that file instead."
                     % input_metadata["resolved"]
                 )
             input_file = input_metadata["resolved"]
@@ -616,7 +616,7 @@ def main():
         if semantic_input["was_natural"]:
             if mpi_manager.rank == 0:
                 print('\n   PyOQP: free-form text was not executed.\n'
-                      '   A corrected one-line .oqp suggestion was written to:\n'
+                      '   A corrected canonical .oqp suggestion was written to:\n'
                       f'   {semantic_input["resolved"]}\n'
                       '   Review it, then run that canonical file.\n')
             if usempi:

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -1152,11 +1152,11 @@ def _check_dftb(config: dict[str, Any], report: CheckReport) -> None:
             report.add(
                 "ERROR",
                 "dftb.parameter_path",
-                "OpenQP-DFTB requires an explicit parameter source.",
-                expected=".opdftb file or SKF directory",
+                "OpenQP-DFTB could not resolve a parameter source.",
+                expected="bundled parameters, an .opdftb file, or an SKF directory",
                 action=(
-                    "Set [dftb] parameter_path, export OPENQP_DFTB_PARAMETER_PATH, or "
-                    "install an openqp-dftb wheel that ships the bundled parameter set."
+                    "Install an openqp-dftb wheel with bundled parameters, set "
+                    "[dftb] parameter_path, or export OPENQP_DFTB_PARAMETER_PATH."
                 ),
                 wiki=WIKI_HELP["dftb.parameter_path"],
             )

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -146,6 +146,27 @@ class OQPResolution:
     resolved_path: Optional[Path] = None
 
 
+def _normalize_default_section_call(call: CallSpec) -> Optional[CallSpec]:
+    """Remove concise section options whose runtime defaults say the same thing."""
+
+    if call.name != "dftb":
+        return call
+    kwargs = dict(call.kwargs)
+    if str(kwargs.get("backend", "")).strip().lower() == "native":
+        kwargs.pop("backend")
+    if "parameter_path" in kwargs and not str(kwargs["parameter_path"]).strip():
+        kwargs.pop("parameter_path")
+    if not call.args and not kwargs:
+        return None
+    return CallSpec(call.name, call.args, kwargs, call.explicit)
+
+
+DEFAULT_SINGLET_MODELS = {
+    "dft", "rks", "uks", "roks", "hf", "rhf", "uhf", "rohf", "mp2",
+    "tddft", "tda", "tdhf", "tda-hf",
+}
+
+
 # Calls in this set are mutually exclusive.  Everything else is a modifier or
 # a direct legacy-section call.  Aliases are normalized before counting, so
 # ``grad(...) opt(...)`` is always rejected rather than silently picking one.
@@ -295,7 +316,7 @@ ROUTE_DRIVER_SCHEMA_KEYS = {
 # backend selection and geomeTRIC/SciPy controls.  The concise ``.oqp`` format
 # intentionally hides those implementation details and always selects the
 # native OpenQP geometry engine.  Keeping these keys in the inventory preserves
-# the legacy schema without exposing them as canonical one-line options.
+# the legacy schema without exposing them as canonical top-level options.
 LEGACY_ONLY_SCHEMA_KEYS = {
     "optimize": _keys("lib optimizer step_size step_tol mep_maxit"),
     "geometric": _keys("""
@@ -398,7 +419,7 @@ TOP_OPTION_ALIASES = {
     "threads": "omp_threads",
 }
 
-# Public one-line driver signatures.  State selectors (positional S0/S1/T0 or
+# Public compact-input driver signatures. State selectors (positional S0/S1/T0 or
 # ``root=N`` for SF) are handled separately; the sets below are the concise
 # workflow options that may live directly in the primary call.  Backend names
 # are deliberately absent: concise ``.oqp`` geometry workflows always use the
@@ -841,13 +862,15 @@ def parse_canonical_oqp(text: str) -> CalculationSpec:
         single = text.strip()
         if single.startswith("#") and "/" in single:
             raise OQPInputError(
-                "A leading '#' route marker is not used in .oqp. Remove '#' and keep the one-line command."
+                "A leading '#' route marker is not used in .oqp. Remove '#'; "
+                "the route may be followed by options and calls on the same or later lines."
             )
         raise OQPInputError("Empty .oqp input")
     if cleaned.startswith("["):
         raise OQPInputError(
             "Sectioned [input]/[scf] syntax belongs in a legacy .inp file. "
-            "Use a one-line .oqp command such as dft/pbe0/def2-svp h2o.xyz energy."
+            "Use compact .oqp syntax such as dft/pbe0/def2-svp, energy, and "
+            "geom=\"h2o.xyz\" on one or more lines."
         )
     tokens = _split_top_level(cleaned)
     model, model_options, functional, basis = _parse_route(tokens[0])
@@ -882,7 +905,18 @@ def parse_canonical_oqp(text: str) -> CalculationSpec:
             canonical_key = TOP_OPTION_ALIASES[key]
             if canonical_key in options:
                 raise OQPInputError("Duplicate top-level option: %s" % canonical_key)
-            options[canonical_key] = _parse_value(value)
+            parsed_value = _parse_value(value)
+            if canonical_key in {"geom", "geom2"} and value.lstrip().startswith(
+                ('"""', "'''")
+            ):
+                # Triple-quoted geometry blocks are formatted with the opening
+                # and closing delimiter on their own lines. Those presentation
+                # newlines are not part of the molecular coordinates.
+                if parsed_value.startswith("\n"):
+                    parsed_value = parsed_value[1:]
+                if parsed_value.endswith("\n"):
+                    parsed_value = parsed_value[:-1]
+            options[canonical_key] = parsed_value
         else:
             calls.append(_parse_call(token))
 
@@ -897,6 +931,14 @@ def parse_canonical_oqp(text: str) -> CalculationSpec:
         if basis and flat != basis:
             raise OQPInputError("Conflicting basis values in route and options")
         basis = flat
+    if _is_integer(options.get("charge")) and options["charge"] == 0:
+        options.pop("charge")
+    if (
+        model in DEFAULT_SINGLET_MODELS
+        and _is_integer(options.get("mult"))
+        and options["mult"] == 1
+    ):
+        options.pop("mult")
 
     primary: List[CallSpec] = []
     modifiers: List[CallSpec] = []
@@ -907,7 +949,11 @@ def parse_canonical_oqp(text: str) -> CalculationSpec:
                 PRIMARY_ALIASES[normalized], call.args, dict(call.kwargs), call.explicit
             ))
         elif normalized in SECTION_NAMES or normalized in {"nmr", "ir", "raman", "d4"}:
-            modifiers.append(CallSpec(normalized, call.args, dict(call.kwargs)))
+            normalized_call = _normalize_default_section_call(
+                CallSpec(normalized, call.args, dict(call.kwargs))
+            )
+            if normalized_call is not None:
+                modifiers.append(normalized_call)
         else:
             choices = list(PRIMARY_ALIASES) + list(SECTION_NAMES) + ["nmr", "ir", "raman", "d4"]
             close = difflib.get_close_matches(normalized, choices, n=1, cutoff=0.6)
@@ -922,6 +968,7 @@ def parse_canonical_oqp(text: str) -> CalculationSpec:
             % names
         )
     driver = primary[0] if primary else CallSpec("energy", explicit=False)
+    driver = _normalize_driver_defaults(model, driver)
     spec = CalculationSpec(
         model=model,
         functional=functional,
@@ -963,6 +1010,50 @@ def _driver_states(driver: CallSpec) -> Tuple[StateRef, ...]:
     if "root" in driver.kwargs:
         states.append(_state_from_value(driver.kwargs["root"], keyword="root"))
     return tuple(states)
+
+
+def _normalize_ground_state_driver(model: str, driver: CallSpec) -> CallSpec:
+    """Make an explicit HF/DFT ``S0`` selector equal to the omitted default.
+
+    Ground-state HF and DFT have only one physical surface, so ``grad(S0)`` and
+    ``opt(S0)`` carry no more information than ``grad`` and ``opt``. Removing
+    the redundant selector here gives both spellings the same canonical form,
+    while leaving response-method state labels untouched.
+    """
+
+    if model not in {"dft", "rks", "uks", "roks", "hf", "rhf", "uhf", "rohf"}:
+        return driver
+    if driver.name not in {"grad", "optimize"}:
+        return driver
+    states = _driver_states(driver)
+    if len(states) != 1 or states[0].label != "S0":
+        return driver
+
+    kwargs = dict(driver.kwargs)
+    if driver.args:
+        args: Tuple[Any, ...] = ()
+    elif "state" in kwargs:
+        kwargs.pop("state")
+        args = driver.args
+    else:
+        return driver
+    return CallSpec(driver.name, args, kwargs, driver.explicit)
+
+
+def _normalize_driver_defaults(model: str, driver: CallSpec) -> CallSpec:
+    """Remove driver options that exactly reproduce public runtime defaults."""
+
+    driver = _normalize_ground_state_driver(model, driver)
+    maxit = driver.kwargs.get("maxit")
+    if (
+        driver.name != "optimize"
+        or not _is_integer(maxit)
+        or maxit != 30
+    ):
+        return driver
+    kwargs = dict(driver.kwargs)
+    kwargs.pop("maxit")
+    return CallSpec(driver.name, driver.args, kwargs, driver.explicit)
 
 
 def _validate_semantics(spec: CalculationSpec) -> None:
@@ -1859,6 +1950,19 @@ def _normalize_geometry(value: Any, source_dir: Optional[Path]) -> Any:
     )
 
 
+def _qmmm_pdb_from_geometry(value: Any, source_dir: Optional[Path]) -> Optional[str]:
+    """Extract the PDB path from ``geom="system.pdb ATOM-SELECTION"``."""
+
+    if not isinstance(value, str) or "\n" in value:
+        return None
+    stripped = value.strip()
+    pdb_end = stripped.lower().find(".pdb")
+    if pdb_end < 0:
+        return None
+    pdb_path = stripped[:pdb_end + len(".pdb")]
+    return str(_resolve_path(pdb_path, source_dir))
+
+
 def _resolve_search_path_list(value: Any, source_dir: Optional[Path]) -> Any:
     """Resolve explicit/local files while preserving package search names."""
 
@@ -2057,6 +2161,12 @@ def lower_to_legacy(
             put(call.name, target_key, value)
         if call.name == "qmmm":
             put("input", "qmmm_flag", True)
+            if "pdb_file" not in call.kwargs:
+                inferred_pdb = _qmmm_pdb_from_geometry(
+                    spec.options.get("geom"), source_dir
+                )
+                if inferred_pdb is not None:
+                    put("qmmm", "pdb_file", inferred_pdb)
 
     roots = [_internal_root(spec.model, state) for state in states]
     driver_options = _driver_options(spec.driver)
@@ -2201,6 +2311,14 @@ def _render_value(value: Any) -> str:
     return str(value)
 
 
+def _render_geometry_value(value: Any) -> str:
+    """Render inline coordinates as a readable triple-quoted atom block."""
+
+    if isinstance(value, str) and "\n" in value and '"""' not in value:
+        return '"""\n%s\n"""' % value.strip("\n")
+    return _render_value(value)
+
+
 def _render_call(call: CallSpec) -> str:
     args = [_render_value(value) for value in call.args]
     args.extend("%s=%s" % (key, _render_value(value)) for key, value in call.kwargs.items())
@@ -2213,7 +2331,13 @@ def _render_call(call: CallSpec) -> str:
 
 
 def render_canonical_oqp(spec: CalculationSpec) -> str:
-    """Render a stable one-line canonical request that reparses identically."""
+    """Render stable, readable canonical input that reparses identically.
+
+    The route, options, driver, and modifiers are written as separate logical
+    lines. Geometry is deliberately last; inline coordinates use a
+    triple-quoted block with one atom per source line. The parser also accepts
+    the equivalent single-line spelling.
+    """
 
     model_args = ",".join(
         "%s=%s" % (key, _render_value(value)) for key, value in spec.model_options.items()
@@ -2231,17 +2355,42 @@ def render_canonical_oqp(spec: CalculationSpec) -> str:
     elif spec.basis:
         route += "/" + spec.basis
     option_order = (
-        "geom", "geom2", "charge", "mult", "library", "ispher",
-        "perf", "d4", "qmmm_flag", "omp_threads",
+        "charge", "mult", "library", "ispher", "perf", "d4", "qmmm_flag",
+        "omp_threads",
     )
     option_parts = [
         "%s=%s" % (key, _render_value(spec.options[key]))
-        for key in option_order if key in spec.options
+        for key in option_order
+        if key in spec.options
+        and not (
+            key == "charge"
+            and _is_integer(spec.options[key])
+            and spec.options[key] == 0
+        )
+        and not (
+            key == "mult"
+            and spec.model in DEFAULT_SINGLET_MODELS
+            and _is_integer(spec.options[key])
+            and spec.options[key] == 1
+        )
     ]
-    extra = sorted(set(spec.options) - set(option_order))
+    extra = sorted(set(spec.options) - set(option_order) - {"geom", "geom2"})
     option_parts.extend("%s=%s" % (key, _render_value(spec.options[key])) for key in extra)
-    calls = [_render_call(spec.driver)] + [_render_call(call) for call in spec.modifiers]
-    return " ".join([route] + option_parts + calls) + "\n"
+    driver = _normalize_driver_defaults(spec.model, spec.driver)
+    normalized_modifiers = [
+        normalized
+        for call in spec.modifiers
+        if (normalized := _normalize_default_section_call(call)) is not None
+    ]
+    calls = [_render_call(driver)] + [
+        _render_call(call) for call in normalized_modifiers
+    ]
+    geometry_parts = [
+        "%s=%s" % (key, _render_geometry_value(spec.options[key]))
+        for key in ("geom", "geom2")
+        if key in spec.options
+    ]
+    return "\n".join([route] + option_parts + calls + geometry_parts) + "\n"
 
 
 def _natural_model(text: str) -> Optional[str]:
@@ -2429,6 +2578,7 @@ def compile_natural_request(text: str) -> CalculationSpec:
         if images:
             driver_kwargs["images"] = int(images.group(1))
     driver = CallSpec(driver_name, tuple(args), driver_kwargs)
+    driver = _normalize_driver_defaults(model, driver)
 
     modifiers: List[CallSpec] = []
     conv = re.search(

--- a/tests/test_dftb_parameter_defaults.py
+++ b/tests/test_dftb_parameter_defaults.py
@@ -1,0 +1,69 @@
+"""Source-only tests for the bundled OpenQP-DFTB parameter default."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_input_checker(monkeypatch):
+    oqp = types.ModuleType("oqp")
+    utils = types.ModuleType("oqp.utils")
+    mpi_utils = types.ModuleType("oqp.utils.mpi_utils")
+
+    class MPIManager:
+        use_mpi = False
+        size = 1
+
+    mpi_utils.MPIManager = MPIManager
+    monkeypatch.setitem(sys.modules, "oqp", oqp)
+    monkeypatch.setitem(sys.modules, "oqp.utils", utils)
+    monkeypatch.setitem(sys.modules, "oqp.utils.mpi_utils", mpi_utils)
+
+    name = "_openqp_dftb_default_checker"
+    spec = importlib.util.spec_from_file_location(
+        name, ROOT / "pyoqp/oqp/utils/input_checker.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _dftb_config():
+    return {
+        "input": {"method": "dftb", "runtype": "energy"},
+        "dftb": {"backend": "native", "type": "ground"},
+        "properties": {"scf_prop": []},
+        "pcm": {"enabled": False},
+    }
+
+
+def test_checker_accepts_omitted_parameter_path_when_bundle_exists(
+    monkeypatch,
+):
+    checker = _load_input_checker(monkeypatch)
+    package = types.ModuleType("openqp_dftb")
+    package.default_parameter_path = lambda: "/bundle/OB2W0PT3"
+    monkeypatch.setitem(sys.modules, "openqp_dftb", package)
+    monkeypatch.delenv("OPENQP_DFTB_PARAMETER_PATH", raising=False)
+
+    report = checker.CheckReport()
+    checker._check_dftb(_dftb_config(), report)
+
+    assert not any(item.path == "dftb.parameter_path" for item in report.errors)
+
+
+def test_checker_reports_missing_bundle_and_override(monkeypatch):
+    checker = _load_input_checker(monkeypatch)
+    package = types.ModuleType("openqp_dftb")
+    monkeypatch.setitem(sys.modules, "openqp_dftb", package)
+    monkeypatch.delenv("OPENQP_DFTB_PARAMETER_PATH", raising=False)
+
+    report = checker.CheckReport()
+    checker._check_dftb(_dftb_config(), report)
+
+    assert any(item.path == "dftb.parameter_path" for item in report.errors)

--- a/tests/test_legacy_example_conversion.py
+++ b/tests/test_legacy_example_conversion.py
@@ -52,10 +52,12 @@ def test_every_current_legacy_example_is_convertible_and_committed():
         assert result.target == result.source.with_suffix(".oqp")
         assert result.target.is_file(), result.target.relative_to(ROOT)
         assert result.target.read_text(encoding="utf-8") == result.text
-        assert "\n" not in result.text.rstrip("\n")
+        assert "\n" in result.text.rstrip("\n")
+        assert "\ngeom=" in result.text
+        assert "charge=0" not in result.text
         reparsed = converter.oqp_input.parse_canonical_oqp(result.text)
         assert converter.oqp_input.render_canonical_oqp(reparsed) == result.text
-        # Compilation is also exercised: a syntactically valid line must still
+        # Compilation is also exercised: a syntactically valid file must still
         # lower into an executable legacy request.
         converter.oqp_input.lower_to_legacy(
             reparsed, source_dir=result.target.parent
@@ -116,7 +118,8 @@ def test_native_workflows_use_public_concise_options():
         run, "OPT/C2H4_BHHLYP-MRSFTDDFT_MEP.inp"
     ).text
 
-    assert 'opt(S0,' in constrained
+    assert "\nopt(" in constrained
+    assert "opt(S0" not in constrained
     assert 'freeze="distance(1,2)"' in constrained
     assert "geometric" not in constrained.lower()
     assert "meci(S0,S1,S2," in baeka
@@ -187,7 +190,7 @@ def test_ump2_reference_survives_example_conversion():
     run = _run()
     ump2 = _result(run, "MP2/h2o_ump2_6-31g.inp")
 
-    assert ump2.text.startswith("mp2(reference=uhf)/6-31g ")
+    assert ump2.text.startswith("mp2(reference=uhf)/6-31g\n")
     lowered = converter.oqp_input.lower_to_legacy(
         converter.oqp_input.parse_canonical_oqp(ump2.text),
         source_dir=ump2.target.parent,

--- a/tests/test_openqp_api.py
+++ b/tests/test_openqp_api.py
@@ -838,6 +838,8 @@ $$$$
         self.assertEqual(config["input"]["qmmm_flag"], "True")
         self.assertEqual(config["input"]["runtype"], "energy")
         self.assertEqual(config["qmmm"]["embedding"], "electrostatic")
+        self.assertEqual(config["qmmm"]["pdb_file"], "ala.pdb")
+        self.assertEqual(config["qmmm"]["qm_atoms"], "9 10 17 18 19")
 
     def test_qmmm_frontier_scheme_sets_section_key(self):
         openqp = load_openqp_module()
@@ -874,15 +876,16 @@ $$$$
         openqp = load_openqp_module()
         job = (
             openqp.OpenQP(project="socnamd_qmmm")
-            .molecule("chromo.pdb 0 1 2 3 4", basis="6-31g*")
+            .molecule("chromo.pdb 0-4", basis="6-31g*")
             .theory("mrsf-tddft", functional="bhhlyp", nstate=3)
-            .qmmm(qm_atoms="0-4", cutoff="PME")
+            .qmmm(cutoff="PME")
         )
         job.workflow.namd(soc=True, soc_basis="mch", nstep=200, dt=0.5, init_state="S1")
         config = job.to_input_dict()
         self.assertEqual(config["input"]["qmmm_flag"], "True")
         self.assertEqual(config["input"]["runtype"], "namd")
         self.assertEqual(config["qmmm"]["pdb_file"], "chromo.pdb")
+        self.assertEqual(config["qmmm"]["qm_atoms"], "0-4")
         self.assertEqual(config["tdhf"]["type"], "mrsf")
         self.assertEqual(config["md"]["soc"], "True")
         self.assertEqual(config["md"]["soc_basis"], "mch")

--- a/tests/test_openqp_api.py
+++ b/tests/test_openqp_api.py
@@ -855,7 +855,6 @@ $$$$
         openqp = load_openqp_module()
         job = openqp.OpenQP(project="qmmm_md").molecule("m.pdb 0 1 2", basis="6-31g")
         job.qmmm(
-            pdb_file="m.pdb",
             forcefield=["amber14-all.xml", "amber14/tip3p.xml"],
             qm_atoms=[0, 1, 2],
             cutoff="PME",
@@ -865,6 +864,7 @@ $$$$
         self.assertEqual(
             config["qmmm"]["forcefield_files"], "amber14-all.xml,amber14/tip3p.xml"
         )
+        self.assertEqual(config["qmmm"]["pdb_file"], "m.pdb")
         self.assertEqual(config["qmmm"]["qm_atoms"], "0 1 2")
         self.assertEqual(config["qmmm"]["cutoff"], "PME")
         with self.assertRaisesRegex(ValueError, "either forcefield or forcefield_files"):
@@ -876,12 +876,13 @@ $$$$
             openqp.OpenQP(project="socnamd_qmmm")
             .molecule("chromo.pdb 0 1 2 3 4", basis="6-31g*")
             .theory("mrsf-tddft", functional="bhhlyp", nstate=3)
-            .qmmm(pdb_file="chromo.pdb", qm_atoms="0-4", cutoff="PME")
+            .qmmm(qm_atoms="0-4", cutoff="PME")
         )
         job.workflow.namd(soc=True, soc_basis="mch", nstep=200, dt=0.5, init_state="S1")
         config = job.to_input_dict()
         self.assertEqual(config["input"]["qmmm_flag"], "True")
         self.assertEqual(config["input"]["runtype"], "namd")
+        self.assertEqual(config["qmmm"]["pdb_file"], "chromo.pdb")
         self.assertEqual(config["tdhf"]["type"], "mrsf")
         self.assertEqual(config["md"]["soc"], "True")
         self.assertEqual(config["md"]["soc_basis"], "mch")

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -105,7 +105,7 @@ def test_mult_is_canonical_and_long_spelling_is_only_an_input_alias():
         'hf/6-31g* geom="radical.xyz" multiplicity=2 energy()'
     )
     assert short.options == long.options == {"geom": "radical.xyz", "mult": 2}
-    assert " mult=2 " in oqp_input.render_canonical_oqp(long)
+    assert "\nmult=2\n" in oqp_input.render_canonical_oqp(long)
     assert "multiplicity=" not in oqp_input.render_canonical_oqp(long)
     with pytest.raises(OQPInputError, match="not a route option"):
         oqp_input.parse_canonical_oqp(
@@ -243,7 +243,7 @@ def test_no_driver_defaults_to_explicitly_rendered_energy():
     assert spec.driver.name == "energy"
     assert spec.driver.explicit is False
     assert legacy["input"]["runtype"] == "energy"
-    assert oqp_input.render_canonical_oqp(spec).endswith(" energy\n")
+    assert "\nenergy\n" in oqp_input.render_canonical_oqp(spec)
 
 
 @pytest.mark.parametrize("driver", ["opt", "opt()"])
@@ -255,6 +255,134 @@ def test_mrsf_opt_without_state_defaults_to_s0(driver):
     assert legacy["optimize"]["istate"] == "1"
 
 
+@pytest.mark.parametrize(
+    ("route", "short_driver", "explicit_driver", "section", "key"),
+    [
+        ("hf/6-31g", "grad", "grad(S0)", "properties", "grad"),
+        ("dft/pbe0/6-31g", "grad", "grad(S0)", "properties", "grad"),
+        ("hf/6-31g", "opt", "opt(S0)", "optimize", "istate"),
+        ("dft/pbe0/6-31g", "opt", "opt(S0)", "optimize", "istate"),
+    ],
+)
+def test_hf_dft_ground_driver_s0_is_the_omitted_default(
+    route, short_driver, explicit_driver, section, key
+):
+    short = oqp_input.parse_canonical_oqp(
+        '%s geom="h2o.xyz" %s' % (route, short_driver)
+    )
+    explicit = oqp_input.parse_canonical_oqp(
+        '%s geom="h2o.xyz" %s' % (route, explicit_driver)
+    )
+
+    assert short.driver == explicit.driver
+    assert oqp_input.render_canonical_oqp(short) == oqp_input.render_canonical_oqp(
+        explicit
+    )
+    assert oqp_input.lower_to_legacy(short) == oqp_input.lower_to_legacy(explicit)
+    assert oqp_input.lower_to_legacy(explicit)[section][key] == "0"
+
+
+def test_concise_defaults_do_not_need_to_be_written():
+    short = oqp_input.parse_canonical_oqp(
+        'dft/pbe0/6-31g geom="h2o.xyz" opt'
+    )
+    explicit = oqp_input.parse_canonical_oqp(
+        'dft/pbe0/6-31g geom="h2o.xyz" charge=0 mult=1 '
+        'opt(S0,maxit=30)'
+    )
+
+    assert short.options == explicit.options
+    assert short.driver == explicit.driver
+    assert oqp_input.render_canonical_oqp(short) == oqp_input.render_canonical_oqp(
+        explicit
+    )
+    assert "charge=" not in oqp_input.render_canonical_oqp(explicit)
+    assert "mult=" not in oqp_input.render_canonical_oqp(explicit)
+    assert "maxit" not in oqp_input.render_canonical_oqp(explicit)
+    assert "maxit" not in oqp_input.lower_to_legacy(explicit)["optimize"]
+
+
+def test_dftb_bundled_parameter_defaults_need_no_section_call():
+    short = oqp_input.parse_canonical_oqp(
+        'dftb geom="h2o.xyz" energy'
+    )
+    explicit_defaults = oqp_input.parse_canonical_oqp(
+        'dftb geom="h2o.xyz" charge=0 energy '
+        'dftb(backend=native,parameter_path="")'
+    )
+
+    assert oqp_input.render_canonical_oqp(short) == oqp_input.render_canonical_oqp(
+        explicit_defaults
+    )
+    assert all(call.name != "dftb" for call in explicit_defaults.modifiers)
+    assert "parameter_path" not in oqp_input.lower_to_legacy(short)["dftb"]
+
+
+def test_single_line_and_line_oriented_inputs_are_identical():
+    single = oqp_input.parse_canonical_oqp(
+        'dft/pbe0/6-31g geom="h2o.xyz" charge=0 opt(S0) scf(conv=1e-8)'
+    )
+    multiline = oqp_input.parse_canonical_oqp(
+        """\
+dft/pbe0/6-31g
+opt(S0)
+scf(
+  conv=1e-8
+)
+geom="h2o.xyz"
+"""
+    )
+
+    assert multiline.model == single.model
+    assert multiline.functional == single.functional
+    assert multiline.basis == single.basis
+    assert multiline.options == single.options
+    assert multiline.driver == single.driver
+    assert multiline.modifiers == single.modifiers
+    assert oqp_input.lower_to_legacy(multiline) == oqp_input.lower_to_legacy(single)
+    assert oqp_input.render_canonical_oqp(multiline) == (
+        "dft/pbe0/6-31g\n"
+        "opt\n"
+        "scf(conv=1e-08)\n"
+        'geom="h2o.xyz"\n'
+    )
+
+
+def test_inline_geometry_renders_one_atom_per_line_and_reparses():
+    single_line = oqp_input.parse_canonical_oqp(
+        'hf/sto-3g energy geom="O 0 0 0\\nH 0 0 1\\nH 0 1 0"'
+    )
+    multiline = oqp_input.parse_canonical_oqp(
+        '''\
+hf/sto-3g
+energy
+geom="""
+O 0 0 0
+H 0 0 1
+H 0 1 0
+"""
+'''
+    )
+
+    assert multiline.options["geom"] == single_line.options["geom"]
+    rendered = oqp_input.render_canonical_oqp(single_line)
+
+    assert rendered == (
+        "hf/sto-3g\n"
+        "energy\n"
+        'geom="""\n'
+        "O 0 0 0\n"
+        "H 0 0 1\n"
+        "H 0 1 0\n"
+        '"""\n'
+    )
+    reparsed = oqp_input.parse_canonical_oqp(rendered)
+    assert reparsed.options["geom"] == single_line.options["geom"]
+    assert oqp_input.lower_to_legacy(reparsed) == oqp_input.lower_to_legacy(
+        single_line
+    )
+
+
 def test_harmless_whitespace_and_bare_calls_normalize_to_compact_input():
     spec, legacy = _parse(
         'mrsf(nstate = 3)/bhhlyp/6-31g* geom = "h2o.xyz" '
@@ -264,8 +392,10 @@ def test_harmless_whitespace_and_bare_calls_normalize_to_compact_input():
     assert legacy["optimize"]["maxit"] == "100"
     assert legacy["scf"]["conv"] == "1e-08"
     assert oqp_input.render_canonical_oqp(spec) == (
-        'mrsf(nstate=3)/bhhlyp/6-31g* geom="h2o.xyz" '
-        'opt(S0,maxit=100) scf(conv=1e-08)\n'
+        "mrsf(nstate=3)/bhhlyp/6-31g*\n"
+        "opt(S0,maxit=100)\n"
+        "scf(conv=1e-08)\n"
+        'geom="h2o.xyz"\n'
     )
 
 
@@ -275,7 +405,12 @@ def test_zero_argument_drivers_and_simple_modifiers_render_without_parentheses()
     )
     rendered = oqp_input.render_canonical_oqp(spec)
     assert rendered == (
-        'dft/pbe0/def2-svp geom="h2o.xyz" energy pcm nmr d4\n'
+        "dft/pbe0/def2-svp\n"
+        "energy\n"
+        "pcm\n"
+        "nmr\n"
+        "d4\n"
+        'geom="h2o.xyz"\n'
     )
     assert oqp_input.render_canonical_oqp(
         oqp_input.parse_canonical_oqp(rendered)
@@ -286,7 +421,7 @@ def test_zero_argument_drivers_and_simple_modifiers_render_without_parentheses()
     mrsf = oqp_input.parse_canonical_oqp(
         'mrsf(nstate=3)/bhhlyp/6-31g* geom="h2o.xyz" opt()'
     )
-    assert oqp_input.render_canonical_oqp(mrsf).endswith(" opt\n")
+    assert "\nopt\n" in oqp_input.render_canonical_oqp(mrsf)
 
 
 @pytest.mark.parametrize("geometry", ["h2o.xyz", '"water molecule.pdb"'])
@@ -298,8 +433,9 @@ def test_geometry_file_may_follow_the_route_positionally(geometry):
     assert spec.options["geom"] == expected
     assert legacy["input"]["system"] == expected
     assert oqp_input.render_canonical_oqp(spec) == (
-        'mrsf(nstate=3)/bhhlyp/6-31g* geom=%s opt\n'
-        % oqp_input._render_value(expected)
+        "mrsf(nstate=3)/bhhlyp/6-31g*\n"
+        "opt\n"
+        "geom=%s\n" % oqp_input._render_value(expected)
     )
 
 
@@ -498,8 +634,10 @@ def test_natural_korean_request_writes_and_reparses_resolved_file(tmp_path):
     assert result.resolved_path == tmp_path / "water.resolved.oqp"
     assert result.resolved_path.read_text(encoding="utf-8") == result.canonical_text
     assert result.canonical_text == (
-        'mrsf(nstate=5)/bhhlyp/6-31g* geom="h2o.xyz" charge=0 '
-        'opt(S1,maxit=100) scf(conv=1e-08)\n'
+        "mrsf(nstate=5)/bhhlyp/6-31g*\n"
+        "opt(S1,maxit=100)\n"
+        "scf(conv=1e-08)\n"
+        'geom="h2o.xyz"\n'
     )
     assert result.legacy_config["input"]["system"] == str((tmp_path / "h2o.xyz").resolve())
     assert result.legacy_config["optimize"]["istate"] == "2"
@@ -605,6 +743,22 @@ def test_qmmm_call_enables_qmmm_and_resolves_local_paths(tmp_path):
         "amber14-all.xml," + str((tmp_path / "custom.xml").resolve())
     )
     assert legacy["properties"]["grad"] == "0"
+
+
+def test_qmmm_pdb_file_is_inferred_from_the_last_geometry_line(tmp_path):
+    text = """\
+mrsf(nstate=3)/bhhlyp/6-31g*
+namd(S1,soc=true,soc_basis=mch,nstep=200)
+qmmm(forcefield_files="amber14-all.xml,amber14/tip3p.xml",qm_atoms="0-14")
+geom="chromophore_water.pdb 0-14"
+"""
+
+    spec, legacy = _parse(text, tmp_path)
+
+    pdb = str((tmp_path / "chromophore_water.pdb").resolve())
+    assert legacy["input"]["system"] == pdb + " 0-14"
+    assert legacy["qmmm"]["pdb_file"] == pdb
+    assert "pdb_file" not in oqp_input.render_canonical_oqp(spec)
 
 
 @pytest.mark.parametrize("spelling", ["nsteps", "n_steps"])
@@ -1010,6 +1164,17 @@ def test_count_and_multiplicity_fields_reject_lossy_integer_coercion(value):
         )
 
 
+def test_default_normalization_does_not_hide_lossy_numeric_types():
+    with pytest.raises(OQPInputError, match="charge must be an integer"):
+        oqp_input.parse_canonical_oqp(
+            'dft/pbe0/6-31g* geom="g.xyz" charge=0.0 energy'
+        )
+    with pytest.raises(OQPInputError, match="maxit must be a positive integer"):
+        oqp_input.parse_canonical_oqp(
+            'dft/pbe0/6-31g* geom="g.xyz" opt(maxit=30.0)'
+        )
+
+
 def test_tci_retains_legacy_multiplicative_controls():
     _, legacy = _parse(
         'mrsf(nstate=5)/bhhlyp/6-31g* geom="guess.xyz" '
@@ -1147,7 +1312,7 @@ def test_dftb0_route_and_alias_lower_to_non_scc_ground_state():
 
     assert spec.model == "dftb0"
     assert spec.physical_method == "DFTB0"
-    assert oqp_input.render_canonical_oqp(spec).startswith("dftb0 ")
+    assert oqp_input.render_canonical_oqp(spec).startswith("dftb0\n")
     assert legacy["input"]["method"] == "dftb"
     assert legacy["dftb"]["type"] == "ground_noscc"
     assert legacy["properties"]["grad"] == "0"
@@ -1161,7 +1326,7 @@ def test_tda_tddftb_route_is_canonical_tda_singlet_response():
 
     assert spec.model == "tda-dftb"
     assert spec.physical_method == "TD-DFTB (TDA)"
-    assert oqp_input.render_canonical_oqp(spec).startswith("tda-tddftb(nstate=3) ")
+    assert oqp_input.render_canonical_oqp(spec).startswith("tda-tddftb(nstate=3)\n")
     assert legacy["tdhf"]["type"] == "tda"
     assert legacy["tdhf"]["multiplicity"] == "1"
     assert legacy["dftb"]["type"] == "tddftb"
@@ -1212,7 +1377,7 @@ def test_sf_tddftb_route_uses_high_spin_reference_and_explicit_root():
     assert spec.physical_method == "SF-TDDFTB"
     assert spec.reference_method == "ROHF"
     assert spec.reference_multiplicity == 3
-    assert oqp_input.render_canonical_oqp(spec).startswith("sf-tddftb(nstate=3) ")
+    assert oqp_input.render_canonical_oqp(spec).startswith("sf-tddftb(nstate=3)\n")
     assert legacy["scf"] == {"type": "rohf", "multiplicity": "3"}
     assert legacy["tdhf"]["type"] == "sf"
     assert legacy["tdhf"]["multiplicity"] == "1"

--- a/tests/test_oqp_input_schema_manifest.py
+++ b/tests/test_oqp_input_schema_manifest.py
@@ -119,7 +119,7 @@ def test_every_schema_keyword_has_exactly_one_semantic_input_owner():
         owner_counts.update(owners.values())
 
     assert owner_counts == {
-        "generic": 202,
+        "generic": 204,
         "route_driver": 104,
         "legacy_only": 21,
         "intentional_forbidden": 1,
@@ -132,6 +132,7 @@ def test_every_schema_keyword_has_exactly_one_semantic_input_owner():
 def test_all_generic_schema_keys_survive_parse_render_reparse_and_lower():
     oqp_input = _load_oqp_input()
     defaults = _schema_defaults_from_ast()
+    concise_dftb_defaults = {("dftb", "backend"), ("dftb", "parameter_path")}
 
     checked = []
     for section, keys in oqp_input.GENERIC_SCHEMA_KEYS.items():
@@ -149,10 +150,15 @@ def test_all_generic_schema_keys_survive_parse_render_reparse_and_lower():
             canonical = oqp_input.render_canonical_oqp(first)
             reparsed = oqp_input.parse_canonical_oqp(canonical)
             lowered = oqp_input.lower_to_legacy(reparsed)
-            assert key in lowered.get(section, {}), (section, key, canonical, lowered)
+            if (section, key) in concise_dftb_defaults:
+                assert key not in lowered.get(section, {})
+            else:
+                assert key in lowered.get(section, {}), (
+                    section, key, canonical, lowered
+                )
             checked.append((section, key))
 
-    assert len(checked) == 202
+    assert len(checked) == 204
 
 
 def test_legacy_backend_schema_is_recognized_but_not_canonical():

--- a/tools/convert_legacy_examples.py
+++ b/tools/convert_legacy_examples.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate concise, one-line ``.oqp`` companions for legacy examples.
+"""Generate concise, readable ``.oqp`` companions for legacy examples.
 
 This is deliberately an example migration tool, not a second runtime parser.
 It consumes every explicitly written legacy keyword, builds the public


### PR DESCRIPTION
## Summary

- accept equivalent one-line and line-oriented `.oqp` input, render canonical output with one clause per line, and keep `geom`/`geom2` last
- support readable atom-per-line inline geometry while retaining single-line and escaped-newline forms
- omit redundant defaults such as `charge=0`, `opt(maxit=30)`, and native DFTB parameter controls
- normalize HF/DFT `grad(S0)` and `opt(S0)` to the unlabeled ground-state drivers
- infer QM/MM PDB input from the geometry in both `.oqp` and Python, and resolve bundled DFTB parameters automatically
- regenerate all committed `.oqp` example companions

## Companion documentation

- Documentation PR: https://github.com/Open-Quantum-Platform/openqp-docs/pull/17

## Validation

- `209 passed` across the semantic input, converter, schema, Python API, DFTB API, and runtime-root test suites
- `252` legacy examples convertible, `0` blocked
- Python byte-compilation passed for the changed runtime modules

## Native test note

The source/API suites pass. The optional local compiled DFTB QM/MM test was not
run to completion because the installed native DFTB backend segfaults in its
existing ethane link-atom call.
