### PR TITLE
fix: three runtime bounds-checking aborts (-fcheck=bounds) in tagarray driver, guess, and dftlib

### DIFF
--- a/source/dftlib/dft_molgrid.F90
+++ b/source/dftlib/dft_molgrid.F90
@@ -728,8 +728,11 @@ contains
       integer, allocatable, intent(INOUT) :: v(:)
       integer, intent(IN) :: newsz
       integer, allocatable :: nv(:)
+      integer :: nold
       if (allocated(v)) then
-        allocate (nv(1:newsz), source=v)
+        nold = min(size(v), newsz)
+        allocate (nv(1:newsz))
+        nv(1:nold) = v(1:nold)
         call move_alloc(from=nv, to=v)
       end if
     end subroutine reallocate_int
@@ -742,8 +745,11 @@ contains
       real(kind=fp), allocatable, intent(INOUT) :: v(:)
       integer, intent(IN) :: newsz
       real(kind=fp), allocatable :: nv(:)
+      integer :: nold
       if (allocated(v)) then
-        allocate (nv(1:newsz), source=v)
+        nold = min(size(v), newsz)
+        allocate (nv(1:newsz))
+        nv(1:nold) = v(1:nold)
         call move_alloc(from=nv, to=v)
       end if
     end subroutine reallocate_real

--- a/source/dftlib/grid_storage.F90
+++ b/source/dftlib/grid_storage.F90
@@ -341,7 +341,8 @@ contains
     isz = DEFAULT_GRID_CHUNK
     if (present(iSize)) isz = iSize
 
-    allocate (elem_new(list%maxGrids+isz), source=list%elem)
+    allocate (elem_new(list%maxGrids+isz))
+    elem_new(1:list%maxGrids) = list%elem(1:list%maxGrids)
     call move_alloc(from=elem_new, to=list%elem)
     list%maxGrids = list%maxGrids+isz
 

--- a/source/guess.F90
+++ b/source/guess.F90
@@ -247,7 +247,9 @@ end subroutine get_ab_initio_density
 !   corresponds to Huckel/old MO i in order
     unused(:nmo) = .true.
     do i = 1, nmo
-      j = maxloc(abs(tmp(:nmo,i)), dim=1, mask=unused)
+      ! mask must conform to the (:nmo) section being searched; passing the
+      ! full-length `unused` is nonconforming Fortran (caught by -fcheck=bounds)
+      j = maxloc(abs(tmp(:nmo,i)), dim=1, mask=unused(:nmo))
       iwrk(i) = j
       unused(j) = .false.
     end do

--- a/source/tagarray_driver.F90
+++ b/source/tagarray_driver.F90
@@ -228,7 +228,10 @@ contains
     res = record_info%count
     if (present(type_id)) type_id = record_info%type_id
     if (present(ndims  )) ndims   = int(record_info%ndims, c_int32_t)
-    if (present(dims   )) dims(1:record_info%ndims) = record_info%dims
+    ! subscript the right-hand side too: for scalar records (ndims = 0)
+    ! record_info%dims still holds one element, and a 0-size = 1-size
+    ! assignment is nonconforming (caught by -fcheck=bounds)
+    if (present(dims   )) dims(1:record_info%ndims) = record_info%dims(1:record_info%ndims)
     if (present(data_size   )) data_size = record_info%count
 
   end function tagarray_get_cptr


### PR DESCRIPTION
Three small standard-conformance fixes for runtime aborts under a Debug `-fcheck=bounds` build (gfortran-13). All three are nonconforming array operations that gfortran's bounds checking rejects on perfectly ordinary inputs — on current `main`, a bounds-checked build cannot run *any* calculation. No numerical behavior changes: with the fixes, `examples/MRSF-TDDFT/H2O_BHHLYP-MRSFTDDFT_ENERGY.inp` completes under `-fcheck=bounds` and reproduces the reference energies in the adjacent `.json` (SCF −76.0774468204; S0/S1/S2 −76.36093649 / −76.03214231 / −75.97388051) to print precision.

The three aborts form a cascade on the same H2O example — each fix uncovers the next:

### 1. `source/tagarray_driver.F90` — dims copy nonconforming for scalar records

```fortran
if (present(dims)) dims(1:record_info%ndims) = record_info%dims
```

For a scalar record (`ndims = 0`) the left side has 0 elements while `record_info%dims` still holds one element, so the assignment is nonconforming. This aborts on the *first* scalar `oqp_get` from Python (tag `usempi`):

```
Fortran runtime error: Array bound mismatch for dimension 1 of array 'dims' (0/1)
At line 231 of file source/tagarray_driver.F90
```

Fix: subscript the right-hand side with the same section, `record_info%dims(1:record_info%ndims)`.

### 2. `source/guess.F90` — maxloc mask does not conform to the searched section

```fortran
j = maxloc(abs(tmp(:nmo,i)), dim=1, mask=unused)
```

`unused` has the full declared length, but the array being searched is the `(:nmo)` section; the standard requires MASK to be conformable with ARRAY. With fix 1 applied, the H2O example aborts here during the Huckel guess:

```
Fortran runtime error: Array bound mismatch for dimension 1 of array 'unused' (19/4)
At line 250 of file source/guess.F90
```

Fix: pass `mask=unused(:nmo)`.

### 3. `source/dftlib` — `allocate(..., source=)` with a larger shape when growing arrays

`dft_molgrid.F90` (`reallocate_int`/`reallocate_real` in `extend_dft_grid_t`):

```fortran
allocate (nv(1:newsz), source=v)   ! newsz > size(v) when growing
```

and the same pattern in `grid_storage.F90` (`extendListGrid`). When growing, the source does not conform to the allocated shape. With fixes 1–2 applied, the example aborts while assembling the molecular grid:

```
Fortran runtime error: Array bound mismatch for dimension 1 of array 'nv' (452/300)
At line 732 of file source/dftlib/dft_molgrid.F90
```

Fix: allocate without `source=`, copy the old elements explicitly, then `move_alloc`.

### Verification

macOS arm64, gfortran-13, `pip install .` with `cmake.build-type=Debug` and `-DCMAKE_Fortran_FLAGS=-fcheck=bounds`. gfortran-13 rather than 14/15 because those releases have an unrelated `-fcheck=bounds` false positive on valid array-section actual arguments (it triggers elsewhere in `dft_molgrid.F90` before any of the real issues).

- unfixed `main`: aborts at `tagarray_driver.F90:231` before any output;
- fix 1 only: aborts at `guess.F90:250`;
- fixes 1–2: aborts at `dft_molgrid.F90:732`;
- all three: H2O MRSF example completes; SCF and all three MRSF state energies match the reference `.json`.

A Release build is unaffected by construction: fixes 1 and 2 only make the already-intended section explicit, and fix 3 replaces `source=` initialization with an explicit copy of the same elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
