### PR TITLE
fix optimizer coordinate overflow warnings

### DIFF
--- a/pyoqp/oqp/library/oqp_coords.py
+++ b/pyoqp/oqp/library/oqp_coords.py
@@ -73,6 +73,24 @@ def _cartesian_rmsd(x, x_new):
     return _scaled_rms(displacement)
 
 
+def _safe_matmul(left, right):
+    """Multiply coordinate matrices without leaking handled FP exceptions.
+
+    Accelerate's ``matmul`` implementation on macOS can report divide by
+    zero/overflow/invalid warnings for a BLAS product even when the inputs
+    are finite.  Genuine overflow is also possible while recovering from a
+    bad geometry.  Both cases are handled by the callers through their
+    finite-value checks, so keep the product quiet and let them select a
+    fallback coordinate system instead of emitting a warning from NumPy.
+
+    Coordinate transformations only pass vectors and two-dimensional
+    matrices here; ``dot`` has the same semantics for those operands and is
+    less prone to the Accelerate warning behaviour than the ``@`` ufunc.
+    """
+    with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+        return np.dot(left, right)
+
+
 # Cordero et al. covalent radii (Angstrom), Dalton Trans. 2008, 2832.
 # Indexed by atomic number; entry 0 is a placeholder.
 _COVALENT_RADII_ANG = [
@@ -119,6 +137,13 @@ class Bond:
         i, j = self.atoms
         u = x[i] - x[j]
         r = np.linalg.norm(u)
+        # A trial geometry can collapse a bond while an optimizer is
+        # recovering from a rejected electronic step.  Returning a zero row
+        # marks this primitive unusable; the rank checks then select a
+        # Cartesian fallback without emitting 1/r RuntimeWarnings.
+        if not np.isfinite(r) or r <= 1.0e-12:
+            z = np.zeros(3)
+            return [(i, z), (j, z.copy())]
         u = u / r
         return [(i, u), (j, -u)]
 
@@ -134,8 +159,13 @@ class Angle:
         i, j, k = self.atoms
         u = x[i] - x[j]
         v = x[k] - x[j]
-        u /= np.linalg.norm(u)
-        v /= np.linalg.norm(v)
+        lu = np.linalg.norm(u)
+        lv = np.linalg.norm(v)
+        if (not np.isfinite(lu) or not np.isfinite(lv)
+                or lu <= 1.0e-12 or lv <= 1.0e-12):
+            return 0.0
+        u /= lu
+        v /= lv
         c = float(np.clip(np.dot(u, v), -1.0, 1.0))
         return float(np.arccos(c))
 
@@ -145,6 +175,10 @@ class Angle:
         v = x[k] - x[j]
         lu = np.linalg.norm(u)
         lv = np.linalg.norm(v)
+        if (not np.isfinite(lu) or not np.isfinite(lv)
+                or lu <= 1.0e-12 or lv <= 1.0e-12):
+            z = np.zeros(3)
+            return [(i, z), (j, z.copy()), (k, z.copy())]
         u = u / lu
         v = v / lv
         c = float(np.clip(np.dot(u, v), -1.0, 1.0))
@@ -222,10 +256,10 @@ def _rotation_vector(X, X0):
     """
     Xc = X - X.mean(axis=0)
     X0c = X0 - X0.mean(axis=0)
-    h = X0c.T @ Xc
+    h = _safe_matmul(X0c.T, Xc)
     u, _, vt = np.linalg.svd(h)
-    d = np.sign(np.linalg.det(vt.T @ u.T))
-    rot = vt.T @ np.diag([1.0, 1.0, d]) @ u.T
+    d = np.sign(np.linalg.det(_safe_matmul(vt.T, u.T)))
+    rot = _safe_matmul(_safe_matmul(vt.T, np.diag([1.0, 1.0, d])), u.T)
     return _rotmat_to_expmap(rot)
 
 
@@ -356,8 +390,18 @@ class RedundantInternalCoordinates:
         # this medium-size B B^T product even when B and the resulting G matrix
         # are fully finite.  np.dot routes to the same BLAS product but does not
         # leak those false-positive fenv flags.
-        g = np.dot(b, b.T)
-        w, v = np.linalg.eigh(g)
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            g = np.dot(b, b.T)
+        # A finite, but very large, B-matrix can still overflow in G = B B^T
+        # (for example after a near-coincident bond).  Treat this exactly like
+        # a non-finite B: no usable internal subspace remains, so the caller
+        # can fall back to a safer coordinate representation.
+        if not np.all(np.isfinite(g)):
+            return np.zeros((nq, nq)), 0
+        try:
+            w, v = np.linalg.eigh(g)
+        except (np.linalg.LinAlgError, ValueError):
+            return np.zeros((nq, nq)), 0
         # Relative cutoff: drop near-null eigenvalues so the pseudo-inverse does
         # not divide by ~0 (an absolute cutoff lets tiny-but-positive eigenvalues
         # through and blows the G-inverse up on ill-conditioned, near-linear sets).
@@ -375,7 +419,8 @@ class RedundantInternalCoordinates:
     def grad_to_q(self, x, gx):
         b = self.b_matrix(x)
         ginv, _ = self._g_inverse(b)
-        return ginv @ (b @ np.asarray(gx, dtype=float).reshape(-1))
+        return _safe_matmul(ginv, _safe_matmul(
+            b, np.asarray(gx, dtype=float).reshape(-1)))
 
     def guess_hessian(self, x):
         diag = np.array([_GUESS_FC[p.kind] for p in self.primitives])
@@ -419,7 +464,8 @@ class RedundantInternalCoordinates:
             if err < tol:
                 return x_cur.reshape(-1), True
             with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
-                dx = (b.T @ (ginv @ dq_remain)).reshape(-1, 3)
+                dx = _safe_matmul(
+                    b.T, _safe_matmul(ginv, dq_remain)).reshape(-1, 3)
                 x_next = x_cur + dx
             if not np.all(np.isfinite(dx)) or not np.all(np.isfinite(x_next)):
                 return best.reshape(-1), False
@@ -452,7 +498,10 @@ class DelocalizedInternalCoordinates:
     @classmethod
     def from_ric(cls, ric, x, eig_tol=1.0e-6):
         b = ric.b_matrix(x)
-        g = np.dot(b, b.T)
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            g = np.dot(b, b.T)
+        if not np.all(np.isfinite(g)):
+            raise ValueError("non-finite DLC metric")
         w, v = np.linalg.eigh(0.5 * (g + g.T))
         u = v[:, w > eig_tol]
         return cls(ric, u, ric.q(x))
@@ -461,14 +510,22 @@ class DelocalizedInternalCoordinates:
         return self.ric.q_displacement(self.ric.q(x), self.q_ref)
 
     def q(self, x):
-        return self.U.T @ self._disp_prim(x)
+        return _safe_matmul(self.U.T, self._disp_prim(x))
 
     def b_matrix(self, x):
-        return self.U.T @ self.ric.b_matrix(x)
+        return _safe_matmul(self.U.T, self.ric.b_matrix(x))
 
     def _g_inverse(self, b, eig_tol=1.0e-8):
-        g = np.dot(b, b.T)
-        w, v = np.linalg.eigh(0.5 * (g + g.T))
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            g = np.dot(b, b.T)
+        if not np.all(np.isfinite(g)):
+            n = b.shape[0]
+            return np.zeros((n, n)), 0
+        try:
+            w, v = np.linalg.eigh(0.5 * (g + g.T))
+        except (np.linalg.LinAlgError, ValueError):
+            n = b.shape[0]
+            return np.zeros((n, n)), 0
         keep = w > eig_tol
         inv = np.dot(v[:, keep] / w[keep], v[:, keep].T)
         return inv, int(np.count_nonzero(keep))
@@ -476,11 +533,12 @@ class DelocalizedInternalCoordinates:
     def grad_to_q(self, x, gx):
         b = self.b_matrix(x)
         ginv, _ = self._g_inverse(b)
-        return ginv @ (b @ np.asarray(gx, dtype=float).reshape(-1))
+        return _safe_matmul(ginv, _safe_matmul(
+            b, np.asarray(gx, dtype=float).reshape(-1)))
 
     def guess_hessian(self, x):
         diag = np.array([_GUESS_FC[p.kind] for p in self.ric.primitives])
-        return self.U.T @ (diag[:, None] * self.U)
+        return _safe_matmul(self.U.T, diag[:, None] * self.U)
 
     def q_displacement(self, q2, q1):
         return np.asarray(q2, dtype=float) - np.asarray(q1, dtype=float)
@@ -510,7 +568,8 @@ class DelocalizedInternalCoordinates:
             if err < tol:
                 return x_cur.reshape(-1), True
             with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
-                dx = (b.T @ (ginv @ ds)).reshape(-1, 3)
+                dx = _safe_matmul(
+                    b.T, _safe_matmul(ginv, ds)).reshape(-1, 3)
                 x_next = x_cur + dx
             if not np.all(np.isfinite(dx)) or not np.all(np.isfinite(x_next)):
                 return best.reshape(-1), False

--- a/pyoqp/oqp/library/oqp_coords.py
+++ b/pyoqp/oqp/library/oqp_coords.py
@@ -138,11 +138,13 @@ class Bond:
         u = x[i] - x[j]
         r = np.linalg.norm(u)
         # A trial geometry can collapse a bond while an optimizer is
-        # recovering from a rejected electronic step.  Returning a zero row
-        # marks this primitive unusable; the rank checks then select a
-        # Cartesian fallback without emitting 1/r RuntimeWarnings.
+        # recovering from a rejected electronic step.  Returning a non-finite
+        # row marks this primitive unusable; the rank checks then select a
+        # Cartesian fallback without emitting 1/r RuntimeWarnings.  A zero
+        # row would instead look like a valid, finite gradient direction and
+        # could silently stall an already-created DLC/RIC engine.
         if not np.isfinite(r) or r <= 1.0e-12:
-            z = np.zeros(3)
+            z = np.full(3, np.nan)
             return [(i, z), (j, z.copy())]
         u = u / r
         return [(i, u), (j, -u)]
@@ -177,7 +179,7 @@ class Angle:
         lv = np.linalg.norm(v)
         if (not np.isfinite(lu) or not np.isfinite(lv)
                 or lu <= 1.0e-12 or lv <= 1.0e-12):
-            z = np.zeros(3)
+            z = np.full(3, np.nan)
             return [(i, z), (j, z.copy()), (k, z.copy())]
         u = u / lu
         v = v / lv
@@ -418,7 +420,9 @@ class RedundantInternalCoordinates:
 
     def grad_to_q(self, x, gx):
         b = self.b_matrix(x)
-        ginv, _ = self._g_inverse(b)
+        ginv, rank = self._g_inverse(b)
+        if rank == 0 and b.shape[0]:
+            return np.full(b.shape[0], np.nan, dtype=float)
         return _safe_matmul(ginv, _safe_matmul(
             b, np.asarray(gx, dtype=float).reshape(-1)))
 
@@ -502,7 +506,11 @@ class DelocalizedInternalCoordinates:
             g = np.dot(b, b.T)
         if not np.all(np.isfinite(g)):
             raise ValueError("non-finite DLC metric")
-        w, v = np.linalg.eigh(0.5 * (g + g.T))
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            g = 0.5 * g + 0.5 * g.T
+        if not np.all(np.isfinite(g)):
+            raise ValueError("non-finite DLC metric")
+        w, v = np.linalg.eigh(g)
         u = v[:, w > eig_tol]
         return cls(ric, u, ric.q(x))
 
@@ -521,8 +529,13 @@ class DelocalizedInternalCoordinates:
         if not np.all(np.isfinite(g)):
             n = b.shape[0]
             return np.zeros((n, n)), 0
+        with np.errstate(over="ignore", divide="ignore", invalid="ignore"):
+            g = 0.5 * g + 0.5 * g.T
+        if not np.all(np.isfinite(g)):
+            n = b.shape[0]
+            return np.zeros((n, n)), 0
         try:
-            w, v = np.linalg.eigh(0.5 * (g + g.T))
+            w, v = np.linalg.eigh(g)
         except (np.linalg.LinAlgError, ValueError):
             n = b.shape[0]
             return np.zeros((n, n)), 0
@@ -532,7 +545,9 @@ class DelocalizedInternalCoordinates:
 
     def grad_to_q(self, x, gx):
         b = self.b_matrix(x)
-        ginv, _ = self._g_inverse(b)
+        ginv, rank = self._g_inverse(b)
+        if rank == 0 and b.shape[0]:
+            return np.full(b.shape[0], np.nan, dtype=float)
         return _safe_matmul(ginv, _safe_matmul(
             b, np.asarray(gx, dtype=float).reshape(-1)))
 

--- a/tests/test_oqp_optimizer.py
+++ b/tests/test_oqp_optimizer.py
@@ -737,9 +737,12 @@ class TestInternalCoordinates(unittest.TestCase):
             bond_deriv = bond.derivatives(x)
             angle_value = angle.value(x)
             angle_deriv = angle.derivatives(x)
-        self.assertTrue(np.all(np.isfinite([d for _, d in bond_deriv])))
+        # The invalid derivative row is intentional: it forces an existing
+        # internal-coordinate engine into bounded Cartesian recovery instead
+        # of silently accepting a zero gradient direction.
+        self.assertFalse(np.all(np.isfinite([d for _, d in bond_deriv])))
         self.assertTrue(np.isfinite(angle_value))
-        self.assertTrue(np.all(np.isfinite([d for _, d in angle_deriv])))
+        self.assertFalse(np.all(np.isfinite([d for _, d in angle_deriv])))
 
     def test_bmatrix_matches_fd_water_and_ethane(self):
         cases = [
@@ -842,6 +845,25 @@ class TestTRICandDLC(unittest.TestCase):
             g_inverse, rank = ic._g_inverse(b)
         self.assertEqual(rank, 0)
         self.assertTrue(np.array_equal(g_inverse, np.zeros_like(g_inverse)))
+
+    def test_dlc_g_inverse_rejects_overflowing_symmetrization(self):
+        """Finite G must remain safe when G + G.T would overflow."""
+        ic = NC.build_coordinates(self.WATER_AT, self.WATER_X, coordsys="dlc")
+        b = np.full_like(ic.b_matrix(self.WATER_X), 9.0e153)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            g_inverse, rank = ic._g_inverse(b)
+        self.assertEqual(rank, 0)
+        self.assertTrue(np.array_equal(g_inverse, np.zeros_like(g_inverse)))
+
+    def test_dlc_rank_zero_gradient_requests_recovery(self):
+        ic = NC.build_coordinates(self.WATER_AT, self.WATER_X, coordsys="dlc")
+        b = np.full_like(ic.b_matrix(self.WATER_X), 9.0e153)
+        ic.b_matrix = lambda _x: b
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            gradient = ic.grad_to_q(self.WATER_X, np.ones(9))
+        self.assertTrue(np.all(np.isnan(gradient)))
 
     def test_safe_matmul_suppresses_handled_overflow(self):
         left = np.full((2, 2), 1.0e308)
@@ -1035,6 +1057,18 @@ class TestOQPEngineInitialHessian(unittest.TestCase):
         self.assertTrue(np.all(np.isfinite(x_new)))
         self.assertEqual(eng.nonfinite_step_rejections, 1)
         self.assertIsInstance(eng.coords, NC.CartesianCoordinates)
+
+    def test_collapsed_internal_geometry_switches_to_cartesian_recovery(self):
+        eng = NE.OQPEngine(self.WATER_AT, self.WATER_X.copy(), coordsys="dlc",
+                           trust=0.1)
+        eng.x[:] = 0.0
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            x_new = eng._take_step(0.0, np.ones(9))
+        self.assertTrue(np.all(np.isfinite(x_new)))
+        self.assertEqual(eng.nonfinite_step_rejections, 1)
+        self.assertIsInstance(eng.coords, NC.CartesianCoordinates)
+        self.assertFalse(np.allclose(x_new, np.zeros(9)))
 
     def test_trust_restriction_scales_huge_finite_step_without_overflow(self):
         eng = NE.OQPEngine([1], [0.0, 0.0, 0.0], coordsys="cart",

--- a/tests/test_oqp_optimizer.py
+++ b/tests/test_oqp_optimizer.py
@@ -728,6 +728,19 @@ class TestInternalCoordinates(unittest.TestCase):
             self.assertLess(self._fd_brow(NC.Angle(0, 1, 2), x), 1e-6)
             self.assertLess(self._fd_brow(NC.Dihedral(0, 1, 2, 3), x), 1e-6)
 
+    def test_collapsed_primitive_is_finite_and_warning_free(self):
+        x = np.zeros((3, 3))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            bond = NC.Bond(0, 1)
+            angle = NC.Angle(0, 1, 2)
+            bond_deriv = bond.derivatives(x)
+            angle_value = angle.value(x)
+            angle_deriv = angle.derivatives(x)
+        self.assertTrue(np.all(np.isfinite([d for _, d in bond_deriv])))
+        self.assertTrue(np.isfinite(angle_value))
+        self.assertTrue(np.all(np.isfinite([d for _, d in angle_deriv])))
+
     def test_bmatrix_matches_fd_water_and_ethane(self):
         cases = [
             ([8, 1, 1], np.array([[0, 0, 0.12], [0, 1.43, -0.96],
@@ -805,6 +818,37 @@ class TestTRICandDLC(unittest.TestCase):
         self.assertIsInstance(ic, NC.DelocalizedInternalCoordinates)
         self.assertEqual(len(ic.q(self.WATER_X)), 3)  # 3N-6 active coords
         self.assertLess(self._bmatrix_fd(ic, self.WATER_X), 1e-6)
+
+    def test_dlc_linear_algebra_is_warning_free(self):
+        """Coordinate products must not leak handled Accelerate FP flags."""
+        ic = NC.build_coordinates(self.WATER_AT, self.WATER_X, coordsys="dlc")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            q = ic.q(self.WATER_X)
+            b = ic.b_matrix(self.WATER_X)
+            gq = ic.grad_to_q(self.WATER_X, np.ones(9))
+            hessian = ic.guess_hessian(self.WATER_X)
+        self.assertTrue(np.all(np.isfinite(q)))
+        self.assertTrue(np.all(np.isfinite(b)))
+        self.assertTrue(np.all(np.isfinite(gq)))
+        self.assertTrue(np.all(np.isfinite(hessian)))
+
+    def test_dlc_g_inverse_rejects_overflowing_metric(self):
+        """An overflowing B B^T metric must request coordinate fallback."""
+        ic = NC.build_coordinates(self.WATER_AT, self.WATER_X, coordsys="dlc")
+        b = np.full_like(ic.b_matrix(self.WATER_X), 1.0e308)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            g_inverse, rank = ic._g_inverse(b)
+        self.assertEqual(rank, 0)
+        self.assertTrue(np.array_equal(g_inverse, np.zeros_like(g_inverse)))
+
+    def test_safe_matmul_suppresses_handled_overflow(self):
+        left = np.full((2, 2), 1.0e308)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            product = NC._safe_matmul(left, left)
+        self.assertFalse(np.all(np.isfinite(product)))
 
     def test_internal_back_transform_rejects_overflow_without_poisoning_geometry(self):
         for coordsys in ("ric", "dlc"):


### PR DESCRIPTION
## Summary

- Replace DLC/RIC coordinate transformations that used raw @ matmul with a guarded NumPy dot helper.
- Reject non-finite or overflowing coordinate metrics so the native optimizer falls back safely.
- Add regression tests for warning-free products, degenerate primitives, and overflowing metrics.

## Root cause

On macOS Accelerate, raw NumPy matmul can emit divide/overflow/invalid RuntimeWarnings while recovering from a rejected geometry. The installed package was also older than this checkout. The guarded products now suppress handled floating-point flags and all callers validate finiteness before continuing.

## Validation

- python3 -m pytest -q tests/test_oqp_optimizer.py (58 passed)
- OPENQP_ROOT=/opt/homebrew/lib/python3.11/site-packages/oqp python3 -m pytest -q tests/test_openqp_dftb_abi1.py tests/test_openqp_dftb_api.py tests/test_openqp_dftb_logging.py tests/test_openqp_dftb_schema_hooks.py tests/test_dftb_model_default.py tests/test_dftb_parameter_defaults.py tests/test_openqp_api.py tests/test_oqp_input.py (229 passed)
- git diff --check
