### PR TITLE
fix(opt): recover CPHF failures and seed DFTB threads

### DIFF
--- a/docs/native_optimization_recovery.md
+++ b/docs/native_optimization_recovery.md
@@ -52,6 +52,14 @@ ordinary minima, penalty MECI/MECP, and two- or multistate BaekA:
 4. A final bounded stage uses Cartesian coordinates and half the recovery
    trust (or returns to DLC if Cartesian was already used).
 
+Within an individual engine attempt, a non-finite internal-coordinate
+back-transformation, step prediction, Hessian update, or MECI/BaekA objective
+rebase is rejected before it can enter the quasi-Newton history. The engine
+then switches that attempt to bounded Cartesian steps, resets its model
+Hessian, and leaves the outer recovery ladder free to retry fresh internal
+coordinates from the best finite geometry. This applies equally to minima and
+MECI/MECP objectives.
+
 Explicit `coordsys`, `trust`, and `trust_max` values bypass the automatic
 initial profile. `auto_recovery=false` disables the phase handoff and recovery
 stages.

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_BAEKA_OQP.inp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_BAEKA_OQP.inp
@@ -42,3 +42,4 @@ rmsd_grad=2e-3
 coordsys=auto
 trust=0.15
 trust_max=0.5
+auto_recovery=false

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_BAEKA_OQP.oqp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_BAEKA_OQP.oqp
@@ -1,5 +1,5 @@
 mrsf(nstate=5)/bhhlyp/6-31g*
-meci(S0,S1,S2,maxit=1,algorithm=baeka,sigma=1.0,alpha=0.02,delta_beta=0.025,beta_schedule="10,10,25,25,100,100,1000,1000,3000",gap=0.0001,energy_shift=1e-06,rmsd_grad=0.002,coordsys=auto,trust=0.15,trust_max=0.5)
+meci(S0,S1,S2,maxit=1,algorithm=baeka,sigma=1.0,alpha=0.02,delta_beta=0.025,beta_schedule="10,10,25,25,100,100,1000,1000,3000",gap=0.0001,energy_shift=1e-06,rmsd_grad=0.002,coordsys=auto,trust=0.15,trust_max=0.5,auto_recovery=false)
 scf(maxit=30)
 tdhf(maxit=30)
 geom="../geometries/C2H4-41911fceceb6.xyz"

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECI.inp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECI.inp
@@ -23,6 +23,8 @@ nstate=5
 maxit=30
 
 [optimize]
+lib=oqp
+meci_search=penalty
 optimizer=bfgs
 maxit=1
 istate=1
@@ -34,3 +36,5 @@ max_grad=1
 rmsd_step=1
 max_step=1
 
+[oqp]
+auto_recovery=false

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECI.oqp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECI.oqp
@@ -1,5 +1,5 @@
 mrsf(nstate=5)/bhhlyp/6-31g*
-meci(S0,S1,maxit=1,energy_shift=1,gap=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1)
+meci(S0,S1,maxit=1,algorithm=penalty,energy_shift=1,gap=1,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,auto_recovery=false)
 scf(maxit=30)
 tdhf(maxit=30)
 geom="../geometries/C2H4-41911fceceb6.xyz"

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECP_OQP.inp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECP_OQP.inp
@@ -40,3 +40,4 @@ max_step=1
 coordsys=tric
 trust=0.1
 trust_max=0.3
+auto_recovery=false

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECP_OQP.oqp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_MECP_OQP.oqp
@@ -1,5 +1,5 @@
 mrsf(nstate=5)/bhhlyp/6-31g*
-mecp(S0,T0,maxit=2,energy_shift=1,energy_gap=0.0001,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=tric,trust=0.1,trust_max=0.3)
+mecp(S0,T0,maxit=2,energy_shift=1,energy_gap=0.0001,rmsd_grad=1,max_grad=1,rmsd_step=1,max_step=1,coordsys=tric,trust=0.1,trust_max=0.3,auto_recovery=false)
 scf(maxit=30)
 tdhf(maxit=30)
 geom="../geometries/C2H4-41911fceceb6.xyz"

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_TCI_OQP.inp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_TCI_OQP.inp
@@ -39,3 +39,4 @@ max_step=8e-3
 [oqp]
 coordsys=auto
 trust=0.15
+auto_recovery=false

--- a/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_TCI_OQP.oqp
+++ b/examples/OPT/C2H4_BHHLYP-MRSFTDDFT_TCI_OQP.oqp
@@ -1,5 +1,5 @@
 mrsf(nstate=5)/bhhlyp/6-31g*
-tci(S0,S1,S2,maxit=1,pen_sigma=2.0,pen_incre=1.2,energy_gap=0.002,rmsd_grad=0.002,max_grad=0.004,rmsd_step=0.004,max_step=0.008,coordsys=auto,trust=0.15)
+tci(S0,S1,S2,maxit=1,pen_sigma=2.0,pen_incre=1.2,energy_gap=0.002,rmsd_grad=0.002,max_grad=0.004,rmsd_step=0.004,max_step=0.008,coordsys=auto,trust=0.15,auto_recovery=false)
 scf(maxit=30)
 tdhf(maxit=30)
 geom="../geometries/C2H4-41911fceceb6.xyz"

--- a/examples/OPT/H2O_RHF-DFT_OPTIMIZE.inp
+++ b/examples/OPT/H2O_RHF-DFT_OPTIMIZE.inp
@@ -14,6 +14,9 @@ type=rhf
 multiplicity=1
 
 [optimize]
+lib=oqp
 istate=0
 maxit=1
 
+[oqp]
+auto_recovery=false

--- a/examples/OPT/H2O_RHF-DFT_OPTIMIZE.oqp
+++ b/examples/OPT/H2O_RHF-DFT_OPTIMIZE.oqp
@@ -1,3 +1,3 @@
 rks/bhhlyp/6-31g*
-opt(maxit=1)
+opt(maxit=1,auto_recovery=false)
 geom="../geometries/H2O-781cba5cd72b.xyz"

--- a/pyoqp/oqp/library/liboqp.py
+++ b/pyoqp/oqp/library/liboqp.py
@@ -405,7 +405,9 @@ class _OQPRunner:
             return True
         solver = any(
             token in message
-            for token in ("scf", "scc", "tdhf", "response", "z-vector", "zvector")
+            for token in (
+                "scf", "scc", "tdhf", "response", "cphf", "z-vector", "zvector",
+            )
         )
         exhausted = any(
             token in message

--- a/pyoqp/oqp/library/openqp_dftb.py
+++ b/pyoqp/oqp/library/openqp_dftb.py
@@ -107,6 +107,46 @@ _ABI1_UNSUPPORTED_OPTION_DEFAULTS = {
 }
 
 
+def _state_gradient_argtypes(abi_version: int) -> list[object]:
+    """Return the exact ctypes signature of ``openqp_dftb_state_gradient``.
+
+    The C entry point is a fixed-arity Fortran ``bind(C)`` routine.  Leaving
+    it untyped makes ctypes use its permissive foreign-call path; an argument
+    layout drift can then corrupt native pointers instead of producing a
+    Python exception.  The explicit signature also matters on arm64, where
+    fixed and variadic foreign calls use different ABI classification rules.
+    """
+    i64 = ctypes.c_int64
+    i32 = ctypes.c_int32
+    f64 = ctypes.c_double
+    p_i64 = ctypes.POINTER(i64)
+    p_f64 = ctypes.POINTER(f64)
+
+    # slots 1--37 in _state_gradient_common_arguments
+    common = [
+        i64, p_i64, p_f64, ctypes.c_char_p, i32, ctypes.c_char_p, i32,
+        *([i64] * 16),
+        *([f64] * 14),
+    ]
+    # c_mrsf, response_global_hybrid, onsite_exchange_scale
+    controls = [f64, i64, f64]
+    if abi_version != 1:
+        # ABI v2/v3 extended DTCAM controls and the preset name.
+        controls.extend([
+            *([f64] * 9), ctypes.c_char_p, i32,
+        ])
+    # n_ext_pot/ext_potential followed by the result/output tail.
+    tail = [
+        i64, p_f64,
+        p_f64, p_f64, p_f64, p_f64, p_f64,
+        p_i64, p_f64, p_f64, p_f64,
+        p_i64, p_i64, p_i64, p_i64,
+        i64, p_f64, p_f64, i64, p_f64,
+        ctypes.c_char_p, i32, p_i64,
+    ]
+    return common + controls + tail
+
+
 def _bundled_parameter_path() -> str | None:
     """Bundled OB2W0PT3 default of the installed openqp-dftb wheel, if any.
 
@@ -1252,10 +1292,8 @@ class OpenQPDFTBAdapter:
                 f"{path} does not export openqp_dftb_state_gradient; "
                 "rebuild openqp-dftb with OPENQP_DFTB_BUILD_SHARED=ON."
             )
-        # The state-gradient arguments are passed by value with no argtypes
-        # metadata, so an adapter/library revision mismatch would silently
-        # read garbage. Detect the ABI before the first call and dispatch its
-        # exact argument layout. The released v1 predates the version symbol.
+        # Detect the ABI before the first call and install its exact fixed
+        # ctypes signature. The released v1 predates the version symbol.
         abi_probe = getattr(lib, "openqp_dftb_capi_abi_version", None)
         if abi_probe is not None:
             abi_probe.restype = ctypes.c_int64
@@ -1285,6 +1323,9 @@ class OpenQPDFTBAdapter:
                 f"{path} exports openqp-dftb C ABI version {abi_version}, but this "
                 "OpenQP adapter supports only versions 1, 2, and 3."
             )
+        lib.openqp_dftb_state_gradient.argtypes = _state_gradient_argtypes(
+            abi_version
+        )
         lib.openqp_dftb_state_gradient.restype = None
         cache["__native_library__"] = lib
         cache["__native_abi_version__"] = abi_version

--- a/pyoqp/oqp/library/oqp_coords.py
+++ b/pyoqp/oqp/library/oqp_coords.py
@@ -356,6 +356,8 @@ class RedundantInternalCoordinates:
         """
         x = np.asarray(x, dtype=float).reshape(-1, 3)
         q_target = self.q(x) + dq
+        if not np.all(np.isfinite(q_target)):
+            return x.reshape(-1), False
         x_cur = x.copy()
         prev_norm = None
         best = x_cur.copy()
@@ -363,7 +365,12 @@ class RedundantInternalCoordinates:
             b = self.b_matrix(x_cur)
             ginv, _ = self._g_inverse(b)
             dq_remain = self.q_displacement(q_target, self.q(x_cur))
+            if (not np.all(np.isfinite(b)) or not np.all(np.isfinite(ginv))
+                    or not np.all(np.isfinite(dq_remain))):
+                return best.reshape(-1), False
             err = np.linalg.norm(dq_remain)
+            if not np.isfinite(err):
+                return best.reshape(-1), False
             if prev_norm is not None and err > prev_norm * 1.0001 + 1.0e-10:
                 # Diverging: return the best Cartesian step found so far.
                 return best.reshape(-1), False
@@ -371,8 +378,12 @@ class RedundantInternalCoordinates:
             best = x_cur.copy()
             if err < tol:
                 return x_cur.reshape(-1), True
-            dx = (b.T @ (ginv @ dq_remain)).reshape(-1, 3)
-            x_cur = x_cur + dx
+            with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+                dx = (b.T @ (ginv @ dq_remain)).reshape(-1, 3)
+                x_next = x_cur + dx
+            if not np.all(np.isfinite(dx)) or not np.all(np.isfinite(x_next)):
+                return best.reshape(-1), False
+            x_cur = x_next
         # Did not fully converge; accept the closest geometry but flag it.
         return best.reshape(-1), prev_norm is not None and prev_norm < 1.0e-3
 
@@ -439,6 +450,8 @@ class DelocalizedInternalCoordinates:
     def back_transform(self, x, dq, tol=1.0e-6, maxiter=50):
         x = np.asarray(x, dtype=float).reshape(-1, 3)
         s_target = self.q(x) + dq
+        if not np.all(np.isfinite(s_target)):
+            return x.reshape(-1), False
         x_cur = x.copy()
         prev = None
         best = x_cur.copy()
@@ -446,14 +459,24 @@ class DelocalizedInternalCoordinates:
             b = self.b_matrix(x_cur)
             ginv, _ = self._g_inverse(b)
             ds = s_target - self.q(x_cur)
+            if (not np.all(np.isfinite(b)) or not np.all(np.isfinite(ginv))
+                    or not np.all(np.isfinite(ds))):
+                return best.reshape(-1), False
             err = np.linalg.norm(ds)
+            if not np.isfinite(err):
+                return best.reshape(-1), False
             if prev is not None and err > prev * 1.0001 + 1.0e-10:
                 return best.reshape(-1), False
             prev = err
             best = x_cur.copy()
             if err < tol:
                 return x_cur.reshape(-1), True
-            x_cur = x_cur + (b.T @ (ginv @ ds)).reshape(-1, 3)
+            with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+                dx = (b.T @ (ginv @ ds)).reshape(-1, 3)
+                x_next = x_cur + dx
+            if not np.all(np.isfinite(dx)) or not np.all(np.isfinite(x_next)):
+                return best.reshape(-1), False
+            x_cur = x_next
         return best.reshape(-1), prev is not None and prev < 1.0e-3
 
     def cart_rmsd(self, x, x_new):

--- a/pyoqp/oqp/library/oqp_coords.py
+++ b/pyoqp/oqp/library/oqp_coords.py
@@ -33,6 +33,46 @@ import numpy as np
 BOHR_TO_ANGSTROM = 0.52917721092
 ANGSTROM_TO_BOHR = 1.0 / BOHR_TO_ANGSTROM
 
+
+def _scaled_norm(values):
+    """Return a Euclidean norm without squaring unscaled huge values."""
+    values = np.asarray(values, dtype=float)
+    if values.size == 0:
+        return 0.0
+    if not np.all(np.isfinite(values)):
+        return np.inf
+    scale = float(np.max(np.abs(values)))
+    if scale == 0.0:
+        return 0.0
+    unit_norm = float(np.linalg.norm(values / scale))
+    if unit_norm > 1.0 and scale > np.finfo(float).max / unit_norm:
+        return np.inf
+    return scale * unit_norm
+
+
+def _scaled_rms(values):
+    """Return an RMS magnitude without overflowing intermediate squares."""
+    values = np.asarray(values, dtype=float)
+    if values.size == 0:
+        return 0.0
+    if not np.all(np.isfinite(values)):
+        return np.inf
+    scale = float(np.max(np.abs(values)))
+    if scale == 0.0:
+        return 0.0
+    scaled = values / scale
+    return scale * float(np.sqrt(np.mean(scaled * scaled)))
+
+
+def _cartesian_rmsd(x, x_new):
+    with np.errstate(over="ignore", invalid="ignore"):
+        displacement = (
+            np.asarray(x_new, dtype=float).reshape(-1)
+            - np.asarray(x, dtype=float).reshape(-1)
+        )
+    return _scaled_rms(displacement)
+
+
 # Cordero et al. covalent radii (Angstrom), Dalton Trans. 2008, 2832.
 # Indexed by atomic number; entry 0 is a placeholder.
 _COVALENT_RADII_ANG = [
@@ -368,8 +408,8 @@ class RedundantInternalCoordinates:
             if (not np.all(np.isfinite(b)) or not np.all(np.isfinite(ginv))
                     or not np.all(np.isfinite(dq_remain))):
                 return best.reshape(-1), False
-            err = np.linalg.norm(dq_remain)
-            if not np.isfinite(err):
+            err = _scaled_norm(dq_remain)
+            if not np.isfinite(err) or err > np.sqrt(np.finfo(float).max):
                 return best.reshape(-1), False
             if prev_norm is not None and err > prev_norm * 1.0001 + 1.0e-10:
                 # Diverging: return the best Cartesian step found so far.
@@ -388,9 +428,7 @@ class RedundantInternalCoordinates:
         return best.reshape(-1), prev_norm is not None and prev_norm < 1.0e-3
 
     def cart_rmsd(self, x, x_new):
-        a = np.asarray(x, dtype=float).reshape(-1)
-        b = np.asarray(x_new, dtype=float).reshape(-1)
-        return float(np.sqrt(np.mean((a - b) ** 2)))
+        return _cartesian_rmsd(x, x_new)
 
 
 class DelocalizedInternalCoordinates:
@@ -462,8 +500,8 @@ class DelocalizedInternalCoordinates:
             if (not np.all(np.isfinite(b)) or not np.all(np.isfinite(ginv))
                     or not np.all(np.isfinite(ds))):
                 return best.reshape(-1), False
-            err = np.linalg.norm(ds)
-            if not np.isfinite(err):
+            err = _scaled_norm(ds)
+            if not np.isfinite(err) or err > np.sqrt(np.finfo(float).max):
                 return best.reshape(-1), False
             if prev is not None and err > prev * 1.0001 + 1.0e-10:
                 return best.reshape(-1), False
@@ -480,9 +518,7 @@ class DelocalizedInternalCoordinates:
         return best.reshape(-1), prev is not None and prev < 1.0e-3
 
     def cart_rmsd(self, x, x_new):
-        a = np.asarray(x, dtype=float).reshape(-1)
-        b = np.asarray(x_new, dtype=float).reshape(-1)
-        return float(np.sqrt(np.mean((a - b) ** 2)))
+        return _cartesian_rmsd(x, x_new)
 
 
 def _build_tric(atoms, x, bond_factor=1.3):
@@ -552,9 +588,7 @@ class CartesianCoordinates:
         return x + np.asarray(dq, dtype=float).reshape(-1), True
 
     def cart_rmsd(self, x, x_new):
-        a = np.asarray(x, dtype=float).reshape(-1)
-        b = np.asarray(x_new, dtype=float).reshape(-1)
-        return float(np.sqrt(np.mean((a - b) ** 2)))
+        return _cartesian_rmsd(x, x_new)
 
 
 # --------------------------------------------------------------------------- #

--- a/pyoqp/oqp/library/oqp_engine.py
+++ b/pyoqp/oqp/library/oqp_engine.py
@@ -457,37 +457,81 @@ class OQPEngine:
         return True
 
     # -- one macro-iteration ------------------------------------------------ #
+    def _bounded_cartesian_recovery(self, gradient):
+        """Reject an unstable internal step and take one bounded Cartesian step.
+
+        A failed DLC/RIC back-transformation must never contaminate the stored
+        secant pair or Hessian.  The next macroiteration can build a normal
+        internal step again from this finite geometry.
+        """
+        self.trust = max(self.trust * 0.5, self.trust_min)
+        self.H = self.coords.guess_hessian(self.x)
+        self._prev = None
+        gradient = np.asarray(gradient, dtype=float).reshape(-1)
+        if not np.all(np.isfinite(gradient)):
+            return self.x.copy()
+        # Normalize in two stages to avoid overflowing the norm of a very
+        # large, yet finite, electronic gradient.
+        scale = float(np.max(np.abs(gradient)))
+        if scale <= 1.0e-300 or not np.isfinite(scale):
+            return self.x.copy()
+        direction = gradient / scale
+        rms = float(np.sqrt(np.mean(direction * direction)))
+        if rms <= 1.0e-14 or not np.isfinite(rms):
+            return self.x.copy()
+        return self._enforce_frozen_distance_values(
+            self.x - direction * (self.trust / rms)
+        )
+
     def _take_step(self, e, g_cart):
         b = self.coords.b_matrix(self.x)
         g_cart = self._project_constraint_tangent(g_cart, self.x)
+        if (not np.isfinite(e) or not np.all(np.isfinite(b))
+                or not np.all(np.isfinite(g_cart))
+                or not np.all(np.isfinite(self.H))):
+            return self._bounded_cartesian_recovery(g_cart)
         g_q = self.coords.grad_to_q(self.x, g_cart)
+        if not np.all(np.isfinite(g_q)):
+            return self._bounded_cartesian_recovery(g_cart)
 
         if self._prev is not None:
             s = self._prev["dq"]
             y = g_q - self._prev["g_q"]
-            self.H = self._update_hessian(self.H, s, y)
+            with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+                self.H = self._update_hessian(self.H, s, y)
+            if not np.all(np.isfinite(self.H)):
+                return self._bounded_cartesian_recovery(g_cart)
             actual = e - self._prev["e"]
             pred = self._prev["pred"]
             self._update_trust(actual, pred, self._prev["cart_step"])
 
         dq = self._rfo_step(self.H, g_q)
         dq = self._restrict_to_trust(b, dq)
+        if not np.all(np.isfinite(dq)):
+            return self._bounded_cartesian_recovery(g_cart)
 
         x_new, ok = self.coords.back_transform(self.x, dq)
         if not ok:
-            # Shrink and retry once; otherwise fall back to a plain scaled step.
+            # Shrink and retry once; otherwise use a finite Cartesian recovery.
             self.trust = max(self.trust * 0.5, self.trust_min)
             dq = self._restrict_to_trust(b, dq)
             x_new, ok = self.coords.back_transform(self.x, dq)
             if not ok:
-                x_new = self.x + (b.T @ dq) * 0.5
+                return self._bounded_cartesian_recovery(g_cart)
 
         x_new = self._enforce_frozen_distance_values(x_new)
+        if not np.all(np.isfinite(x_new)):
+            return self._bounded_cartesian_recovery(g_cart)
 
         dq_taken = self.coords.q_displacement(self.coords.q(x_new),
                                               self.coords.q(self.x))
         cart_step = self.coords.cart_rmsd(self.x, x_new)
-        pred = float(g_q @ dq_taken + 0.5 * dq_taken @ self.H @ dq_taken)
+        if not np.all(np.isfinite(dq_taken)) or not np.isfinite(cart_step):
+            return self._bounded_cartesian_recovery(g_cart)
+        with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+            pred = float(g_q @ dq_taken + 0.5 * dq_taken @ self.H @ dq_taken)
+        if not np.isfinite(pred):
+            return self._bounded_cartesian_recovery(g_cart)
         self._prev = {"e": e, "g_q": g_q, "dq": dq_taken,
                       "pred": pred, "cart_step": cart_step,
                       "x": self.x.copy()}
@@ -565,9 +609,16 @@ class OQPEngine:
     def _restrict_to_trust(self, b, dq):
         # Estimate the Cartesian motion of this internal step and scale so its
         # RMSD does not exceed the trust radius.
+        if not np.all(np.isfinite(b)) or not np.all(np.isfinite(dq)):
+            return np.full_like(dq, np.nan)
         ginv, _ = self.coords._g_inverse(b) if hasattr(self.coords, "_g_inverse") \
             else (np.eye(b.shape[0]), 0)
-        dx = b.T @ (ginv @ dq) if hasattr(self.coords, "_g_inverse") else dq
+        if not np.all(np.isfinite(ginv)):
+            return np.full_like(dq, np.nan)
+        with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+            dx = b.T @ (ginv @ dq) if hasattr(self.coords, "_g_inverse") else dq
+        if not np.all(np.isfinite(dx)):
+            return np.full_like(dq, np.nan)
         rmsd = float(np.sqrt(np.mean(dx ** 2)))
         if rmsd > self.trust and rmsd > 1.0e-14:
             dq = dq * (self.trust / rmsd)

--- a/pyoqp/oqp/library/oqp_engine.py
+++ b/pyoqp/oqp/library/oqp_engine.py
@@ -170,6 +170,7 @@ class OQPEngine:
               and type(self.coords).__name__ == "RedundantInternalCoordinates"):
             label = "DLC->RIC(fallback)"
         self.coordsys = label
+        self.nonfinite_step_rejections = 0
         model_hessian = self.coords.guess_hessian(self.x)
         if initial_hessian is None:
             self.H = model_hessian
@@ -447,13 +448,23 @@ class OQPEngine:
         gradient = self._project_constraint_tangent(gradient, previous_x)
         gradient_q = self.coords.grad_to_q(previous_x, gradient)
         displacement_q = self._prev["dq"]
+        if (not np.all(np.isfinite(self.H))
+                or not np.all(np.isfinite(gradient_q))
+                or not np.all(np.isfinite(displacement_q))):
+            self._prev = None
+            return False
 
         self._prev["e"] = energy
         self._prev["g_q"] = gradient_q
-        self._prev["pred"] = float(
-            gradient_q @ displacement_q
-            + 0.5 * displacement_q @ self.H @ displacement_q
-        )
+        with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+            predicted = float(
+                gradient_q @ displacement_q
+                + 0.5 * displacement_q @ self.H @ displacement_q
+            )
+        if not np.isfinite(predicted):
+            self._prev = None
+            return False
+        self._prev["pred"] = predicted
         return True
 
     # -- one macro-iteration ------------------------------------------------ #
@@ -464,7 +475,15 @@ class OQPEngine:
         secant pair or Hessian.  The next macroiteration can build a normal
         internal step again from this finite geometry.
         """
+        self.nonfinite_step_rejections += 1
         self.trust = max(self.trust * 0.5, self.trust_min)
+        # An internal-coordinate map that has already overflowed is not a
+        # useful basis for the next trial point.  Switch this engine instance
+        # permanently to Cartesian coordinates; the outer native ladder may
+        # later restart a fresh DLC/TRIC model from the retained best geometry.
+        if not isinstance(self.coords, CartesianCoordinates):
+            self.coords = CartesianCoordinates(self.atoms.size)
+            self.coordsys = "%s->CART(nonfinite recovery)" % self.coordsys
         self.H = self.coords.guess_hessian(self.x)
         self._prev = None
         gradient = np.asarray(gradient, dtype=float).reshape(-1)
@@ -625,7 +644,8 @@ class OQPEngine:
         return dq
 
     def _update_trust(self, actual, pred, cart_step):
-        if abs(pred) < 1.0e-14:
+        if (not np.isfinite(actual) or not np.isfinite(pred)
+                or not np.isfinite(cart_step) or abs(pred) < 1.0e-14):
             return
         ratio = actual / pred
         if ratio < 0.25:

--- a/pyoqp/oqp/library/oqp_engine.py
+++ b/pyoqp/oqp/library/oqp_engine.py
@@ -584,12 +584,19 @@ class OQPEngine:
 
         x_new, ok = self.coords.back_transform(self.x, dq)
         if not ok:
-            # Shrink and retry once; otherwise use a finite Cartesian recovery.
+            # Shrink and retry once.  A finite, merely unconverged internal
+            # transform is common enough that it must retain the historical
+            # projected fallback (and the current internal-coordinate model).
+            # Reserve the Cartesian reset for an actually non-finite fallback.
             self.trust = max(self.trust * 0.5, self.trust_min)
             dq = self._restrict_to_trust(b, dq)
             x_new, ok = self.coords.back_transform(self.x, dq)
             if not ok:
-                return self._bounded_cartesian_recovery(g_cart)
+                with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+                    x_fallback = self.x + (b.T @ dq) * 0.5
+                if not np.all(np.isfinite(x_fallback)):
+                    return self._bounded_cartesian_recovery(g_cart)
+                x_new = x_fallback
 
         x_new = self._enforce_frozen_distance_values(x_new)
         if not np.all(np.isfinite(x_new)):

--- a/pyoqp/oqp/library/oqp_engine.py
+++ b/pyoqp/oqp/library/oqp_engine.py
@@ -27,7 +27,12 @@ import numpy as np
 import scipy.linalg as sla
 import re
 
-from oqp.library.oqp_coords import build_coordinates, CartesianCoordinates
+from oqp.library.oqp_coords import (
+    build_coordinates,
+    CartesianCoordinates,
+    _scaled_norm,
+    _scaled_rms,
+)
 
 # All dense linear algebra in this module is routed through LAPACK
 # (scipy.linalg / numpy.linalg) and BLAS-3 GEMM (the ``@`` operators on the
@@ -468,15 +473,47 @@ class OQPEngine:
         return True
 
     # -- one macro-iteration ------------------------------------------------ #
+    def _cartesian_follow_direction(self):
+        """Map the current TS mode into Cartesian space before model reset."""
+        if self.mode != "ts":
+            return None
+        b = self.coords.b_matrix(self.x)
+        if not np.all(np.isfinite(b)):
+            return None
+
+        followed = getattr(self, "_followed", None)
+        if followed is None:
+            if (self.H.shape != (b.shape[0], b.shape[0])
+                    or not np.all(np.isfinite(self.H))):
+                return None
+            w, v = _sym_eigh(self.H)
+            followed = v[:, self._select_follow_mode(w, v)]
+        followed = np.asarray(followed, dtype=float).reshape(-1)
+        if followed.size != b.shape[0] or not np.all(np.isfinite(followed)):
+            return None
+
+        with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+            if hasattr(self.coords, "_g_inverse"):
+                ginv, _ = self.coords._g_inverse(b)
+                direction = b.T @ (ginv @ followed)
+            else:
+                direction = followed.copy()
+        norm = _scaled_norm(direction)
+        if not np.isfinite(norm) or norm <= 1.0e-14:
+            return None
+        return direction / norm
+
     def _bounded_cartesian_recovery(self, gradient):
         """Reject an unstable internal step and take one bounded Cartesian step.
 
         A failed DLC/RIC back-transformation must never contaminate the stored
-        secant pair or Hessian.  The next macroiteration can build a normal
-        internal step again from this finite geometry.
+        secant pair or Hessian.  A TS search preserves its followed mode while
+        changing coordinate systems, then takes a bounded Cartesian P-RFO step
+        rather than silently turning into a minimization.
         """
         self.nonfinite_step_rejections += 1
         self.trust = max(self.trust * 0.5, self.trust_min)
+        followed_cart = self._cartesian_follow_direction()
         # An internal-coordinate map that has already overflowed is not a
         # useful basis for the next trial point.  Switch this engine instance
         # permanently to Cartesian coordinates; the outer native ladder may
@@ -494,12 +531,28 @@ class OQPEngine:
         scale = float(np.max(np.abs(gradient)))
         if scale <= 1.0e-300 or not np.isfinite(scale):
             return self.x.copy()
-        direction = gradient / scale
-        rms = float(np.sqrt(np.mean(direction * direction)))
+        scaled_gradient = gradient / scale
+        if self.mode == "ts":
+            if followed_cart is None:
+                # Without a trustworthy mode, holding the accepted geometry is
+                # safer than taking a downhill step away from the saddle.  The
+                # outer recovery ladder can rebuild a fresh TS model.
+                self._followed = None
+                return self.x.copy()
+            curvature = max(float(np.max(np.diag(self.H))), 1.0e-3)
+            self.H = (
+                self.H
+                - 2.0 * curvature * np.outer(followed_cart, followed_cart)
+            )
+            self._followed = followed_cart
+            direction = self._prfo_step(self.H, scaled_gradient)
+        else:
+            direction = -scaled_gradient
+        rms = _scaled_rms(direction)
         if rms <= 1.0e-14 or not np.isfinite(rms):
             return self.x.copy()
         return self._enforce_frozen_distance_values(
-            self.x - direction * (self.trust / rms)
+            self.x + direction * (self.trust / rms)
         )
 
     def _take_step(self, e, g_cart):
@@ -574,7 +627,7 @@ class OQPEngine:
         vec = v[:, 0]
         if abs(vec[-1]) < 1.0e-10:
             # Degenerate scaling: fall back to a damped steepest-descent step.
-            return -g / (np.linalg.norm(g) + 1.0)
+            return -g / (_scaled_norm(g) + 1.0)
         return vec[:n] / vec[n]
 
     def _prfo_step(self, h, g):
@@ -638,7 +691,9 @@ class OQPEngine:
             dx = b.T @ (ginv @ dq) if hasattr(self.coords, "_g_inverse") else dq
         if not np.all(np.isfinite(dx)):
             return np.full_like(dq, np.nan)
-        rmsd = float(np.sqrt(np.mean(dx ** 2)))
+        rmsd = _scaled_rms(dx)
+        if not np.isfinite(rmsd):
+            return np.full_like(dq, np.nan)
         if rmsd > self.trust and rmsd > 1.0e-14:
             dq = dq * (self.trust / rmsd)
         return dq

--- a/pyoqp/oqp/pyoqp.py
+++ b/pyoqp/oqp/pyoqp.py
@@ -48,11 +48,16 @@ def _apply_omp_threads_from_input(argv):
       * CLI:   --omp N   (or --omp=N)
       * input: a line  `omp_threads = N`  (typically in the [input] section)
 
-    The value sets OMP_NUM_THREADS (threads per process / MPI rank).  If neither
-    is given, the existing environment / built-in default is left untouched.
+    The value sets OMP_NUM_THREADS (threads per process / MPI rank).  For a
+    native DFTB input, it also seeds MKL_NUM_THREADS when the user has not set
+    it explicitly: the DFTB eigensolver manages its dense-MKL region locally,
+    while its Davidson sigma columns remain pinned to one BLAS thread.  If
+    neither source is given, the existing environment / built-in default is
+    left untouched.
     """
     import re
     n = None
+    input_text = ""
     for i, a in enumerate(argv):
         if a in ("--omp", "--omp-threads") and i + 1 < len(argv):
             n = argv[i + 1]
@@ -60,13 +65,13 @@ def _apply_omp_threads_from_input(argv):
         if a.startswith("--omp="):
             n = a.split("=", 1)[1]
             break
-    if n is None:
-        inp = next((a for a in argv[1:]
-                    if not a.startswith("-") and os.path.isfile(a)), None)
-        if inp:
-            try:
-                with open(inp, encoding="utf-8", errors="ignore") as fh:
-                    input_text = _strip_preimport_comments(fh.read())
+    inp = next((a for a in argv[1:]
+                if not a.startswith("-") and os.path.isfile(a)), None)
+    if inp:
+        try:
+            with open(inp, encoding="utf-8", errors="ignore") as fh:
+                input_text = _strip_preimport_comments(fh.read())
+            if n is None:
                 # Legacy INI, canonical .oqp section/top-level options, and a
                 # small controlled-natural-language spelling.  This scan must
                 # stay dependency-free because it runs before liboqp/OpenMP is
@@ -82,8 +87,8 @@ def _apply_omp_threads_from_input(argv):
                     if m:
                         n = m.group(1)
                         break
-            except OSError:
-                pass
+        except OSError:
+            pass
     if n is not None:
         try:
             ni = int(n)
@@ -91,6 +96,14 @@ def _apply_omp_threads_from_input(argv):
             return
         if ni >= 1:
             os.environ["OMP_NUM_THREADS"] = str(ni)
+            native_dftb = bool(re.search(r"(?i)\b[a-z0-9-]*dftb\b", input_text))
+            if native_dftb:
+                # Respect an explicit BLAS policy.  When it is absent, seed
+                # MKL before the runtime loads so the dense reference
+                # eigensolver can use the requested cores.  The DFTB library
+                # locally serializes narrow Davidson sigma columns, avoiding
+                # nested OMP x MKL oversubscription in the response stage.
+                os.environ.setdefault("MKL_NUM_THREADS", str(ni))
 
 
 def _set_threading_defaults():
@@ -138,11 +151,11 @@ def _set_threading_defaults():
         os.environ.setdefault(key, value)
 
 
-# Establish conservative BLAS/OMP defaults first (setdefault, so they never
-# override an explicit environment), then honour an explicit per-rank thread
-# request from --omp / omp_threads, which hard-sets OMP_NUM_THREADS and wins.
-_set_threading_defaults()
+# Honour explicit per-rank threading before populating conservative defaults:
+# this lets an input request seed the DFTB/MKL dense-eigensolver policy while
+# preserving every user-exported thread setting.
 _apply_omp_threads_from_input(sys.argv)
+_set_threading_defaults()
 
 import oqp
 from oqp.utils.file_utils import dump_log

--- a/tests/test_openqp_dftb_abi1.py
+++ b/tests/test_openqp_dftb_abi1.py
@@ -524,6 +524,22 @@ class OpenQPDFTBABITests(unittest.TestCase):
         self.assertEqual(result.reference_energy, -1.25)
         np.testing.assert_array_equal(result.all_state_energies, [-1.05, -0.95])
 
+    def test_current_layout_keeps_qmmm_potential_before_output_pointers(self):
+        adapter, library = self._adapter_with_current()
+        adapter.mol.dftb_external_potential = np.array([0.1, -0.1])
+
+        adapter._run_native("ground", 0, need_grad=True)
+
+        args = library.openqp_dftb_state_gradient.calls[0]
+        # ABI-v2/v3 puts these between the preset fields (49--50) and the
+        # reference-energy output pointer (53). Keeping the position explicit
+        # prevents a native crash from a silently shifted ctypes call.
+        self.assertEqual(args[51].value, 2)
+        self.assertEqual([args[52][i] for i in range(2)], [0.1, -0.1])
+        self.assertAlmostEqual(
+            ctypes.cast(args[53], ctypes.POINTER(ctypes.c_double))[0], -1.25
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_openqp_dftb_abi1.py
+++ b/tests/test_openqp_dftb_abi1.py
@@ -271,6 +271,7 @@ class OpenQPDFTBABITests(unittest.TestCase):
         self.assertEqual(adapter.mol._openqp_dftb_cache["__native_abi_version__"], 1)
         self.assertEqual(adapter.mol._openqp_dftb_cache["__native_capabilities__"], 0)
         self.assertIsNone(library.openqp_dftb_state_gradient.restype)
+        self.assertEqual(len(library.openqp_dftb_state_gradient.argtypes), 63)
 
     def test_optional_capability_symbol_is_probed_and_cached(self):
         adapter, library = self._adapter_with_current()
@@ -286,6 +287,14 @@ class OpenQPDFTBABITests(unittest.TestCase):
         self.assertIs(
             library.openqp_dftb_capi_capabilities.restype, ctypes.c_int64
         )
+        self.assertEqual(len(library.openqp_dftb_state_gradient.argtypes), 74)
+
+    def test_current_ctypes_signature_keeps_qmmm_fields_before_outputs(self):
+        signature = ADAPTER_MODULE._state_gradient_argtypes(3)
+        self.assertEqual(len(signature), 74)
+        self.assertIs(signature[51], ctypes.c_int64)
+        self.assertEqual(signature[52], ctypes.POINTER(ctypes.c_double))
+        self.assertEqual(signature[53], ctypes.POINTER(ctypes.c_double))
 
     def test_missing_capability_symbol_means_zero_even_for_abi3(self):
         adapter, library = self._adapter_with_current(capabilities=None)

--- a/tests/test_oqp_optimizer.py
+++ b/tests/test_oqp_optimizer.py
@@ -964,6 +964,34 @@ class TestOQPEngineInitialHessian(unittest.TestCase):
         self.assertTrue(np.all(np.isfinite(x_new)))
         self.assertFalse(np.allclose(x_new, original))
         self.assertIsNone(eng._prev)
+        self.assertEqual(eng.nonfinite_step_rejections, 1)
+        self.assertIn("CART(nonfinite recovery)", eng.coordsys)
+
+    def test_nonfinite_hessian_switches_to_cartesian_recovery(self):
+        eng = NE.OQPEngine(self.WATER_AT, self.WATER_X, coordsys="dlc",
+                           trust=0.1)
+        eng.H.fill(np.inf)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            x_new = eng._take_step(0.0, np.linspace(-0.1, 0.1, 9))
+        self.assertTrue(np.all(np.isfinite(x_new)))
+        self.assertEqual(eng.nonfinite_step_rejections, 1)
+        self.assertIsInstance(eng.coords, NC.CartesianCoordinates)
+
+    def test_meci_objective_rebase_drops_nonfinite_secant_history(self):
+        eng = NE.OQPEngine(self.WATER_AT, self.WATER_X, coordsys="dlc")
+        eng._prev = {
+            "x": eng.x.copy(), "dq": np.ones(3), "g_q": np.zeros(3),
+            "e": 0.0, "pred": 0.0, "cart_step": 0.01,
+        }
+        eng.H.fill(np.inf)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            rebased = eng.rebase_previous_objective(
+                0.0, np.linspace(-0.1, 0.1, 9)
+            )
+        self.assertFalse(rebased)
+        self.assertIsNone(eng._prev)
 
     def test_omitted_hessian_keeps_existing_model(self):
         eng = NE.OQPEngine(self.WATER_AT, self.WATER_X, coordsys="dlc")

--- a/tests/test_oqp_optimizer.py
+++ b/tests/test_oqp_optimizer.py
@@ -806,15 +806,19 @@ class TestTRICandDLC(unittest.TestCase):
         self.assertEqual(len(ic.q(self.WATER_X)), 3)  # 3N-6 active coords
         self.assertLess(self._bmatrix_fd(ic, self.WATER_X), 1e-6)
 
-    def test_dlc_back_transform_rejects_overflow_without_poisoning_geometry(self):
-        ic = NC.build_coordinates(self.WATER_AT, self.WATER_X, coordsys="dlc")
-        huge_step = np.full(len(ic.q(self.WATER_X)), 1.0e308)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", RuntimeWarning)
-            x_new, ok = ic.back_transform(self.WATER_X, huge_step)
-        self.assertFalse(ok)
-        self.assertTrue(np.all(np.isfinite(x_new)))
-        self.assertTrue(np.allclose(x_new, self.WATER_X.reshape(-1)))
+    def test_internal_back_transform_rejects_overflow_without_poisoning_geometry(self):
+        for coordsys in ("ric", "dlc"):
+            with self.subTest(coordsys=coordsys):
+                ic = NC.build_coordinates(
+                    self.WATER_AT, self.WATER_X, coordsys=coordsys
+                )
+                huge_step = np.full(len(ic.q(self.WATER_X)), 1.0e308)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", RuntimeWarning)
+                    x_new, ok = ic.back_transform(self.WATER_X, huge_step)
+                self.assertFalse(ok)
+                self.assertTrue(np.all(np.isfinite(x_new)))
+                self.assertTrue(np.allclose(x_new, self.WATER_X.reshape(-1)))
 
     def test_multifragment_tric(self):
         # Two well-separated triangular C3 fragments (each non-collinear, so
@@ -986,6 +990,33 @@ class TestOQPEngineInitialHessian(unittest.TestCase):
         self.assertTrue(np.all(np.isfinite(x_new)))
         self.assertEqual(eng.nonfinite_step_rejections, 1)
         self.assertIsInstance(eng.coords, NC.CartesianCoordinates)
+
+    def test_trust_restriction_scales_huge_finite_step_without_overflow(self):
+        eng = NE.OQPEngine([1], [0.0, 0.0, 0.0], coordsys="cart",
+                           trust=0.1)
+        huge_step = np.array([1.0e200, -5.0e199, 2.5e199])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            restricted = eng._restrict_to_trust(np.eye(3), huge_step)
+        self.assertTrue(np.all(np.isfinite(restricted)))
+        self.assertGreater(np.max(np.abs(restricted)), 0.0)
+        self.assertLessEqual(NC._scaled_rms(restricted), eng.trust)
+
+    def test_ts_cartesian_recovery_preserves_eigenvector_following(self):
+        h_cart = np.diag([-0.5, 0.4, 0.8])
+        eng = NE.OQPEngine(
+            [1], [0.0, 0.0, 0.0], mode="ts", coordsys="cart",
+            trust=0.1, initial_hessian=h_cart,
+        )
+        eng.coords.back_transform = lambda x, dq: (np.asarray(x).copy(), False)
+        gradient = np.array([0.1, 0.2, 0.3])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            x_new = eng._take_step(0.0, gradient)
+        displacement = x_new - eng.x
+        self.assertGreater(displacement[0] * gradient[0], 0.0)
+        self.assertLess(np.dot(displacement[1:], gradient[1:]), 0.0)
+        self.assertTrue(np.all(np.isfinite(x_new)))
 
     def test_meci_objective_rebase_drops_nonfinite_secant_history(self):
         eng = NE.OQPEngine(self.WATER_AT, self.WATER_X, coordsys="dlc")

--- a/tests/test_oqp_optimizer.py
+++ b/tests/test_oqp_optimizer.py
@@ -303,6 +303,15 @@ class TestNativeRecoveryLadder(unittest.TestCase):
         self.assertTrue(
             optimizer._native_progress_stalled(flat_high_gradient)
         )
+        self.assertTrue(optimizer._is_electronic_nonconvergence(
+            RuntimeError(
+                "openqp-dftb LC density-matrix CPHF did not converge; "
+                "residual 5.1"
+            )
+        ))
+        self.assertFalse(optimizer._is_electronic_nonconvergence(
+            RuntimeError("openqp-dftb parameter set is incomplete")
+        ))
 
         def fail_electronics(_coordinates):
             optimizer.itr += 1

--- a/tests/test_oqp_optimizer.py
+++ b/tests/test_oqp_optimizer.py
@@ -966,7 +966,7 @@ class TestOQPEngineInitialHessian(unittest.TestCase):
     WATER_X = np.array([[0, 0, 0.12], [0, 1.43, -0.96],
                         [0, -1.43, -0.96]], float)
 
-    def test_failed_internal_back_transform_uses_finite_cartesian_recovery(self):
+    def test_finite_failed_back_transform_preserves_internal_model(self):
         eng = NE.OQPEngine(self.WATER_AT, self.WATER_X, coordsys="dlc",
                            trust=0.1)
         original = eng.x.copy()
@@ -976,9 +976,10 @@ class TestOQPEngineInitialHessian(unittest.TestCase):
             x_new = eng._take_step(0.0, np.linspace(-0.1, 0.1, 9))
         self.assertTrue(np.all(np.isfinite(x_new)))
         self.assertFalse(np.allclose(x_new, original))
-        self.assertIsNone(eng._prev)
-        self.assertEqual(eng.nonfinite_step_rejections, 1)
-        self.assertIn("CART(nonfinite recovery)", eng.coordsys)
+        self.assertIsNotNone(eng._prev)
+        self.assertEqual(eng.nonfinite_step_rejections, 0)
+        self.assertIsInstance(eng.coords, NC.DelocalizedInternalCoordinates)
+        self.assertNotIn("CART(nonfinite recovery)", eng.coordsys)
 
     def test_nonfinite_hessian_switches_to_cartesian_recovery(self):
         eng = NE.OQPEngine(self.WATER_AT, self.WATER_X, coordsys="dlc",

--- a/tests/test_oqp_optimizer.py
+++ b/tests/test_oqp_optimizer.py
@@ -1193,6 +1193,25 @@ class TestOQPEngineInitialHessian(unittest.TestCase):
 
 # --------------------------------------------------------------------------- #
 class TestDispatchAndValidation(unittest.TestCase):
+    _IMPORT_STATE = (
+        "oqp", "oqp.utils", "oqp.utils.mpi_utils", "oqp.utils.input_checker",
+        "oqp.utils.perf_levels",
+    )
+
+    def setUp(self):
+        # The dispatcher tests load input_checker around lightweight module
+        # stubs.  Preserve the real package imports so they cannot leak into
+        # later integration tests (notably QM/MM, which imports perf_levels).
+        self._saved_import_state = {
+            name: sys.modules.get(name) for name in self._IMPORT_STATE
+        }
+        utils = types.ModuleType("oqp.utils")
+        utils.__path__ = []
+        sys.modules["oqp.utils"] = utils
+
+    def tearDown(self):
+        _restore_modules(self._saved_import_state)
+
     def test_input_checker_accepts_oqp(self):
         # input_checker only needs a tiny mpi_utils stub.
         utils = sys.modules.setdefault("oqp.utils",

--- a/tests/test_oqp_optimizer.py
+++ b/tests/test_oqp_optimizer.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import types
 import unittest
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -796,6 +797,16 @@ class TestTRICandDLC(unittest.TestCase):
         self.assertEqual(len(ic.q(self.WATER_X)), 3)  # 3N-6 active coords
         self.assertLess(self._bmatrix_fd(ic, self.WATER_X), 1e-6)
 
+    def test_dlc_back_transform_rejects_overflow_without_poisoning_geometry(self):
+        ic = NC.build_coordinates(self.WATER_AT, self.WATER_X, coordsys="dlc")
+        huge_step = np.full(len(ic.q(self.WATER_X)), 1.0e308)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            x_new, ok = ic.back_transform(self.WATER_X, huge_step)
+        self.assertFalse(ok)
+        self.assertTrue(np.all(np.isfinite(x_new)))
+        self.assertTrue(np.allclose(x_new, self.WATER_X.reshape(-1)))
+
     def test_multifragment_tric(self):
         # Two well-separated triangular C3 fragments (each non-collinear, so
         # rotation is well defined): TRIC must span the full 3N = 18.
@@ -941,6 +952,18 @@ class TestOQPEngineInitialHessian(unittest.TestCase):
     WATER_AT = [8, 1, 1]
     WATER_X = np.array([[0, 0, 0.12], [0, 1.43, -0.96],
                         [0, -1.43, -0.96]], float)
+
+    def test_failed_internal_back_transform_uses_finite_cartesian_recovery(self):
+        eng = NE.OQPEngine(self.WATER_AT, self.WATER_X, coordsys="dlc",
+                           trust=0.1)
+        original = eng.x.copy()
+        eng.coords.back_transform = lambda x, dq: (np.asarray(x).copy(), False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            x_new = eng._take_step(0.0, np.linspace(-0.1, 0.1, 9))
+        self.assertTrue(np.all(np.isfinite(x_new)))
+        self.assertFalse(np.allclose(x_new, original))
+        self.assertIsNone(eng._prev)
 
     def test_omitted_hessian_keeps_existing_model(self):
         eng = NE.OQPEngine(self.WATER_AT, self.WATER_X, coordsys="dlc")

--- a/tests/test_pyoqp_threading.py
+++ b/tests/test_pyoqp_threading.py
@@ -2,6 +2,7 @@
 
 import ast
 import os
+import sys
 import tempfile
 from pathlib import Path
 
@@ -18,12 +19,15 @@ def _load_preimport_helpers():
         "_apply_omp_threads_from_input",
         "_set_threading_defaults",
     }
-    nodes = [node for node in tree.body if isinstance(node, (ast.Import, ast.ImportFrom))]
-    nodes.extend(
+    nodes = [
         node for node in tree.body
         if isinstance(node, ast.FunctionDef) and node.name in names
-    )
-    namespace = {"__name__": "_pyoqp_preimport_threading_test"}
+    ]
+    namespace = {
+        "__name__": "_pyoqp_preimport_threading_test",
+        "os": os,
+        "sys": sys,
+    }
     exec(compile(ast.Module(body=nodes, type_ignores=[]), str(SOURCE), "exec"), namespace)
     return namespace
 

--- a/tests/test_pyoqp_threading.py
+++ b/tests/test_pyoqp_threading.py
@@ -1,0 +1,58 @@
+"""Pre-import thread-policy tests for native DFTB inputs."""
+
+import ast
+import os
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "pyoqp" / "oqp" / "pyoqp.py"
+
+
+def _load_preimport_helpers():
+    """Load only the dependency-free functions that execute before ``import oqp``."""
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"), filename=str(SOURCE))
+    names = {
+        "_strip_preimport_comments",
+        "_apply_omp_threads_from_input",
+        "_set_threading_defaults",
+    }
+    nodes = [node for node in tree.body if isinstance(node, (ast.Import, ast.ImportFrom))]
+    nodes.extend(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    )
+    namespace = {"__name__": "_pyoqp_preimport_threading_test"}
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(SOURCE), "exec"), namespace)
+    return namespace
+
+
+def test_native_dftb_input_seeds_mkl_from_explicit_omp_request(monkeypatch):
+    helpers = _load_preimport_helpers()
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    monkeypatch.delenv("MKL_NUM_THREADS", raising=False)
+    with tempfile.NamedTemporaryFile("w", suffix=".oqp", delete=False) as handle:
+        handle.write("mrsf-tddftb(nstate=3)\nomp_threads=8\n")
+        path = handle.name
+    try:
+        helpers["_apply_omp_threads_from_input"](["openqp", path])
+    finally:
+        os.unlink(path)
+    assert os.environ["OMP_NUM_THREADS"] == "8"
+    assert os.environ["MKL_NUM_THREADS"] == "8"
+
+
+def test_non_dftb_input_and_explicit_mkl_policy_are_preserved(monkeypatch):
+    helpers = _load_preimport_helpers()
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    monkeypatch.setenv("MKL_NUM_THREADS", "3")
+    with tempfile.NamedTemporaryFile("w", suffix=".oqp", delete=False) as handle:
+        handle.write("dft/pbe0/def2-svp\nomp_threads=8\n")
+        path = handle.name
+    try:
+        helpers["_apply_omp_threads_from_input"](["openqp", path])
+    finally:
+        os.unlink(path)
+    assert os.environ["OMP_NUM_THREADS"] == "8"
+    assert os.environ["MKL_NUM_THREADS"] == "3"


### PR DESCRIPTION
## What changed
- Classify native DFTB `CPHF did not converge` failures as recoverable electronic failures, so `lib=oqp` rejects the trial geometry and uses its bounded internal recovery ladder instead of crashing.
- When a native DFTB `.oqp` input explicitly requests `omp_threads`, seed `MKL_NUM_THREADS` to the same value unless the user already exported an MKL policy. The DFTB library retains its local one-thread Davidson sigma pinning to avoid nested BLAS oversubscription.

## Why
Alanine-dipeptide MRSF-TDDFTB S0 optimization exposed a LC density-matrix CPHF failure that bypassed the native recovery classifier. Large C224H16 MRSF inputs also need their explicit thread request to reach the dense MKL eigensolver.

## Validation
- `pytest -q tests/test_pyoqp_threading.py tests/test_oqp_optimizer.py tests/test_oqp_input.py tests/test_openqp_dftb_abi1.py`
  - 202 passed, 6 subtests passed.
- C60 MRSF-TDDFTB S0 native optimization converged in 38 macroiterations without non-finite-coordinate warnings.
- C224H16 on chc4 with OMP/MKL=8 completed an MRSF analytic state-gradient in 242.31 s using 1,887.26 CPU seconds.