### PR TITLE
Add physical-root MRSF state analysis

### DIFF
--- a/examples/MRSF-TDDFT/STATE_ANALYSIS.py
+++ b/examples/MRSF-TDDFT/STATE_ANALYSIS.py
@@ -1,0 +1,28 @@
+"""Physical-root MRSF state analysis for a finished OpenQP calculation.
+
+Run the MRSF energy job in the current process, then pass its ``mol`` object to
+``report_states``.  Atom and state indices below are zero-based.
+"""
+from oqp.interop import AOBasis, MRSFExcitedStates, analyze_mrsf_transition
+
+
+def report_states(mol, fragments, plane_normal=None):
+    states = MRSFExcitedStates(mol)
+    ao = AOBasis(mol)
+    reports = []
+    for final_state in range(1, states.nstates):
+        report = analyze_mrsf_transition(
+            states, ao, final_state, fragments, ref=0,
+            plane_normal=plane_normal)
+        character = report["orbital_character"]
+        print(
+            f"S0 -> S{final_state}: {character['label']}; "
+            f"LE={report['le_fraction']:.3f}, CT={report['ct_fraction']:.3f}; "
+            f"fractions={character['fractions']}")
+        reports.append(report)
+    return reports
+
+
+# Example after running formaldehyde: one chromophore fragment means LE=1 by
+# construction.  Use chemically meaningful donor/acceptor fragments for CT.
+# reports = report_states(runner.mol, fragments=[[0, 1, 2, 3]])

--- a/examples/MRSF-TDDFT/STATE_ANALYSIS.py
+++ b/examples/MRSF-TDDFT/STATE_ANALYSIS.py
@@ -1,12 +1,33 @@
+#!/usr/bin/env python3
 """Physical-root MRSF state analysis for a finished OpenQP calculation.
 
-Run the MRSF energy job in the current process, then pass its ``mol`` object to
-``report_states``.  Atom and state indices below are zero-based.
+Each MRSF root pair ``S_ref -> S_n`` is reported as two independent things:
+
+* **LE/CT** -- how much of the transition moves density between the fragments
+  you supply, from the fragment-partitioned state-interaction 1-TDM.
+* **orbital character** -- the ``n/pi/sigma -> pi*/sigma*`` fractions of the
+  same root pair's NTOs, after a Loewdin population analysis.
+
+The analysis needs the state-interaction densities, and those only live in the
+tagarray of a *finished MRSF run in the current process* -- so the run and the
+analysis have to happen in one script, as below.
+
+Usage
+-----
+    python STATE_ANALYSIS.py H2O_BHHLYP-MRSFTDDFT_ENERGY.inp
+    python STATE_ANALYSIS.py my.inp 0,1 2      # fragment "atoms 0,1" | "atom 2"
+
+Atom and state indices are zero-based.
 """
+
+import os
+import sys
+
 from oqp.interop import AOBasis, MRSFExcitedStates, analyze_mrsf_transition
 
 
 def report_states(mol, fragments, plane_normal=None):
+    """Print and return the analysis of every ``S0 -> Sn`` pair of ``mol``."""
     states = MRSFExcitedStates(mol)
     ao = AOBasis(mol)
     reports = []
@@ -19,10 +40,35 @@ def report_states(mol, fragments, plane_normal=None):
             f"S0 -> S{final_state}: {character['label']}; "
             f"LE={report['le_fraction']:.3f}, CT={report['ct_fraction']:.3f}; "
             f"fractions={character['fractions']}")
+        if not character["classified"]:
+            print(f"    orbital character unavailable: {character['reason']}")
         reports.append(report)
     return reports
 
 
-# Example after running formaldehyde: one chromophore fragment means LE=1 by
-# construction.  Use chemically meaningful donor/acceptor fragments for CT.
-# reports = report_states(runner.mol, fragments=[[0, 1, 2, 3]])
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(f"usage: {sys.argv[0]} <input.inp> [fragment ...]")
+    input_file = sys.argv[1]
+
+    from oqp.pyoqp import Runner
+
+    project = os.path.splitext(input_file)[0]
+    runner = Runner(project=project, input_file=input_file,
+                    log=f"{project}.log", usempi=False)
+    runner.run()
+
+    # One fragment per command-line argument, e.g. "0,1" "2".  With no
+    # arguments the whole molecule is a single fragment, so LE=1 by
+    # construction -- pass donor/acceptor fragments to see any CT.
+    if len(sys.argv) > 2:
+        fragments = [[int(a) for a in group.split(",")] for group in sys.argv[2:]]
+    else:
+        fragments = [list(range(len(runner.mol.get_atoms())))]
+    print(f"fragments = {fragments}")
+
+    report_states(runner.mol, fragments)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyoqp/oqp/analysis/__init__.py
+++ b/pyoqp/oqp/analysis/__init__.py
@@ -7,11 +7,13 @@ from .nto import nto_excitation, nto_transition
 from .density_diff import attachment_detachment
 from .descriptors import participation_ratio, tozer_lambda, fragment_ct_matrix
 from .gto_grid import AOBasis, make_box_grid
+from .state_analysis import analyze_mrsf_transition, infer_molecular_plane
 
 __all__ = [
     "MRSFExcitedStates",
     "nto_excitation", "nto_transition",
     "attachment_detachment",
     "participation_ratio", "tozer_lambda", "fragment_ct_matrix",
+    "analyze_mrsf_transition", "infer_molecular_plane",
     "AOBasis", "make_box_grid",
 ]

--- a/pyoqp/oqp/analysis/descriptors.py
+++ b/pyoqp/oqp/analysis/descriptors.py
@@ -4,10 +4,10 @@
 * ``tozer_lambda`` -- Tozer's Lambda: NTO-weighted spatial overlap of the
   hole/particle moduli (Lambda in [0,1]; high = local, low = charge transfer).
 * ``fragment_ct_matrix`` -- Plasser/Lischka Omega matrix from the Loewdin-
-  orthogonalized spin-flip transition density, partitioned over atom fragments.
+  orthogonalized physical-root state-interaction 1-TDM, partitioned over atom
+  fragments.
 """
 import numpy as np
-from scipy.linalg import sqrtm
 
 __all__ = ["participation_ratio", "tozer_lambda", "fragment_ct_matrix"]
 
@@ -49,41 +49,79 @@ def tozer_lambda(ao, nto_exc, grid_points, dV, weight_thresh=1.0e-8):
     return lam, {"O_k": O, "weights": wk, "norm_hole": norm_h, "norm_part": norm_p}
 
 
-def fragment_ct_matrix(states, ao, n, fragments):
-    """Fragment charge-transfer Omega matrix for excitation to root ``n``.
+def _lowdin_sqrt(overlap, threshold=1.0e-12):
+    """Symmetric positive-semidefinite square root of an AO overlap matrix."""
+    values, vectors = np.linalg.eigh(np.asarray(overlap, dtype=float))
+    if values.size and values.min() < -threshold:
+        raise ValueError("AO overlap matrix is not positive semidefinite")
+    values = np.clip(values, 0.0, None)
+    return (vectors * np.sqrt(values)) @ vectors.T
 
-    ``fragments``: list of lists of 0-based atom indices.  Builds the AO
-    spin-flip transition density T = C_occ X^{(n)} C_vir^T, Loewdin-orthogonalizes
-    (Ttil = S^{1/2} T S^{1/2}), and sums Ttil_{mu,nu}^2 over fragment blocks.
-    Row index = hole fragment, column index = particle fragment."""
-    X = states.amplitude_matrix(n)                      # (noca, nvirb)
-    C = states.C
-    na, nb, nbf = states.na, states.nb, states.nbf
-    T_ao = C[:, :na] @ X @ C[:, nb:nbf].T               # (nbf, nbf)
-    Shalf = np.real(sqrtm(states.S))
+
+def _fragment_map(ao_atom, fragments):
+    """Validate a disjoint, complete atom partition and return AO fragments."""
+    atom_frag = {}
+    for frag, atoms in enumerate(fragments):
+        if not atoms:
+            raise ValueError(f"fragment {frag} is empty")
+        for atom in atoms:
+            atom = int(atom)
+            if atom in atom_frag:
+                raise ValueError(f"atom {atom} occurs in more than one fragment")
+            atom_frag[atom] = frag
+    missing = sorted(set(np.asarray(ao_atom, dtype=int)) - set(atom_frag))
+    if missing:
+        raise ValueError(f"fragments do not assign AO-bearing atoms {missing}")
+    return np.array([atom_frag[int(atom)] for atom in ao_atom], dtype=int)
+
+
+def fragment_ct_matrix(states, ao, n, fragments, ref=0):
+    """Fragment charge-transfer matrix for the physical ``ref -> n`` transition.
+
+    ``fragments`` is a disjoint partition of 0-based atom indices.  The genuine
+    MRSF state-interaction 1-TDM is Loewdin-orthogonalized as
+    ``Ttilde = S^(1/2) T_AO S^(1/2)`` and
+
+    ``Omega[A, B] = sum_(mu in B, nu in A) |Ttilde[mu, nu]|^2``.
+
+    Rows therefore identify the *hole* fragment and columns the *particle*
+    fragment.  This function deliberately does not use ``amplitude_matrix``:
+    that matrix describes a response root relative to the auxiliary high-spin
+    determinant, whereas ``tdm_ao(ref, n)`` describes the requested pair of
+    physical MRSF roots.
+    """
+    ref = int(ref)
+    n = int(n)
+    if ref == n:
+        raise ValueError("fragment CT analysis requires two different states")
+    if not (0 <= ref < states.nstates and 0 <= n < states.nstates):
+        raise IndexError("state index is outside the MRSF root range")
+
+    T_ao = np.asarray(states.tdm_ao(ref, n), dtype=float)
+    if T_ao.shape != (states.nbf, states.nbf):
+        raise ValueError("state-interaction AO transition density has the wrong shape")
+    Shalf = _lowdin_sqrt(states.S)
     Ttil = Shalf @ T_ao @ Shalf
-    P = Ttil ** 2                                       # element-wise CT weights
+    P = np.abs(Ttil) ** 2
 
     nfrag = len(fragments)
-    # map atom -> fragment
-    atom_frag = {}
-    for f, atoms in enumerate(fragments):
-        for a in atoms:
-            atom_frag[int(a)] = f
-    ao_frag = np.array([atom_frag[int(a)] for a in ao.ao_atom])
+    ao_frag = _fragment_map(ao.ao_atom, fragments)
 
     Omega = np.zeros((nfrag, nfrag))
     for A in range(nfrag):
-        rows = ao_frag == A
+        hole_columns = ao_frag == A
         for B in range(nfrag):
-            cols = ao_frag == B
-            Omega[A, B] = P[np.ix_(rows, cols)].sum()
+            particle_rows = ao_frag == B
+            Omega[A, B] = P[np.ix_(particle_rows, hole_columns)].sum()
     total = P.sum()
+    local = float(np.trace(Omega) / total) if total > 0 else 0.0
     return {
+        "pair": (ref, n),
         "Omega": Omega,
         "total": float(total),
         "hole_pop": Omega.sum(axis=1),       # per-fragment hole population
         "particle_pop": Omega.sum(axis=0),   # per-fragment particle population
-        "ct_fraction": float(1.0 - np.trace(Omega) / total) if total > 0 else 0.0,
-        "amplitude_norm": float((X ** 2).sum()),
+        "le_fraction": local,
+        "ct_fraction": 1.0 - local if total > 0 else 0.0,
+        "transition_density_orthogonalized": Ttil,
     }

--- a/pyoqp/oqp/analysis/descriptors.py
+++ b/pyoqp/oqp/analysis/descriptors.py
@@ -75,7 +75,7 @@ def _fragment_map(ao_atom, fragments):
     return np.array([atom_frag[int(atom)] for atom in ao_atom], dtype=int)
 
 
-def fragment_ct_matrix(states, ao, n, fragments, ref=0):
+def fragment_ct_matrix(states, ao, n, fragments, ref=0, norm_tolerance=1.0e-10):
     """Fragment charge-transfer matrix for the physical ``ref -> n`` transition.
 
     ``fragments`` is a disjoint partition of 0-based atom indices.  The genuine
@@ -89,6 +89,18 @@ def fragment_ct_matrix(states, ao, n, fragments, ref=0):
     that matrix describes a response root relative to the auxiliary high-spin
     determinant, whereas ``tdm_ao(ref, n)`` describes the requested pair of
     physical MRSF roots.
+
+    ``total`` is the squared 1-TDM norm that normalizes LE/CT.  A symmetry-
+    forbidden pair has no appreciable 1-TDM, so below ``norm_tolerance`` the
+    fractions would be numerical noise dressed up as three decimal places:
+    ``le_fraction``/``ct_fraction`` are then NaN and ``well_defined`` is False.
+
+    .. note::
+       This is a deliberate behaviour change from the pre-0.9 version, which
+       analyzed ``amplitude_matrix(n)`` -- a response root relative to the
+       auxiliary high-spin determinant, not a physical root pair.  The
+       ``amplitude_norm`` result key belonged to that object and is gone; use
+       :func:`~oqp.analysis.nto_excitation` for amplitude-based character.
     """
     ref = int(ref)
     n = int(n)
@@ -113,15 +125,17 @@ def fragment_ct_matrix(states, ao, n, fragments, ref=0):
         for B in range(nfrag):
             particle_rows = ao_frag == B
             Omega[A, B] = P[np.ix_(particle_rows, hole_columns)].sum()
-    total = P.sum()
-    local = float(np.trace(Omega) / total) if total > 0 else 0.0
+    total = float(P.sum())
+    well_defined = total > float(norm_tolerance)
+    local = float(np.trace(Omega) / total) if well_defined else float("nan")
     return {
         "pair": (ref, n),
         "Omega": Omega,
-        "total": float(total),
+        "total": total,
         "hole_pop": Omega.sum(axis=1),       # per-fragment hole population
         "particle_pop": Omega.sum(axis=0),   # per-fragment particle population
         "le_fraction": local,
-        "ct_fraction": 1.0 - local if total > 0 else 0.0,
+        "ct_fraction": 1.0 - local,
+        "well_defined": well_defined,
         "transition_density_orthogonalized": Ttil,
     }

--- a/pyoqp/oqp/analysis/descriptors.py
+++ b/pyoqp/oqp/analysis/descriptors.py
@@ -62,7 +62,12 @@ def _fragment_map(ao_atom, fragments):
     """Validate a disjoint, complete atom partition and return AO fragments."""
     atom_frag = {}
     for frag, atoms in enumerate(fragments):
-        if not atoms:
+        # len(), not truthiness: fragments are naturally built with numpy
+        # helpers (np.flatnonzero, np.array_split), and `not ndarray` raises
+        # "truth value of an array ... is ambiguous" for any fragment holding
+        # more than one atom.
+        atoms = np.atleast_1d(np.asarray(atoms, dtype=int)).ravel()
+        if len(atoms) == 0:
             raise ValueError(f"fragment {frag} is empty")
         for atom in atoms:
             atom = int(atom)

--- a/pyoqp/oqp/analysis/state_analysis.py
+++ b/pyoqp/oqp/analysis/state_analysis.py
@@ -1,0 +1,186 @@
+"""Physical-root MRSF state analysis.
+
+Spatial LE/CT character and orbital character answer different questions and
+are therefore reported separately.  LE/CT comes from a fragment-partitioned
+state-interaction 1-TDM.  The ``n/pi/sigma -> pi*/sigma*`` fractions come from
+the same physical-root NTO pairs after a Loewdin population analysis.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from .descriptors import _lowdin_sqrt, fragment_ct_matrix, participation_ratio
+from .nto import nto_transition
+
+__all__ = ["analyze_mrsf_transition", "infer_molecular_plane"]
+
+_CHANNELS = (
+    "n->pi*", "pi->pi*", "sigma->pi*",
+    "n->sigma*", "pi->sigma*", "sigma->sigma*",
+)
+_PRETTY = {
+    "n->pi*": "nπ*", "pi->pi*": "ππ*", "sigma->pi*": "σπ*",
+    "n->sigma*": "nσ*", "pi->sigma*": "πσ*", "sigma->sigma*": "σσ*",
+}
+
+
+def _unit_vector(vector, name):
+    vector = np.asarray(vector, dtype=float).reshape(3)
+    norm = np.linalg.norm(vector)
+    if not np.isfinite(norm) or norm <= 1.0e-12:
+        raise ValueError(f"{name} must be a finite nonzero 3-vector")
+    return vector / norm
+
+
+def infer_molecular_plane(ao, atoms=None, relative_tolerance=0.12):
+    """Return the least-squares molecular-plane normal for a planar molecule.
+
+    Hydrogen atoms are omitted when atomic numbers are supplied.  Linear and
+    appreciably non-planar geometries are rejected because their pi direction
+    is not defined by a single global plane; callers may provide an explicit
+    local ``plane_normal`` to :func:`analyze_mrsf_transition` instead.
+    """
+    coords = np.asarray(ao.coords, dtype=float).reshape(-1, 3)
+    if atoms is not None:
+        atoms = np.asarray(atoms, dtype=int).reshape(-1)
+        if atoms.size != coords.shape[0]:
+            raise ValueError("atomic numbers and coordinates have different lengths")
+        selected = coords[atoms > 1]
+        if selected.shape[0] < 3:
+            selected = coords
+    else:
+        selected = coords
+    if selected.shape[0] < 3:
+        raise ValueError("at least three atoms or an explicit plane_normal are required")
+    centered = selected - selected.mean(axis=0)
+    covariance = centered.T @ centered / selected.shape[0]
+    values, vectors = np.linalg.eigh(covariance)
+    if values[1] <= 1.0e-12 * max(values[2], 1.0):
+        raise ValueError("a linear geometry has no unique molecular plane")
+    extent = np.sqrt(max(values[2], 1.0e-30))
+    rms_out_of_plane = np.sqrt(max(values[0], 0.0))
+    if rms_out_of_plane / extent > relative_tolerance:
+        raise ValueError(
+            "geometry is not described by one molecular plane; provide a local plane_normal")
+    return _unit_vector(vectors[:, 0], "inferred plane normal")
+
+
+def _ao_pi_projection(ao, normal):
+    projection = np.zeros(ao.nbf)
+    for mu, (_shell, powers, _scale) in enumerate(ao.ao_index):
+        if sum(powers) == 1:
+            axis = int(np.argmax(powers))
+            projection[mu] = normal[axis] ** 2
+    return projection
+
+
+def _nto_orbital_character(coefficients, shalf, ao, normal, hetero_atoms):
+    # q = S^(1/2)c are coefficients in the symmetric orthonormal AO basis.
+    q = shalf @ np.asarray(coefficients, dtype=float)
+    population = q * q
+    norm = population.sum()
+    if norm <= 1.0e-20:
+        return {"n": 0.0, "pi": 0.0, "sigma": 0.0}
+    population /= norm
+    pi_projection = _ao_pi_projection(ao, normal)
+    pi = float(np.dot(population, pi_projection))
+    hetero_mask = np.isin(ao.ao_atom, np.asarray(hetero_atoms, dtype=int))
+    in_plane = 1.0 - pi_projection
+    lone_pair = float(np.dot(population * hetero_mask, in_plane))
+    n = min(max(lone_pair, 0.0), max(1.0 - pi, 0.0))
+    sigma = max(1.0 - pi - n, 0.0)
+    total = n + pi + sigma
+    return {"n": n / total, "pi": pi / total, "sigma": sigma / total}
+
+
+def _orbital_channel_analysis(nto, states, ao, normal, hetero_atoms, weight_threshold):
+    weights = np.asarray(nto["weights"], dtype=float)
+    if weights.size == 0 or weights.sum() <= 0.0:
+        return {"fractions": {key: 0.0 for key in _CHANNELS}, "pairs": []}
+    keep = weights > weight_threshold * weights.max()
+    if not np.any(keep):
+        keep[np.argmax(weights)] = True
+    selected = np.flatnonzero(keep)
+    selected_weights = weights[selected]
+    selected_weights /= selected_weights.sum()
+    shalf = _lowdin_sqrt(states.S)
+    fractions = np.zeros((3, 2))  # hole n/pi/sigma x particle pi*/sigma*
+    pairs = []
+    for rank, pair_weight in zip(selected, selected_weights):
+        hole = _nto_orbital_character(
+            nto["holes_ao"][:, rank], shalf, ao, normal, hetero_atoms)
+        particle_hps = _nto_orbital_character(
+            nto["particles_ao"][:, rank], shalf, ao, normal, ())
+        particle = {"pi*": particle_hps["pi"],
+                    "sigma*": particle_hps["n"] + particle_hps["sigma"]}
+        h = np.array([hole["n"], hole["pi"], hole["sigma"]])
+        p = np.array([particle["pi*"], particle["sigma*"]])
+        fractions += pair_weight * np.outer(h, p)
+        pairs.append({"rank": int(rank + 1), "weight": float(pair_weight),
+                      "hole": hole, "particle": particle})
+    flat = fractions.ravel(order="F")
+    return {"fractions": dict(zip(_CHANNELS, map(float, flat))), "pairs": pairs}
+
+
+def analyze_mrsf_transition(states, ao, n, fragments, ref=0, plane_normal=None,
+                            hetero_atoms=None, weight_threshold=1.0e-4,
+                            label_threshold=0.55):
+    """Analyze a physical MRSF root pair as LE/CT and orbital-character fractions.
+
+    State indices and atom indices are 0-based.  ``fragments`` defines the
+    chemical units used for LE/CT; atoms are not silently treated as fragments.
+    For a planar chromophore the plane is inferred.  Supply ``plane_normal``
+    for a local chromophore in a non-planar molecule.  If no unique plane can
+    be found, LE/CT and NTO results are still returned while orbital character
+    is marked ``unclassified``.
+
+    The returned label is ``mixed`` unless the largest of the six orbital
+    channels is at least ``label_threshold``.  The fractions remain the primary
+    result and should be reported alongside any compact label.
+    """
+    ref = int(ref)
+    n = int(n)
+    atoms = np.asarray(states.mol.get_atoms(), dtype=int)
+    plane_reason = None
+    if plane_normal is None:
+        try:
+            normal = infer_molecular_plane(ao, atoms)
+        except ValueError as exc:
+            normal = None
+            plane_reason = str(exc)
+    else:
+        normal = _unit_vector(plane_normal, "plane_normal")
+    if hetero_atoms is None:
+        hetero_atoms = np.flatnonzero((atoms != 1) & (atoms != 6))
+    hetero_atoms = np.asarray(hetero_atoms, dtype=int)
+
+    ct = fragment_ct_matrix(states, ao, n, fragments, ref=ref)
+    nto = nto_transition(states, ref, n)
+    if normal is None:
+        orbital = {"fractions": {key: 0.0 for key in _CHANNELS}, "pairs": []}
+        orbital["label_ascii"] = "unclassified"
+        orbital["label"] = "unclassified"
+        orbital["classified"] = False
+        orbital["reason"] = plane_reason
+    else:
+        orbital = _orbital_channel_analysis(
+            nto, states, ao, normal, hetero_atoms, float(weight_threshold))
+        best = max(orbital["fractions"], key=orbital["fractions"].get)
+        best_fraction = orbital["fractions"][best]
+        orbital["label_ascii"] = best if best_fraction >= label_threshold else "mixed"
+        orbital["label"] = _PRETTY[best] if best_fraction >= label_threshold else "mixed"
+        orbital["classified"] = True
+    orbital["plane_normal"] = normal
+    orbital["hetero_atoms"] = hetero_atoms
+    orbital["method"] = "Loewdin NTO p-perpendicular/heteroatom in-plane population"
+
+    return {
+        "pair": (ref, n),
+        "energy_gap": float(states.energies[n] - states.energies[ref]),
+        "fragment_ct": ct,
+        "le_fraction": ct["le_fraction"],
+        "ct_fraction": ct["ct_fraction"],
+        "nto": nto,
+        "nto_participation_ratio": participation_ratio(nto["weights"]),
+        "orbital_character": orbital,
+    }

--- a/pyoqp/oqp/analysis/state_analysis.py
+++ b/pyoqp/oqp/analysis/state_analysis.py
@@ -69,10 +69,21 @@ def _p_shell_groups(ao):
     """Group Cartesian p AOs by shell, with the axis of each component.
 
     A p shell has to be projected on the plane normal *coherently*, so the
-    grouping is what makes the pi fraction independent of how the molecule
-    happens to be oriented in the input frame.  Shells with l >= 2 carry no
-    pi weight here and are counted as in-plane; polarization d functions hold
-    little population, so this only blurs the n/sigma split slightly.
+    grouping is what makes the pi fraction essentially independent of how the
+    molecule happens to be oriented in the input frame.  Shells with l >= 2
+    carry no pi weight here and are counted as in-plane; polarization d
+    functions hold little population, so this only blurs the n/sigma split
+    slightly.
+
+    "Essentially" because a residue remains: q = S^(1/2)c is covariant under
+    rotations only when the AO basis is, and normalized *Cartesian* d shells
+    are not (the six components carry an extra s-like combination and mix
+    non-orthogonally under rotation).  Since ``AOBasis`` accepts only Cartesian
+    bases, rigidly rotating a molecule still moves the reported fractions a
+    little through S^(1/2): measured at 5.4e-3 for formaldehyde MRSF/6-31G*,
+    and below 1.5e-13 for the same molecule in unpolarized 6-31G.  That is far
+    below the ``label_threshold`` margin, but do not read the third decimal of
+    a fraction as physical when polarization functions are present.
     """
     shells = {}
     for mu, (shell, powers, _scale) in enumerate(ao.ao_index):

--- a/pyoqp/oqp/analysis/state_analysis.py
+++ b/pyoqp/oqp/analysis/state_analysis.py
@@ -65,38 +65,64 @@ def infer_molecular_plane(ao, atoms=None, relative_tolerance=0.12):
     return _unit_vector(vectors[:, 0], "inferred plane normal")
 
 
-def _ao_pi_projection(ao, normal):
-    projection = np.zeros(ao.nbf)
-    for mu, (_shell, powers, _scale) in enumerate(ao.ao_index):
+def _p_shell_groups(ao):
+    """Group Cartesian p AOs by shell, with the axis of each component.
+
+    A p shell has to be projected on the plane normal *coherently*, so the
+    grouping is what makes the pi fraction independent of how the molecule
+    happens to be oriented in the input frame.  Shells with l >= 2 carry no
+    pi weight here and are counted as in-plane; polarization d functions hold
+    little population, so this only blurs the n/sigma split slightly.
+    """
+    shells = {}
+    for mu, (shell, powers, _scale) in enumerate(ao.ao_index):
         if sum(powers) == 1:
-            axis = int(np.argmax(powers))
-            projection[mu] = normal[axis] ** 2
-    return projection
+            shells.setdefault(shell, []).append((int(np.argmax(powers)), mu))
+    return [(np.array([mu for _axis, mu in members], dtype=int),
+             np.array([axis for axis, _mu in members], dtype=int))
+            for members in shells.values()]
 
 
-def _nto_orbital_character(coefficients, shalf, ao, normal, hetero_atoms):
+def _nto_orbital_character(coefficients, shalf, ao, normal, hetero_atoms,
+                           p_groups):
     # q = S^(1/2)c are coefficients in the symmetric orthonormal AO basis.
     q = shalf @ np.asarray(coefficients, dtype=float)
     population = q * q
     norm = population.sum()
     if norm <= 1.0e-20:
         return {"n": 0.0, "pi": 0.0, "sigma": 0.0}
-    population /= norm
-    pi_projection = _ao_pi_projection(ao, normal)
-    pi = float(np.dot(population, pi_projection))
     hetero_mask = np.isin(ao.ao_atom, np.asarray(hetero_atoms, dtype=int))
-    in_plane = 1.0 - pi_projection
-    lone_pair = float(np.dot(population * hetero_mask, in_plane))
-    n = min(max(lone_pair, 0.0), max(1.0 - pi, 0.0))
+    pi_population = 0.0
+    lone_pair = 0.0
+    in_p_shell = np.zeros(ao.nbf, dtype=bool)
+    for indices, axes in p_groups:
+        shell_population = float(population[indices].sum())
+        # (n.q)^2, not sum_a n_a^2 q_a^2: dropping the p_x/p_y/p_z cross terms
+        # would make the pi fraction correct only when the plane normal is a
+        # Cartesian axis, and underestimate it by up to 3x otherwise.
+        pi_shell = min(float(normal[axes] @ q[indices]) ** 2, shell_population)
+        pi_population += pi_shell
+        if hetero_mask[indices[0]]:      # one shell sits on one atom
+            lone_pair += shell_population - pi_shell
+        in_p_shell[indices] = True
+    lone_pair += float(population[hetero_mask & ~in_p_shell].sum())
+    pi = pi_population / norm
+    n = min(max(lone_pair / norm, 0.0), max(1.0 - pi, 0.0))
     sigma = max(1.0 - pi - n, 0.0)
     total = n + pi + sigma
     return {"n": n / total, "pi": pi / total, "sigma": sigma / total}
 
 
-def _orbital_channel_analysis(nto, states, ao, normal, hetero_atoms, weight_threshold):
+def _orbital_channel_analysis(nto, states, ao, normal, hetero_atoms,
+                              weight_threshold, norm_tolerance):
     weights = np.asarray(nto["weights"], dtype=float)
-    if weights.size == 0 or weights.sum() <= 0.0:
-        return {"fractions": {key: 0.0 for key in _CHANNELS}, "pairs": []}
+    if weights.size == 0 or weights.sum() <= norm_tolerance:
+        # sum(sigma^2) is the squared 1-TDM norm.  Normalizing it away would
+        # turn the numerical noise of a forbidden transition into fractions
+        # that look precise; report "no character" instead.
+        return {"fractions": {key: float("nan") for key in _CHANNELS},
+                "pairs": [], "classified": False,
+                "reason": "the ref->n transition density has no appreciable norm"}
     keep = weights > weight_threshold * weights.max()
     if not np.any(keep):
         keep[np.argmax(weights)] = True
@@ -104,13 +130,14 @@ def _orbital_channel_analysis(nto, states, ao, normal, hetero_atoms, weight_thre
     selected_weights = weights[selected]
     selected_weights /= selected_weights.sum()
     shalf = _lowdin_sqrt(states.S)
+    p_groups = _p_shell_groups(ao)
     fractions = np.zeros((3, 2))  # hole n/pi/sigma x particle pi*/sigma*
     pairs = []
     for rank, pair_weight in zip(selected, selected_weights):
         hole = _nto_orbital_character(
-            nto["holes_ao"][:, rank], shalf, ao, normal, hetero_atoms)
+            nto["holes_ao"][:, rank], shalf, ao, normal, hetero_atoms, p_groups)
         particle_hps = _nto_orbital_character(
-            nto["particles_ao"][:, rank], shalf, ao, normal, ())
+            nto["particles_ao"][:, rank], shalf, ao, normal, (), p_groups)
         particle = {"pi*": particle_hps["pi"],
                     "sigma*": particle_hps["n"] + particle_hps["sigma"]}
         h = np.array([hole["n"], hole["pi"], hole["sigma"]])
@@ -119,12 +146,13 @@ def _orbital_channel_analysis(nto, states, ao, normal, hetero_atoms, weight_thre
         pairs.append({"rank": int(rank + 1), "weight": float(pair_weight),
                       "hole": hole, "particle": particle})
     flat = fractions.ravel(order="F")
-    return {"fractions": dict(zip(_CHANNELS, map(float, flat))), "pairs": pairs}
+    return {"fractions": dict(zip(_CHANNELS, map(float, flat))), "pairs": pairs,
+            "classified": True, "reason": None}
 
 
 def analyze_mrsf_transition(states, ao, n, fragments, ref=0, plane_normal=None,
                             hetero_atoms=None, weight_threshold=1.0e-4,
-                            label_threshold=0.55):
+                            label_threshold=0.55, norm_tolerance=1.0e-10):
     """Analyze a physical MRSF root pair as LE/CT and orbital-character fractions.
 
     State indices and atom indices are 0-based.  ``fragments`` defines the
@@ -132,11 +160,21 @@ def analyze_mrsf_transition(states, ao, n, fragments, ref=0, plane_normal=None,
     For a planar chromophore the plane is inferred.  Supply ``plane_normal``
     for a local chromophore in a non-planar molecule.  If no unique plane can
     be found, LE/CT and NTO results are still returned while orbital character
-    is marked ``unclassified``.
+    is marked ``unclassified`` and its fractions are NaN.  The same happens
+    when the ``ref -> n`` transition density has no appreciable norm, since
+    every fraction here is normalized by it.
 
     The returned label is ``mixed`` unless the largest of the six orbital
     channels is at least ``label_threshold``.  The fractions remain the primary
     result and should be reported alongside any compact label.
+
+    .. warning::
+       ``n`` is *heteroatom in-plane population*, not a localized lone pair:
+       a heteroatom s orbital and a polarized C-O sigma bond both land in it.
+       The n/sigma split is therefore indicative only; ``pi`` (and hence the
+       pi*/sigma* axis) is the well-defined quantity, being a projection on the
+       molecular-plane normal.  Treat ``n->pi*`` vs ``sigma->pi*`` as a hint and
+       confirm with the NTO pairs in ``orbital_character["pairs"]``.
     """
     ref = int(ref)
     n = int(n)
@@ -154,22 +192,24 @@ def analyze_mrsf_transition(states, ao, n, fragments, ref=0, plane_normal=None,
         hetero_atoms = np.flatnonzero((atoms != 1) & (atoms != 6))
     hetero_atoms = np.asarray(hetero_atoms, dtype=int)
 
-    ct = fragment_ct_matrix(states, ao, n, fragments, ref=ref)
+    ct = fragment_ct_matrix(states, ao, n, fragments, ref=ref,
+                            norm_tolerance=norm_tolerance)
     nto = nto_transition(states, ref, n)
     if normal is None:
-        orbital = {"fractions": {key: 0.0 for key in _CHANNELS}, "pairs": []}
-        orbital["label_ascii"] = "unclassified"
-        orbital["label"] = "unclassified"
-        orbital["classified"] = False
-        orbital["reason"] = plane_reason
+        orbital = {"fractions": {key: float("nan") for key in _CHANNELS},
+                   "pairs": [], "classified": False, "reason": plane_reason}
     else:
         orbital = _orbital_channel_analysis(
-            nto, states, ao, normal, hetero_atoms, float(weight_threshold))
+            nto, states, ao, normal, hetero_atoms, float(weight_threshold),
+            float(norm_tolerance))
+    if orbital["classified"]:
         best = max(orbital["fractions"], key=orbital["fractions"].get)
         best_fraction = orbital["fractions"][best]
         orbital["label_ascii"] = best if best_fraction >= label_threshold else "mixed"
         orbital["label"] = _PRETTY[best] if best_fraction >= label_threshold else "mixed"
-        orbital["classified"] = True
+    else:
+        orbital["label_ascii"] = "unclassified"
+        orbital["label"] = "unclassified"
     orbital["plane_normal"] = normal
     orbital["hetero_atoms"] = hetero_atoms
     orbital["method"] = "Loewdin NTO p-perpendicular/heteroatom in-plane population"

--- a/pyoqp/oqp/interop/__init__.py
+++ b/pyoqp/oqp/interop/__init__.py
@@ -18,7 +18,8 @@ from .compare import compare_results, format_table
 # excited-state analysis
 from oqp.analysis import (
     MRSFExcitedStates, nto_excitation, nto_transition, attachment_detachment,
-    participation_ratio, tozer_lambda, fragment_ct_matrix, AOBasis, make_box_grid,
+    participation_ratio, tozer_lambda, fragment_ct_matrix,
+    analyze_mrsf_transition, infer_molecular_plane, AOBasis, make_box_grid,
 )
 # export formats (cubes, QCSchema, FCIDUMP)
 from oqp.export import (
@@ -33,6 +34,7 @@ __all__ = [
     # analysis
     "MRSFExcitedStates", "nto_excitation", "nto_transition", "attachment_detachment",
     "participation_ratio", "tozer_lambda", "fragment_ct_matrix", "AOBasis", "make_box_grid",
+    "analyze_mrsf_transition", "infer_molecular_plane",
     # export
     "CubeExporter", "to_qcschema", "validate_qcschema", "dump_fcidump", "verify_fcidump_fci",
     # FCIDUMP / Hamiltonian

--- a/tests/test_excited_toolkit.py
+++ b/tests/test_excited_toolkit.py
@@ -232,3 +232,59 @@ def test_integration_keystone_qcschema_fcidump(tmp_path):
     dump_fcidump(path, r2.mol)
     ver = verify_fcidump_fci(path, r2.mol)
     assert ver["diff"] < 1e-8
+
+
+@pytest.mark.skipif(not os.environ.get("OPENQP_ROOT"),
+                    reason="needs a built OpenQP (OPENQP_ROOT)")
+def test_integration_state_analysis_on_real_mrsf_roots(tmp_path):
+    """Run the state analysis on genuine MRSF densities, not a hand-made 2x2.
+
+    The unit tests inject a 2x2 matrix with ``tdm_ao == tdm_mo``, so they cannot
+    see the tagarray reshape, the root ordering, the MO->AO transform or the
+    nonorthogonal overlap.  Formaldehyde exercises all of them.
+    """
+    pytest.importorskip("oqp")
+    if not _have_input("ch2o_mrsf.inp"):
+        pytest.skip("excited-toolkit fixture inputs not present")
+    from oqp.pyoqp import Runner
+    from oqp.interop import (AOBasis, MRSFExcitedStates, analyze_mrsf_transition,
+                             infer_molecular_plane)
+
+    r = Runner(project="ch2o_sa", input_file=_input_path("ch2o_mrsf.inp"),
+               log=str(tmp_path / "ch2o_sa.log"), silent=1, usempi=False)
+    r.run()
+    st = MRSFExcitedStates(r.mol)
+    ao = AOBasis(r.mol)
+    whole = [list(range(len(np.asarray(r.mol.get_atoms()).ravel())))]
+
+    # The fixture geometry is planar in yz, so the pi axis is x.  This is pure
+    # geometry and holds regardless of the electronic structure.
+    normal = infer_molecular_plane(ao, np.asarray(r.mol.get_atoms(), dtype=int))
+    assert abs(abs(float(normal[0])) - 1.0) < 1e-6
+
+    for n in range(1, st.nstates):
+        rep = analyze_mrsf_transition(st, ao, n, whole)
+        ct = rep["fragment_ct"]
+        assert ct["well_defined"]
+        # Omega is a partition of the squared 1-TDM norm.
+        assert abs(ct["Omega"].sum() - ct["total"]) < 1e-8 * max(ct["total"], 1.0)
+        # A single fragment cannot support charge transfer.
+        assert abs(rep["le_fraction"] - 1.0) < 1e-8
+        fractions = rep["orbital_character"]["fractions"]
+        assert rep["orbital_character"]["classified"]
+        assert abs(sum(fractions.values()) - 1.0) < 1e-8
+        assert all(np.isfinite(v) for v in fractions.values())
+
+        # gamma^{n->0} is the transpose of gamma^{0->n}, so hole and particle
+        # swap and Omega must transpose with them.  A stray transpose in the
+        # MO->AO path or in the fragment loop breaks this.
+        back = analyze_mrsf_transition(st, ao, 0, whole, ref=n)
+        np.testing.assert_allclose(back["fragment_ct"]["Omega"],
+                                   ct["Omega"].T, rtol=1e-8, atol=1e-10)
+        assert abs(back["energy_gap"] + rep["energy_gap"]) < 1e-10
+
+    # Formaldehyde's low MRSF roots are the classic n->pi* / pi->pi* pair: the
+    # acceptor is pi* in both, which the plane projection must reproduce.
+    s1 = analyze_mrsf_transition(st, ao, 1, whole)["orbital_character"]
+    to_pi_star = sum(v for k, v in s1["fractions"].items() if k.endswith("->pi*"))
+    assert to_pi_star > 0.5

--- a/tests/test_excited_toolkit.py
+++ b/tests/test_excited_toolkit.py
@@ -305,3 +305,17 @@ def test_integration_state_analysis_on_real_mrsf_roots(tmp_path):
     s1 = analyze_mrsf_transition(st, ao, 1, whole)["orbital_character"]
     to_pi_star = sum(v for k, v in s1["fractions"].items() if k.endswith("->pi*"))
     assert to_pi_star > 0.5
+
+
+def test_fragment_ct_accepts_numpy_fragment_definitions():
+    # Fragments are naturally built with numpy helpers, and `not ndarray`
+    # raises "truth value of an array ... is ambiguous" for any fragment with
+    # more than one atom (Codex review of #290).
+    states, ao = _PhysicalPairStates(), _TwoAO()
+    result = descriptors.fragment_ct_matrix(
+        states, ao, 1, [np.array([0]), np.array([1])], ref=0)
+    np.testing.assert_allclose(result["Omega"], [[0.0, 1.0], [0.0, 0.0]])
+    # ... including a multi-atom fragment, which is the case that raised.
+    with pytest.raises(ValueError, match="more than one"):
+        descriptors.fragment_ct_matrix(
+            states, ao, 1, [np.array([0, 1]), np.array([1])], ref=0)

--- a/tests/test_excited_toolkit.py
+++ b/tests/test_excited_toolkit.py
@@ -256,12 +256,17 @@ def test_integration_state_analysis_on_real_mrsf_roots(tmp_path):
     st = MRSFExcitedStates(r.mol)
     ao = AOBasis(r.mol)
     whole = [list(range(len(np.asarray(r.mol.get_atoms()).ravel())))]
+    # C, O | H, H -- two fragments, so Omega is 2x2 and its off-diagonal
+    # elements are what the hole/particle index convention actually controls.
+    # A single fragment would make every transpose assertion below vacuous.
+    split = [[0, 1], [2, 3]]
 
     # The fixture geometry is planar in yz, so the pi axis is x.  This is pure
     # geometry and holds regardless of the electronic structure.
     normal = infer_molecular_plane(ao, np.asarray(r.mol.get_atoms(), dtype=int))
     assert abs(abs(float(normal[0])) - 1.0) < 1e-6
 
+    off_diagonal_seen = False
     for n in range(1, st.nstates):
         rep = analyze_mrsf_transition(st, ao, n, whole)
         ct = rep["fragment_ct"]
@@ -277,11 +282,23 @@ def test_integration_state_analysis_on_real_mrsf_roots(tmp_path):
 
         # gamma^{n->0} is the transpose of gamma^{0->n}, so hole and particle
         # swap and Omega must transpose with them.  A stray transpose in the
-        # MO->AO path or in the fragment loop breaks this.
-        back = analyze_mrsf_transition(st, ao, 0, whole, ref=n)
-        np.testing.assert_allclose(back["fragment_ct"]["Omega"],
-                                   ct["Omega"].T, rtol=1e-8, atol=1e-10)
-        assert abs(back["energy_gap"] + rep["energy_gap"]) < 1e-10
+        # MO->AO path or in the fragment loop breaks this -- but only shows up
+        # once Omega has off-diagonal weight, hence the two-fragment split.
+        pair = analyze_mrsf_transition(st, ao, n, split)["fragment_ct"]
+        back = analyze_mrsf_transition(st, ao, 0, split, ref=n)["fragment_ct"]
+        np.testing.assert_allclose(back["Omega"], pair["Omega"].T,
+                                   rtol=1e-8, atol=1e-12)
+        assert abs(back["le_fraction"] - pair["le_fraction"]) < 1e-8
+        off_diagonal_seen |= bool(
+            np.max(np.abs(pair["Omega"] - np.diag(np.diag(pair["Omega"]))))
+            > 1e-6 * pair["total"])
+        assert abs(rep["energy_gap"]
+                   + analyze_mrsf_transition(st, ao, 0, whole,
+                                             ref=n)["energy_gap"]) < 1e-10
+
+    # Guard the guard: if every Omega were diagonal the transpose check above
+    # would have proved nothing.
+    assert off_diagonal_seen
 
     # Formaldehyde's low MRSF roots are the classic n->pi* / pi->pi* pair: the
     # acceptor is pi* in both, which the plane projection must reproduce.

--- a/tests/test_excited_toolkit.py
+++ b/tests/test_excited_toolkit.py
@@ -70,6 +70,62 @@ def test_participation_ratio_bounds():
     assert abs(descriptors.participation_ratio([0.25] * 4) - 4.0) < 1e-12
 
 
+class _PhysicalPairStates:
+    """Two-root fixture whose auxiliary-reference amplitudes must not be used."""
+
+    nstates = 2
+    nbf = 2
+    S = np.eye(2)
+    C = np.eye(2)
+    energies = np.array([-10.0, -9.8])
+
+    class _Mol:
+        @staticmethod
+        def get_atoms():
+            return np.array([8, 6])
+
+    mol = _Mol()
+
+    @staticmethod
+    def tdm_mo(i, j):
+        assert (i, j) == (0, 1)
+        # Row = particle AO (C p_z), column = hole AO (O p_x).
+        return np.array([[0.0, 0.0], [1.0, 0.0]])
+
+    @classmethod
+    def tdm_ao(cls, i, j):
+        return cls.tdm_mo(i, j)
+
+    @staticmethod
+    def amplitude_matrix(_n):
+        raise AssertionError("physical-root analysis used the high-spin reference")
+
+
+class _TwoAO:
+    nbf = 2
+    ao_atom = np.array([0, 1])
+    # O p_x is in the xy plane; C p_z is perpendicular.
+    ao_index = [(0, (1, 0, 0), 1.0), (1, (0, 0, 1), 1.0)]
+    coords = np.array([[0.0, 0.0, 0.0], [1.2, 0.0, 0.0]])
+
+
+def test_fragment_ct_uses_physical_root_pair_and_orientation():
+    result = descriptors.fragment_ct_matrix(
+        _PhysicalPairStates(), _TwoAO(), 1, [[0], [1]], ref=0)
+    np.testing.assert_allclose(result["Omega"], [[0.0, 1.0], [0.0, 0.0]])
+    assert result["le_fraction"] == 0.0
+    assert result["ct_fraction"] == 1.0
+    assert result["pair"] == (0, 1)
+
+
+def test_fragment_ct_rejects_incomplete_or_overlapping_partition():
+    states, ao = _PhysicalPairStates(), _TwoAO()
+    with pytest.raises(ValueError, match="do not assign"):
+        descriptors.fragment_ct_matrix(states, ao, 1, [[0]])
+    with pytest.raises(ValueError, match="more than one"):
+        descriptors.fragment_ct_matrix(states, ao, 1, [[0], [0, 1]])
+
+
 # --------------------------------------------------------------------------
 # GTO evaluator guard  (Codex finding: spherical shells unsupported)
 # --------------------------------------------------------------------------
@@ -116,6 +172,7 @@ def test_interop_public_api_shape():
     import oqp.interop as I
     for name in ("MRSFExcitedStates", "nto_excitation", "attachment_detachment",
                  "participation_ratio", "tozer_lambda", "fragment_ct_matrix",
+                 "analyze_mrsf_transition", "infer_molecular_plane",
                  "CubeExporter", "to_qcschema", "validate_qcschema",
                  "dump_fcidump", "verify_fcidump_fci", "from_openqp",
                  "parse_output", "parse_pyscf_tddft", "compare_results"):

--- a/tests/test_mrsf_state_analysis.py
+++ b/tests/test_mrsf_state_analysis.py
@@ -1,0 +1,89 @@
+"""Focused tests for physical-root MRSF state labels."""
+import importlib.util
+import os
+import sys
+import types
+
+import numpy as np
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+_ANALYSIS = os.path.join(_ROOT, "pyoqp", "oqp", "analysis")
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(
+        f"_state_analysis_test.{name}", os.path.join(_ANALYSIS, f"{name}.py"))
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "_state_analysis_test"
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+package = types.ModuleType("_state_analysis_test")
+package.__path__ = [_ANALYSIS]
+sys.modules[package.__name__] = package
+_load("descriptors")
+_load("nto")
+state_analysis = _load("state_analysis")
+
+
+class _Mol:
+    @staticmethod
+    def get_atoms():
+        return np.array([8, 6])
+
+
+class _States:
+    nstates = 2
+    nbf = 2
+    S = np.eye(2)
+    C = np.eye(2)
+    energies = np.array([-10.0, -9.8])
+    mol = _Mol()
+
+    @staticmethod
+    def tdm_mo(i, j):
+        assert (i, j) == (0, 1)
+        return np.array([[0.0, 0.0], [1.0, 0.0]])
+
+    @classmethod
+    def tdm_ao(cls, i, j):
+        return cls.tdm_mo(i, j)
+
+
+class _AO:
+    nbf = 2
+    ao_atom = np.array([0, 1])
+    ao_index = [(0, (1, 0, 0), 1.0), (1, (0, 0, 1), 1.0)]
+    coords = np.array([[0.0, 0.0, 0.0], [1.2, 0.0, 0.0]])
+
+
+def test_n_pi_star_and_ct_are_reported_separately():
+    result = state_analysis.analyze_mrsf_transition(
+        _States(), _AO(), 1, [[0], [1]], plane_normal=[0, 0, 1])
+    assert result["pair"] == (0, 1)
+    assert result["ct_fraction"] == 1.0
+    assert result["le_fraction"] == 0.0
+    assert result["orbital_character"]["label"] == "nπ*"
+    fractions = result["orbital_character"]["fractions"]
+    assert fractions["n->pi*"] == 1.0
+    assert abs(sum(fractions.values()) - 1.0) < 1.0e-12
+    assert result["nto_participation_ratio"] == 1.0
+
+
+def test_mixed_label_retains_channel_fractions():
+    result = state_analysis.analyze_mrsf_transition(
+        _States(), _AO(), 1, [[0], [1]], plane_normal=[1, 0, 1],
+        label_threshold=0.75)
+    assert result["orbital_character"]["label"] == "mixed"
+    assert abs(sum(result["orbital_character"]["fractions"].values()) - 1.0) < 1.0e-12
+
+
+def test_le_ct_survives_when_no_unique_plane_exists():
+    result = state_analysis.analyze_mrsf_transition(
+        _States(), _AO(), 1, [[0], [1]])
+    assert result["ct_fraction"] == 1.0
+    assert result["orbital_character"]["label"] == "unclassified"
+    assert not result["orbital_character"]["classified"]
+    assert "three atoms" in result["orbital_character"]["reason"]

--- a/tests/test_mrsf_state_analysis.py
+++ b/tests/test_mrsf_state_analysis.py
@@ -80,6 +80,38 @@ def test_mixed_label_retains_channel_fractions():
     assert abs(sum(result["orbital_character"]["fractions"].values()) - 1.0) < 1.0e-12
 
 
+class _FullPShellAO:
+    """One atom carrying a complete Cartesian p shell (p_x, p_y, p_z)."""
+
+    nbf = 3
+    ao_atom = np.array([0, 0, 0])
+    ao_index = [(0, (1, 0, 0), 1.0), (0, (0, 1, 0), 1.0), (0, (0, 0, 1), 1.0)]
+    coords = np.array([[0.0, 0.0, 0.0]])
+
+
+def test_pi_character_is_independent_of_molecular_orientation():
+    # A p orbital along the plane normal is 100% pi whatever frame the molecule
+    # was given in.  Projecting each Cartesian component separately would report
+    # 1/2 for a normal in the xz plane and 1/3 for the body diagonal.
+    ao = _FullPShellAO()
+    p_groups = state_analysis._p_shell_groups(ao)
+    shalf = np.eye(3)
+    for normal in ([0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0],
+                   [0.3, -0.7, 0.2]):
+        normal = np.asarray(normal) / np.linalg.norm(normal)
+        along = state_analysis._nto_orbital_character(
+            normal, shalf, ao, normal, (), p_groups)
+        assert abs(along["pi"] - 1.0) < 1.0e-12
+        # ... and a p orbital lying in the plane carries no pi character.
+        in_plane = np.cross(normal, [1.0, 0.0, 0.0])
+        if np.linalg.norm(in_plane) < 1.0e-8:
+            in_plane = np.cross(normal, [0.0, 1.0, 0.0])
+        in_plane /= np.linalg.norm(in_plane)
+        across = state_analysis._nto_orbital_character(
+            in_plane, shalf, ao, normal, (), p_groups)
+        assert across["pi"] < 1.0e-12
+
+
 def test_le_ct_survives_when_no_unique_plane_exists():
     result = state_analysis.analyze_mrsf_transition(
         _States(), _AO(), 1, [[0], [1]])

--- a/tests/test_mrsf_state_analysis.py
+++ b/tests/test_mrsf_state_analysis.py
@@ -93,6 +93,8 @@ def test_pi_character_is_independent_of_molecular_orientation():
     # A p orbital along the plane normal is 100% pi whatever frame the molecule
     # was given in.  Projecting each Cartesian component separately would report
     # 1/2 for a normal in the xz plane and 1/3 for the body diagonal.
+    # (Exact here because a lone p shell is a rotationally covariant basis; with
+    # Cartesian d shells present a small residue survives -- see _p_shell_groups.)
     ao = _FullPShellAO()
     p_groups = state_analysis._p_shell_groups(ao)
     shalf = np.eye(3)


### PR DESCRIPTION
Summary:
- correct fragment CT analysis to use the physical MRSF root-pair 1-TDM
- add NTO-based LE/CT and n/pi/sigma to pi*/sigma* fractional analysis
- expose a public Python API, tests, and a small example

Companion PRs:
- openqp-dftb native API: https://github.com/Open-Quantum-Platform/openqp-dftb/pull/25
- Manual: https://github.com/Open-Quantum-Platform/openqp-docs/pull/20

Validation:
- python3 -m pytest -q tests/test_excited_toolkit.py tests/test_mrsf_state_analysis.py (11 passed, 2 skipped)