### PR TITLE
Omit duplicate QM/MM PDB paths

### DIFF
--- a/examples/QMMM/ala-dipeptide_BHHLYP-QMMM-MD-RCD.oqp
+++ b/examples/QMMM/ala-dipeptide_BHHLYP-QMMM-MD-RCD.oqp
@@ -1,4 +1,4 @@
 rks/bhhlyp/6-31g
 md(S0)
-qmmm(pdb_file="ala.pdb",forcefield_files="amber14-all.xml",qm_atoms="8,9,16,17,18",cutoff=NoCutoff,embedding=electrostatic,frontier_scheme=rcd,n_steps=2,timestep=0.5,ensemble=nve,temperature=300.0)
+qmmm(forcefield_files="amber14-all.xml",qm_atoms="8,9,16,17,18",cutoff=NoCutoff,embedding=electrostatic,frontier_scheme=rcd,n_steps=2,timestep=0.5,ensemble=nve,temperature=300.0)
 geom="ala.pdb"

--- a/examples/QMMM/run.oqp
+++ b/examples/QMMM/run.oqp
@@ -1,5 +1,5 @@
 rks/bhhlyp/6-31g
 md(S0)
 scf(maxit=100)
-qmmm(pdb_file="water_dimer.pdb",forcefield_files="tip3p.xml",qm_atoms="0-2",cutoff=PME,embedding=electrostatic,n_steps=1000,timestep=0.1,temperature=300.0)
+qmmm(forcefield_files="tip3p.xml",qm_atoms="0-2",cutoff=PME,embedding=electrostatic,n_steps=1000,timestep=0.1,temperature=300.0)
 geom="water_dimer.pdb"

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -18,6 +18,7 @@ import ast
 import difflib
 import json
 import math
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -158,6 +159,31 @@ def _normalize_default_section_call(call: CallSpec) -> Optional[CallSpec]:
         kwargs.pop("parameter_path")
     if not call.args and not kwargs:
         return None
+    return CallSpec(call.name, call.args, kwargs, call.explicit)
+
+
+def _normalize_geometry_owned_section_call(
+    call: CallSpec,
+    geometry: Any,
+) -> CallSpec:
+    """Remove section values already supplied by the compact geometry."""
+
+    if call.name != "qmmm" or "pdb_file" not in call.kwargs:
+        return call
+    geometry_pdb = _qmmm_pdb_from_geometry(geometry, source_dir=None)
+    explicit_pdb = call.kwargs["pdb_file"]
+    if not isinstance(geometry_pdb, str) or not isinstance(explicit_pdb, str):
+        return call
+    normalized_geometry = os.path.normcase(
+        os.path.normpath(os.path.expanduser(geometry_pdb.strip()))
+    )
+    normalized_explicit = os.path.normcase(
+        os.path.normpath(os.path.expanduser(explicit_pdb.strip()))
+    )
+    if normalized_geometry != normalized_explicit:
+        return call
+    kwargs = dict(call.kwargs)
+    kwargs.pop("pdb_file")
     return CallSpec(call.name, call.args, kwargs, call.explicit)
 
 
@@ -2378,7 +2404,10 @@ def render_canonical_oqp(spec: CalculationSpec) -> str:
     option_parts.extend("%s=%s" % (key, _render_value(spec.options[key])) for key in extra)
     driver = _normalize_driver_defaults(spec.model, spec.driver)
     normalized_modifiers = [
-        normalized
+        _normalize_geometry_owned_section_call(
+            normalized,
+            spec.options.get("geom"),
+        )
         for call in spec.modifiers
         if (normalized := _normalize_default_section_call(call)) is not None
     ]

--- a/tests/test_legacy_example_conversion.py
+++ b/tests/test_legacy_example_conversion.py
@@ -140,6 +140,9 @@ def test_nmr_qmmm_and_nacme_edge_cases_preserve_intent():
     nmr = _result(run, "NMR/H2O_RHF-NMR.inp")
     compact_qmmm = _result(run, "QMMM/ala.inp")
     qmmm_without_system = _result(run, "QMMM/run.inp")
+    qmmm_same_pdb = _result(
+        run, "QMMM/ala-dipeptide_BHHLYP-QMMM-MD-RCD.inp"
+    )
     soc_namd = _result(
         run, "QMMM/H2CO-water_BHHLYP-SOC-NAMD-QMMM.inp"
     )
@@ -168,7 +171,10 @@ def test_nmr_qmmm_and_nacme_edge_cases_preserve_intent():
         + " 9 10 17 18 19"
     )
     assert 'geom="water_dimer.pdb"' in qmmm_without_system.text
+    assert "pdb_file" not in qmmm_without_system.text
     assert "synthesized geom from qmmm.pdb_file" in qmmm_without_system.warnings
+    assert 'geom="ala.pdb"' in qmmm_same_pdb.text
+    assert "pdb_file" not in qmmm_same_pdb.text
     lowered_md = converter.oqp_input.lower_to_legacy(
         converter.oqp_input.parse_canonical_oqp(qmmm_without_system.text),
         source_dir=qmmm_without_system.target.parent,

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -760,6 +760,20 @@ geom="chromophore_water.pdb 0-14"
     assert legacy["qmmm"]["pdb_file"] == pdb
     assert "pdb_file" not in oqp_input.render_canonical_oqp(spec)
 
+    redundant = oqp_input.parse_canonical_oqp(
+        text.replace(
+            'qmmm(forcefield_files=',
+            'qmmm(pdb_file="chromophore_water.pdb",forcefield_files=',
+        )
+    )
+    assert "pdb_file" not in oqp_input.render_canonical_oqp(redundant)
+
+    distinct = oqp_input.parse_canonical_oqp(
+        'dft/pbe0/def2-svp energy '
+        'qmmm(pdb_file="environment.pdb") geom="qm.xyz"'
+    )
+    assert 'pdb_file="environment.pdb"' in oqp_input.render_canonical_oqp(distinct)
+
 
 @pytest.mark.parametrize("spelling", ["nsteps", "n_steps"])
 def test_qmmm_md_step_alias_lowers_to_active_config_key(spelling):


### PR DESCRIPTION
## Summary

- omit `qmmm.pdb_file` from canonical `.oqp` rendering when `geom` already names the same PDB
- keep explicit `pdb_file` when the QM geometry is a different XYZ or PDB source
- regenerate the two affected QM/MM examples so each PDB path appears once

## Why

PR #282 added geometry-based QM/MM PDB inference, but two generated `.oqp`
companions still repeated the same PDB in both `qmmm(...)` and `geom`.

## Validation

- `131 passed` across semantic `.oqp` and legacy-example conversion tests
- `252` legacy examples convertible, `0` blocked
