### PR TITLE
Prepare OpenQP v1.2.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ unset(_oqp_env_cc)
 unset(_oqp_env_cxx)
 
 project(Open-Quantum-Package
-  VERSION 1.2.0
+  VERSION 1.2.1
   LANGUAGES C CXX Fortran)
 
 set(CMAKE_Fortran_STANDARD 2003)

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -23,10 +23,16 @@ wheel jobs use the default `~/Library/Caches/openqp/externals` location.
 ## Release Checklist
 
 1. Update `project.version` in `pyproject.toml`.
-2. Create and push a matching tag, for example `v1.2.0`.
-3. Publish a GitHub Release from that tag.
-4. Wait for the full wheel workflow to finish.
-5. Confirm that the release assets and PyPI files include the expected wheels.
+2. Synchronize the version in `CMakeLists.txt` and `pyoqp/setup.py`, then run
+   `python -m unittest tests.test_release_metadata`.
+3. Write detailed release notes as described below and include them in the
+   release-preparation pull request for review.
+4. Merge the release-preparation pull request only after its checks pass.
+5. Create and push a matching tag, for example `v1.2.0`.
+6. Publish a GitHub Release from that tag using the reviewed release notes.
+7. Wait for the full wheel workflow to finish, then confirm that the GitHub
+   Release assets and PyPI files include the expected wheels and source
+   distribution.
 
 The workflow verifies that the GitHub Release tag is exactly `v` plus the
 `pyproject.toml` version. For example, `version = "1.2.0"` must be released as
@@ -35,6 +41,54 @@ The workflow verifies that the GitHub Release tag is exactly `v` plus the
 Pushing a `v*` tag by itself does not start this workflow. Publish a GitHub
 Release from the tag instead, so the full wheel build and PyPI upload happen
 once from the release event.
+
+## Release Notes Requirements
+
+Every release must describe the complete change set since the previous release,
+not just the version bump or a short list of highlights.
+
+1. Generate GitHub's candidate notes between the previous and new tags to
+   collect merged pull requests and contributors.
+2. Audit `git log <previous-tag>..HEAD` as well, because direct commits and
+   multi-commit pull requests may not appear as separate entries in generated
+   notes.
+3. Reconcile the two lists so every merged pull request and every user-visible
+   direct commit is represented exactly once.
+4. Organize the notes under these headings where applicable:
+   - Highlights
+   - New features and scientific capabilities
+   - Performance improvements
+   - Bug fixes and reliability
+   - Packaging, platforms, and CI
+   - Documentation and developer experience
+5. Explain the user or developer impact of each item and link it to its pull
+   request or commit. Call out changed defaults, compatibility constraints,
+   optional dependencies, migration steps, and known limitations explicitly.
+6. End with contributor acknowledgements and a full comparison link between
+   the two release tags.
+
+Use the following structure for the reviewed release-note document and the
+GitHub Release body:
+
+```markdown
+# OpenQP vX.Y.Z
+
+## Highlights
+
+## New features and scientific capabilities
+
+## Performance improvements
+
+## Bug fixes and reliability
+
+## Packaging, platforms, and CI
+
+## Documentation and developer experience
+
+## Contributors
+
+**Full changelog:** https://github.com/Open-Quantum-Platform/openqp/compare/vPREVIOUS...vX.Y.Z
+```
 
 ## PyPI Trusted Publishing
 

--- a/docs/releases/v1.2.1.md
+++ b/docs/releases/v1.2.1.md
@@ -201,6 +201,14 @@ coverage.
   selecting SciPy's more robust `eigh` `evd` driver
   ([b664ce7](https://github.com/Open-Quantum-Platform/openqp/commit/b664ce7c45d2d67b7ec3b397724ea7b713030d8d)).
 
+- Hardened native optimizer DLC/RIC coordinate transformations with guarded
+  NumPy dot products and explicit finite-value checks. Degenerate or overflowing
+  coordinate metrics are now rejected so bounded recovery can fall back safely,
+  without emitting handled divide, overflow, or invalid-value warnings on
+  macOS Accelerate. Regression coverage includes ordinary products, degenerate
+  primitives, and overflowing metrics
+  ([#286](https://github.com/Open-Quantum-Platform/openqp/pull/286)).
+
 - Removed duplicate QM/MM PDB path materialization after geometry-based PDB
   inference
   ([#283](https://github.com/Open-Quantum-Platform/openqp/pull/283)).

--- a/docs/releases/v1.2.1.md
+++ b/docs/releases/v1.2.1.md
@@ -1,0 +1,318 @@
+# OpenQP v1.2.1
+
+OpenQP v1.2.1 is a broad feature and reliability release covering the complete
+change set since v1.2.0. It introduces the concise `.oqp` input language and
+native geometry workflows, a high-level Python API, standalone MP2, MRSF
+analysis tools, nonadiabatic and QM/MM dynamics, and a decoupled OpenQP-DFTB
+integration. It also adds a unified performance-control layer, strengthens
+optimizer and ABI reliability, and expands automated packaging and regression
+coverage.
+
+## Highlights
+
+- A markerless, readable `.oqp` input can now express ordinary calculations,
+  physical excited-state labels, and complete native optimization and
+  reaction-path workflows.
+- OpenQP-DFTB now supports ground-state, TD-, SF-, and MRSF-TDDFTB through a
+  separately installed, ABI-aware `ctypes` backend with DTCAM-TB presets,
+  bundled-parameter discovery, structured diagnostics, and OpenQP-style output.
+- The new `OpenQP` Python API offers compact molecule, theory, workflow, and
+  runtime helpers without removing the lower-level interfaces.
+- Native MRSF NAMD, SOC-NAMD, ESPF QM/MM, and their combined SOC-NAMD-QMMM
+  workflows are available for production-oriented dynamics.
+- Linux and macOS packaging now share a uniform ILP64 integer model, and the
+  release workflow builds and publishes source and wheel artifacts through
+  GitHub Releases and PyPI Trusted Publishing.
+
+## New features and scientific capabilities
+
+- **Native Python scripting API.** Added the `OpenQP` high-level API and `OQP`
+  alias, with `molecule`, `theory`, `workflow`, `control`, and `run` helpers.
+  Workflow helpers cover gradients, Hessians, optimization and crossing
+  searches, NAC/NACME, MRSF-EKT, SOC, PCM, NMR, and related calculations
+  ([#230](https://github.com/Open-Quantum-Platform/openqp/pull/230)).
+
+- **Standalone MP2.** Added `method=mp2` for RHF, UHF, and ROHF references,
+  semicanonical MP2 correlation, same- and opposite-spin energy components, and
+  MP2, SCS-MP2, SOS-MP2, OS/SS-MP2, SCS-MI-MP2, and custom scaling variants
+  ([#252](https://github.com/Open-Quantum-Platform/openqp/pull/252)). The
+  high-level Python API gained a matching MP2 helper
+  ([#254](https://github.com/Open-Quantum-Platform/openqp/pull/254)).
+
+- **MRSF excited-state analysis and interoperability.** Added first-class MRSF
+  one-particle transition and state density matrices plus Python-side analysis
+  and export tools, enabling richer excited-state interpretation and
+  interoperability beyond printed energies and oscillator strengths
+  ([#250](https://github.com/Open-Quantum-Platform/openqp/pull/250)).
+
+- **NAMD, SOC, and QM/MM dynamics.** Added native Tully fewest-switches surface
+  hopping for MRSF-TDDFT, overlap-derived NAC/TDC propagation, spin-adiabatic and
+  MCH-basis SOC-NAMD modes, and ESPF QM/MM dynamics through OpenMM. These pieces
+  compose into SOC-NAMD-QMMM with PME electrostatics, rigid-water constraints,
+  state tracking, and energy-conservation diagnostics
+  ([#205](https://github.com/Open-Quantum-Platform/openqp/pull/205)).
+
+- **Covalent-boundary QM/MM controls.** Added optional RCD, RC, and Z1 frontier
+  charge-redistribution schemes for covalent QM/MM boundaries
+  ([#258](https://github.com/Open-Quantum-Platform/openqp/pull/258)).
+
+- **Native DFT-D4.** Replaced the optional Python `dftd4` runtime dependency
+  with the native DFT-D4 Fortran stack linked into `liboqp`, covering energy and
+  gradient paths and allowing the capability to ship inside wheels
+  ([#235](https://github.com/Open-Quantum-Platform/openqp/pull/235)).
+
+- **ddX/PCM availability.** Enabled and exercised the ddX continuum-solvation
+  backend in Linux CI, fixed its propagated BLAS/LAPACK link interface, and made
+  the DDPCM examples converge reliably
+  ([#234](https://github.com/Open-Quantum-Platform/openqp/pull/234)).
+
+- **Readable `.oqp` input and native workflows.** Added the markerless `.oqp`
+  language, physical labels such as `S0`, `S1`, and `T0`, BaekA MECI, and native
+  optimization, MECI, MECP, TCI, TS, IRC, MEP, NEB, and constrained-minimum
+  routes. Every legacy example received a same-stem `.oqp` companion, and the
+  regression runner can select either syntax or both
+  ([#273](https://github.com/Open-Quantum-Platform/openqp/pull/273)).
+
+- **Modern multiline `.oqp` syntax.** Added equivalent one-line and
+  line-oriented forms, atom-per-line inline geometries, canonical rendering,
+  redundant-default elision, ground-state route normalization, inferred QM/MM
+  PDB input, and regenerated concise examples
+  ([#282](https://github.com/Open-Quantum-Platform/openqp/pull/282)).
+
+- **Native optimizer recovery and automatic MECI.** Added bounded recovery from
+  non-finite internal-coordinate steps and recoverable electronic-structure
+  failures, persistent Cartesian fallback when necessary, and automatic MECI
+  handling for native workflows
+  ([26425f5](https://github.com/Open-Quantum-Platform/openqp/commit/26425f580a38781b2b6ae425aae7b79306e8f5c1)).
+
+- **SCF selector assets.** Moved the SCF converger machine-learning training
+  database, tooling, model, and retraining workflow into the OpenQP repository
+  and normalized predicted DIIS subtype handling
+  ([#263](https://github.com/Open-Quantum-Platform/openqp/pull/263)).
+
+### OpenQP-DFTB integration
+
+- Added a decoupled Python/`ctypes` integration for the separately built
+  `libopenqp_dftb_c` library. Ground-state DFTB, TD-DFTB, SF-TDDFTB, and
+  MRSF-TDDFTB energies and analytic gradients feed the ordinary OpenQP data
+  model, allowing native optimization, MECI, and dynamics workflows without
+  linking the two Fortran projects
+  ([#266](https://github.com/Open-Quantum-Platform/openqp/pull/266)).
+
+- Added `[dftb] model=dtcam-tb` as a single-source-of-truth preset for the
+  published DTCAM-TB operator and numerical protocol, including the complete
+  operator surface, validation, examples, and BaekA MECI use
+  ([#275](https://github.com/Open-Quantum-Platform/openqp/pull/275)).
+
+- Added automatic discovery of the parameter set bundled with an installed
+  `openqp-dftb` package, allowing shipped DFTB examples to run without a manual
+  parameter path while preserving explicit overrides
+  ([#276](https://github.com/Open-Quantum-Platform/openqp/pull/276)).
+
+- Exposed concise and programmatic routes for all four DFTB calculation
+  families, grouped calculation/SCC/response/gradient/operator settings,
+  captured native iteration diagnostics, and capability negotiation across
+  historical C ABI versions 1, 2, and 3
+  ([#277](https://github.com/Open-Quantum-Platform/openqp/pull/277)).
+
+- Reworked DFTB output into OpenQP-style settings, SCC/Davidson/Z-vector
+  iteration tables, energy components, charges, dipoles, excited-state and
+  state-to-state spectra, timings, and structured results JSON. Production
+  defaults now select the appropriate model while retaining an explicit
+  `model=none` opt-out and explicit-parameter routes
+  ([#279](https://github.com/Open-Quantum-Platform/openqp/pull/279)).
+
+- Added per-state dominant SF/MRSF configurations with coefficients and
+  occupied-to-virtual orbital pairs
+  ([#280](https://github.com/Open-Quantum-Platform/openqp/pull/280)).
+
+- Added DFTB MO tables with occupations and frontier-orbital markers, plus
+  optional MO and excited-state symmetry labels and corresponding JSON metadata
+  ([#281](https://github.com/Open-Quantum-Platform/openqp/pull/281)).
+
+## Performance improvements
+
+- Optimized MRSF-TDDFT response Fock digestion by collapsing redundant Coulomb
+  updates and fusing stride-1 loops. The exact default path measured about a
+  16% response-stage improvement, with an additional optional FP32 accumulation
+  path for controlled experiments
+  ([#236](https://github.com/Open-Quantum-Platform/openqp/pull/236)).
+
+- Added optional progressive SCF screening driven by the DIIS error, covering
+  two-electron integrals, XC thresholds, and coarse-to-fine XC grids. The
+  schedule returns to full requested accuracy before convergence
+  ([#238](https://github.com/Open-Quantum-Platform/openqp/pull/238)).
+
+- Added a dedicated coarse-to-fine XC grid schedule that performs early DFT SCF
+  iterations on a cheaper grid before switching and reconverging on the
+  production grid
+  ([#241](https://github.com/Open-Quantum-Platform/openqp/pull/241)).
+
+- Added exact XC collocation-function caching and an experimental incremental
+  DFT path to avoid recomputing density-independent grid data on every SCF
+  iteration
+  ([#242](https://github.com/Open-Quantum-Platform/openqp/pull/242)).
+
+- Reduced MRSF, SF, and RHF excited-state gradient cost through Z-vector
+  warm-starting, configurable convergence, and progressive response screening,
+  with validation against tight gradients and finite differences
+  ([#243](https://github.com/Open-Quantum-Platform/openqp/pull/243)).
+
+- Added configurable derivative two-electron Schwarz screening for HF, DFT, and
+  MRSF gradients, with measured accuracy/speed guidance and screening statistics
+  ([#244](https://github.com/Open-Quantum-Platform/openqp/pull/244)).
+
+- Exposed the recent performance mechanisms through `[input] perf=0|1|2|3` and
+  individual input keys, replacing environment-only control with a documented
+  accuracy-versus-speed interface
+  ([#247](https://github.com/Open-Quantum-Platform/openqp/pull/247)).
+
+## Bug fixes and reliability
+
+- Corrected UHF example references affected by SCF stability, enabled the full
+  regression suite in CI, and isolated each example in a subprocess so a native
+  crash or leaked process-global state cannot invalidate unrelated tests
+  ([#231](https://github.com/Open-Quantum-Platform/openqp/pull/231)).
+
+- Fixed QM atom ordering so forces computed in topology order scatter back to
+  the correct atoms in QM/MM calculations
+  ([#259](https://github.com/Open-Quantum-Platform/openqp/pull/259)).
+
+- Prevented spurious coordinate matrix-multiplication warnings on macOS
+  ([#249](https://github.com/Open-Quantum-Platform/openqp/pull/249)).
+
+- Fixed TD response-vector JSON dimensions and layout for downstream consumers
+  ([#271](https://github.com/Open-Quantum-Platform/openqp/pull/271)).
+
+- Protected restricted-MO references from being overwritten during TRAH
+  recovery
+  ([#272](https://github.com/Open-Quantum-Platform/openqp/pull/272)).
+
+- Fixed out-of-bounds determinant-overlap writes on diagonal exact-overlap
+  evaluations
+  ([#278](https://github.com/Open-Quantum-Platform/openqp/pull/278)).
+
+- Classified native DFTB CPHF nonconvergence as a recoverable optimizer failure
+  and propagated explicit `.oqp` thread requests to MKL unless the user already
+  supplied a policy
+  ([#284](https://github.com/Open-Quantum-Platform/openqp/pull/284)).
+
+- Fixed optimizer `LinAlgError` failures caused by threaded OpenBLAS `dsyevr` by
+  selecting SciPy's more robust `eigh` `evd` driver
+  ([b664ce7](https://github.com/Open-Quantum-Platform/openqp/commit/b664ce7c45d2d67b7ec3b397724ea7b713030d8d)).
+
+- Removed duplicate QM/MM PDB path materialization after geometry-based PDB
+  inference
+  ([#283](https://github.com/Open-Quantum-Platform/openqp/pull/283)).
+
+## Packaging, platforms, and CI
+
+- Established deterministic native-BLAS selection and a uniform ILP64
+  eight-byte-integer model on every platform. This fixed basis-metadata and
+  native-library ABI mismatches, aligned CI with shipped wheels, uses
+  Accelerate on macOS, MKL for Linux x86_64 source builds, and OpenBLAS for
+  Linux aarch64 and distributable Linux wheels
+  ([#253](https://github.com/Open-Quantum-Platform/openqp/pull/253)).
+
+- Fixed Python 3.12+ extension naming by replacing the removed
+  `distutils.sysconfig` API with `sysconfig` as part of the native DFT-D4 work
+  ([#235](https://github.com/Open-Quantum-Platform/openqp/pull/235)).
+
+- Migrated to `Open-Quantum-Platform/tagarray` v1.0.0
+  ([#232](https://github.com/Open-Quantum-Platform/openqp/pull/232)) and patched
+  its long Fortran import line for gfortran 12 and newer as part of the
+  performance-preset work
+  ([#247](https://github.com/Open-Quantum-Platform/openqp/pull/247)).
+
+- Reduced committed example-reference JSON size by about 99% by retaining
+  regression quantities and removing internal `OQP::` arrays
+  ([#233](https://github.com/Open-Quantum-Platform/openqp/pull/233)).
+
+- Added a registry-driven regression allowlist and expanded required coverage
+  for IR/Raman data, NAC/IRC results, properties, Hessian sidecars, and other
+  physics outputs
+  ([#237](https://github.com/Open-Quantum-Platform/openqp/pull/237)).
+
+- Warmed bundled external-dependency caches from `main` so ordinary pull-request
+  wheel smoke builds do not repeatedly rebuild LAPACK and other externals
+  ([#240](https://github.com/Open-Quantum-Platform/openqp/pull/240)).
+
+- Fixed release-artifact upload by giving `gh release upload` an explicit
+  repository, and added a manual recovery path that can publish already-built
+  artifacts to a release and PyPI
+  ([e9bf377](https://github.com/Open-Quantum-Platform/openqp/commit/e9bf377596e4db1fd1d44b5b452e25e4ea0d26fd)).
+
+- Added automatic Claude review support for pull requests from forks
+  ([#251](https://github.com/Open-Quantum-Platform/openqp/pull/251)) and CI
+  enforcement for BLAS-wrapper registration, example coverage, Python API
+  exposure, and companion manual documentation
+  ([#255](https://github.com/Open-Quantum-Platform/openqp/pull/255)).
+
+- Removed obsolete proof-of-concept benchmark scaffolding
+  ([#257](https://github.com/Open-Quantum-Platform/openqp/pull/257)).
+
+- Synchronized `pyproject.toml`, CMake, and legacy setup metadata at version
+  1.2.1, added reviewed release notes, and documented a repeatable detailed
+  release-note process
+  ([#285](https://github.com/Open-Quantum-Platform/openqp/pull/285)).
+
+## Documentation and developer experience
+
+- Expanded the README into capability tables covering methods, spectroscopy,
+  geometry, dynamics, performance, and integrations
+  ([#246](https://github.com/Open-Quantum-Platform/openqp/pull/246)).
+
+- Documented SOC-NAMD-QMMM in the README
+  ([#256](https://github.com/Open-Quantum-Platform/openqp/pull/256)), surfaced
+  the standalone OpenQP manual and tutorial book
+  ([#261](https://github.com/Open-Quantum-Platform/openqp/pull/261)), and added
+  deep links to workflow-specific tutorials
+  ([#262](https://github.com/Open-Quantum-Platform/openqp/pull/262)).
+
+- Built an initial repository-owned manual
+  ([e3aace2](https://github.com/Open-Quantum-Platform/openqp/commit/e3aace2ff61dd695d02f28d366367f3b864d07c8)),
+  then moved it to the dedicated `openqp-docs` repository and refocused the
+  README on stable external documentation links
+  ([46cf8f6](https://github.com/Open-Quantum-Platform/openqp/commit/46cf8f6a48713571fce27646efae87d9c62f22c0)).
+
+- Clarified MRSF-TDDFT ground-state scope
+  ([83b6782](https://github.com/Open-Quantum-Platform/openqp/commit/83b6782c7c79323e58e30a4d04a267f49a7e2abe)),
+  linked the Python API guide
+  ([b6ab2ac](https://github.com/Open-Quantum-Platform/openqp/commit/b6ab2ac46e0200adb3f955f0465acba3d8865529)),
+  linked build options
+  ([b38b108](https://github.com/Open-Quantum-Platform/openqp/commit/b38b10824ded1217acace937501e9594b5d8e29e)),
+  and tightened installed-runtime wording
+  ([ea66cc0](https://github.com/Open-Quantum-Platform/openqp/commit/ea66cc0ba24f561124b2669bd40957208b0b89cf)).
+
+- Updated the README to use verified `.oqp` first-run examples and removed
+  unverified or obsolete MPI, legacy geomeTRIC-extra, and mixed regression-suite
+  commands
+  ([eadc047](https://github.com/Open-Quantum-Platform/openqp/commit/eadc047ff628212334a557de54fa5ab6f08df495),
+  [79dfb3a](https://github.com/Open-Quantum-Platform/openqp/commit/79dfb3ac8f1d9004ecb039d7b1fc4fa992130e8e),
+  [027a179](https://github.com/Open-Quantum-Platform/openqp/commit/027a179ab4fb567f2ab7a835aea2baf69f96fe72),
+  [ebb51c0](https://github.com/Open-Quantum-Platform/openqp/commit/ebb51c07d6938394dc20a9be002218ce2e6c3c3a)).
+
+## Compatibility and upgrade notes
+
+- The concise `.oqp` language is now the preferred example format, while the
+  established sectioned `.inp` language remains supported for compatibility.
+- OpenQP-DFTB remains a separately installed package. OpenQP negotiates
+  supported ABI capabilities and retains historical ABI-1 compatibility, but
+  newer DTCAM-TB presets and bundled-parameter discovery require a current
+  `openqp-dftb` build.
+- Custom native builds must use an ILP64-compatible BLAS/LAPACK configuration.
+  The automatic backend policy is deterministic; explicit supported overrides
+  remain available for advanced builds.
+- Release wheels target CPython 3.9 through 3.14 on Linux x86_64, Linux aarch64,
+  macOS x86_64, and macOS arm64. Windows users should continue using WSL2 or
+  Docker.
+
+## Contributors
+
+Thanks to [@karmachoi](https://github.com/karmachoi),
+[@mohsenkor](https://github.com/mohsenkor), and
+[@VladimirMakhnev](https://github.com/VladimirMakhnev), along with everyone who
+reviewed, tested, documented, and reported issues for this release.
+
+**Full changelog:**
+https://github.com/Open-Quantum-Platform/openqp/compare/v1.2.0...v1.2.1

--- a/pyoqp/setup.py
+++ b/pyoqp/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="OpenQP",
-    version="1.2.0",
+    version="1.2.1",
     author="Jingbai Li",
     author_email="lijingbai@zspu.edu.cn",
     description="Python Wrapper for Open Quantum Platform",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "OpenQP"
-version = "1.2.0"
+version = "1.2.1"
 description = "Python bindings for the Open Quantum Platform (Fortran core + Python wrapper)"
 authors = [{ name = "Mohsen Mazaherifar", email = "moh.mazaheri@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- bump the package version from `1.2.0` to `1.2.1` in `pyproject.toml`
- keep the CMake project version and legacy `pyoqp/setup.py` metadata in sync
- add reviewed, categorized [v1.2.1 release notes](https://github.com/Open-Quantum-Platform/openqp/blob/codex/release-v1.2.1/docs/releases/v1.2.1.md)
- document a repeatable release-note audit and template for future releases

## Release-note coverage

The notes reconcile GitHub-generated notes with `git log v1.2.0..HEAD` so merged PRs and user-visible direct commits are both covered. They include all 46 PRs in GitHub's candidate notes through PR #286, 13 additional user-visible direct commits, PR #285 itself, contributor acknowledgements, compatibility notes, and the full comparison link. Changes are organized into highlights, scientific features, performance, reliability fixes, packaging/CI, and documentation.

## Release and PyPI impact

After this PR is merged, publish a GitHub Release from tag `v1.2.1` using `docs/releases/v1.2.1.md` as the release body. The existing `build_wheels.yml` workflow verifies that the tag matches `pyproject.toml`, builds the full Linux/macOS wheel matrix and source distribution, attaches those artifacts to the GitHub Release, and publishes them to PyPI through Trusted Publishing.

## Validation

- `python3 -m unittest tests.test_release_metadata`
- built `openqp-1.2.1.tar.gz` with `python -m build --sdist`
- verified `pyproject.toml`, `CMakeLists.txt`, and `pyoqp/setup.py` all report `1.2.1`
- mechanically compared all 46 PR references in GitHub-generated notes against `docs/releases/v1.2.1.md`
- verified all 13 additional user-visible direct commits are referenced
- after integrating PR #286: `python -m pytest -q tests/test_oqp_optimizer.py` (`61 passed, 8 subtests passed`)
- `git diff --check`