### PR TITLE
Petite-list integral reduction was silently disabled on every spherical basis (3.6-3.7x once fixed)

### DIFF
--- a/docs/planned/integral-symmetry.md
+++ b/docs/planned/integral-symmetry.md
@@ -1,0 +1,59 @@
+# Petite-list integral reduction: measured, and currently worth nothing
+
+## What was measured
+
+Benzene, D2h, cc-pVTZ (264 basis functions), RHF, 8 OpenMP threads, same machine,
+back to back:
+
+| run | wall clock | energy |
+|---|---|---|
+| `[symmetry] enabled=false` | 40.1 s | -230.7789916457 |
+| `enabled=true, use_integral_symmetry=true` | 40.5 s | -230.7789916457 |
+
+Energies agree to all printed digits, so whatever runs is not wrong. But there is
+**no speed benefit at all** — the symmetric run is marginally slower. The same
+comparison at 6-31G* also gave identical energies and no measurable difference.
+
+## Why this is surprising
+
+The reduction is implemented. `source/integrals/int2.F90:724` computes
+`q4 = petite_quartet_weight(...)` per shell quartet and `cycle`s when `q4 == 0`,
+weighting the surviving orbit representative. For D2h (order 8) that should be a
+large saving in the 2e build.
+
+The point group is detected correctly (`d2h` in the log) and the flag is on
+(`use integral symmetry: yes`).
+
+## What to find out first
+
+1. Does the petite path actually engage at run time, or does it fail-safe to C1?
+   `stage_integral_symmetry_maps` (`pyoqp/oqp/molecule/molecule.py:499`) returns
+   early unless `meta['integral_symmetry']['status'] == 'reoriented'` (:511), and
+   `reorient_for_integral_symmetry` has its own gates. If the maps are never
+   staged, `OQP::sym_petite` stays 0 and `int2.F90:306` returns before doing
+   anything. Instrument `this%petite` and the skipped-quartet count and compare.
+2. If it does engage, where does the saving go? Schwarz screening may already be
+   removing most of what the petite list would remove, in which case the honest
+   answer is that the reduction is redundant with screening for this class of
+   system and the gain only appears elsewhere (tight thresholds, diffuse sets).
+3. Only then decide about defaults.
+
+## Blockers to enabling it by default
+
+- `use_integral_symmetry` **reorients the molecule to the standard frame at load
+  time**, so anything that persists or compares geometries (restarts, saved
+  `.oqp`, gradients, NAMD trajectories, optimisation histories, reference data)
+  has to be checked first.
+- `input_to_standard` is written (`molecule.py:489`) and copied (:641, :649) but
+  **consumed nowhere** — nothing back-transforms a gradient, mode or velocity out
+  of the standard frame. That missing piece is why the runtype allow-list keeps
+  the optimizer and Hessian in the input frame today.
+- `source/integrals/grd2.F90:253` has no per-caller opt-in, unlike `int2.F90:291`
+  (`enable_petite`). CPHF probe densities routed through
+  `fock_deriv_contract` are not totally symmetric. Latent today because `hess`
+  fails the runtype gate; live the moment that gate is widened.
+
+## Suggested order
+
+Instrument first (is it even on?), then fix whatever prevents the saving, then
+the back-transform, then the `grd2` opt-in audit, and only then discuss defaults.

--- a/docs/planned/integral-symmetry.md
+++ b/docs/planned/integral-symmetry.md
@@ -1,59 +1,111 @@
-# Petite-list integral reduction: measured, and currently worth nothing
+# Petite-list integral reduction: it works, and it was silently off
 
-## What was measured
+## Correction
 
-Benzene, D2h, cc-pVTZ (264 basis functions), RHF, 8 OpenMP threads, same machine,
-back to back:
+An earlier revision of this note recorded the reduction as **measured and worth
+nothing** (benzene/cc-pVTZ, 40.1 s off vs 40.5 s on). That conclusion was wrong.
+The benchmark compared C1 against C1: at cc-pVTZ the reduction never engaged.
 
-| run | wall clock | energy |
-|---|---|---|
-| `[symmetry] enabled=false` | 40.1 s | -230.7789916457 |
-| `enabled=true, use_integral_symmetry=true` | 40.5 s | -230.7789916457 |
+## What it is actually worth
 
-Energies agree to all printed digits, so whatever runs is not wrong. But there is
-**no speed benefit at all** — the symmetric run is marginally slower. The same
-comparison at 6-31G* also gave identical energies and no measurable difference.
+Freshly built binary, 8 OpenMP threads, D2h, RHF, wall clock of the SCF module
+(the log's `Total ... Wall time`, not process wall clock -- process time is
+dominated by Python startup and the molden write, which is how the effect was
+missed the first time).
 
-## Why this is surprising
+| system | nbf | `enabled=false` | petite, \|G\| = 8 | speedup |
+|---|---|---|---|---|
+| benzene / cc-pVTZ | 264 | 39.414 s | 10.937 s | **3.60x** |
+| anthracene / 6-31G* | 230 | 7.694 s | 2.295 s | **3.37x** |
+| naphthalene / 6-31G* | 166 | 2.921 s | 0.849 s | **3.40x** |
 
-The reduction is implemented. `source/integrals/int2.F90:724` computes
-`q4 = petite_quartet_weight(...)` per shell quartet and `cycle`s when `q4 == 0`,
-weighting the surviving orbit representative. For D2h (order 8) that should be a
-large saving in the 2e build.
+Energies agree to 1e-10 or better with identical iteration counts. The
+non-abelian `full` tier reaches **8.06x** on benzene/cc-pVTZ (24 D6h operations).
 
-The point group is detected correctly (`d2h` in the log) and the flag is on
-(`use integral symmetry: yes`).
+The ceiling for a **planar** molecule is 4x, not 8x: sigma_h fixes every shell,
+so it is in the stabilizer of every quartet and `q4 <= |G|/2`. The measured
+3.4-3.6x is 85-90% of that. A non-planar D2h system is the case that could
+approach 8x; nothing here measures one.
 
-## What to find out first
+## Why the original benchmark saw nothing
 
-1. Does the petite path actually engage at run time, or does it fail-safe to C1?
-   `stage_integral_symmetry_maps` (`pyoqp/oqp/molecule/molecule.py:499`) returns
-   early unless `meta['integral_symmetry']['status'] == 'reoriented'` (:511), and
-   `reorient_for_integral_symmetry` has its own gates. If the maps are never
-   staged, `OQP::sym_petite` stays 0 and `int2.F90:306` returns before doing
-   anything. Instrument `this%petite` and the skipped-quartet count and compare.
-2. If it does engage, where does the saving go? Schwarz screening may already be
-   removing most of what the petite list would remove, in which case the honest
-   answer is that the reduction is redundant with screening for this class of
-   system and the gain only appears elsewhere (tight thresholds, diffuse sets).
-3. Only then decide about defaults.
+`stage_integral_symmetry_maps` bailed with `skipped_basis_mismatch`. It built
+the shell list as `(atom, l)` pairs with no purity flag, so `_normalize_shells`
+defaulted every shell to Cartesian and `maps['n_ao']` came out 300 against
+`nbf = 264`.
 
-## Blockers to enabling it by default
+**The blast radius was much wider than cc-pVTZ.** Shell purity comes from the
+Basis Set Exchange per-shell tag, and the 6-311G family is spherical too --
+measured: naphthalene/6-311++G** gives nbf = 276, not the Cartesian 286. The
+reduction worked **only** on bases whose l >= 2 shells BSE tags Cartesian, i.e.
+6-31G*/6-31G** and below. Every cc-pVXZ, aug-cc-pVXZ, def2 and 6-311G run
+silently fell back to C1.
 
-- `use_integral_symmetry` **reorients the molecule to the standard frame at load
-  time**, so anything that persists or compares geometries (restarts, saved
-  `.oqp`, gradients, NAMD trajectories, optimisation histories, reference data)
-  has to be checked first.
-- `input_to_standard` is written (`molecule.py:489`) and copied (:641, :649) but
-  **consumed nowhere** — nothing back-transforms a gradient, mode or velocity out
-  of the standard frame. That missing piece is why the runtype allow-list keeps
-  the optimizer and Hessian in the input frame today.
-- `source/integrals/grd2.F90:253` has no per-caller opt-in, unlike `int2.F90:291`
-  (`enable_petite`). CPHF probe densities routed through
-  `fock_deriv_contract` are not totally symmetric. Latent today because `hess`
-  fails the runtype gate; live the moment that gate is widened.
+## The fix
 
-## Suggested order
+Shell purity is now exported from the library rather than guessed:
+`oqp_get_basis_spherical` (`source/c_interop.F90`) returns the **effective**
+per-shell flag, `HARMONIC_ACTIVE .and. harmonic(i) == 1 .and. am(i) >= 2`,
+matching `c2s_ncomp` in `source/integrals/cart2sph.F90`.
 
-Instrument first (is it even on?), then fix whatever prevents the saving, then
-the back-transform, then the `grd2` opt-in audit, and only then discuss defaults.
+Deriving it outside that one place had already gone wrong twice, in opposite
+directions, and the AO total cannot arbitrate between them because Cartesian and
+spherical sizes agree for l <= 1:
+
+| shells passed to `build_reduction_maps` | n_ao vs nbf | max abs(T S T^T - S) | |
+|---|---|---|---|
+| all Cartesian (the old staging code) | 300 vs 264 | -- | bails, silently C1 |
+| all pure (the naive fix) | 264 vs 264 | **1.2** | wrong maps, would corrupt the Fock |
+| effective, `l >= 2` | 264 vs 264 | **3.1e-16** | exact |
+
+Verified against the real overlap matrix from live benzene runs at cc-pVDZ and
+cc-pVTZ. The existing `T S T^T = S` guard remains as the run-time check.
+
+Measured per-shell flags: 6-31G* reports 0 spherical shells of 48 (so the
+staging input is byte-identical to before on Cartesian bases); cc-pVTZ reports
+24 of 96 -- 18 d and 6 f, with s and p correctly Cartesian.
+
+## The fallback is no longer silent
+
+`_dump_symmetry_log` was called only on the success path, so a run that asked
+for the reduction and fell back to C1 printed nothing -- and the fallback is
+energy-identical, so nothing else could reveal it. It is now emitted on every
+exit, and a non-active status prints:
+
+```
+   integral reduction   : skipped_runtype_hess
+   *** the petite-list reduction is NOT active: this run used the full (C1) integral list ***
+```
+
+`skipped_basis_mismatch` additionally reports the two AO counts.
+
+## Still open
+
+- **`tests/smoke_petite_*.py` are not collected.** `testpaths = ["tests"]` but
+  pytest's default `python_files` never matches `smoke_*.py`, and no workflow or
+  doc invokes them. `smoke_petite_benchmark.py` already asserts
+  `status == 'active'` on two cc-pVTZ cases -- it would have caught this bug the
+  day it was written. Waking it is the single highest-value follow-up, and an
+  energy-only assertion cannot substitute: the fail-safe path gives the
+  identical energy.
+- **`benzene_full_dft` fails that benchmark**: dE = 3.14e-04 against a
+  documented `full`-tier tolerance of 5e-7. Pre-existing and unrelated to this
+  change (it is a 6-31G* case, where the staging input is unchanged), but it is
+  a real defect in the non-abelian tier with DFT and now finally visible.
+- **Do not enable by default yet.** Reorientation rewrites the geometry into the
+  standard frame, and `coord` is a required, exactly-compared key in the example
+  regression suite.
+- **`runtype=grad` returns the gradient in the standard frame** with no
+  back-rotation (`input_to_standard` is written and consumed nowhere). See
+  `input-to-standard.md`.
+- **Finite-difference child jobs reorient independently.** Reproduced here: a
+  `runtype=hess` parent is correctly excluded (`skipped_runtype_hess`) while its
+  children stage into *different* frames -- c2v, cs, and one
+  `skipped_orientation_not_converged` -- within a single run. See
+  `hessian-reorient.md`. This fix widens engagement to spherical bases, so it
+  makes that defect bite on far more runs; it must land first.
+- **`grd2` per-caller opt-in must land first** as well, for the same reason.
+  See `grd2-optin.md`.
+- `nint` and `thr_nshq` are in the `reduction(+:...)` clause at
+  `source/integrals/int2.F90` but never initialised before the parallel region
+  (only `nschwz` is), so their post-region values are indeterminate.

--- a/include/oqp.h
+++ b/include/oqp.h
@@ -206,6 +206,14 @@ int64_t oqp_get_basis(struct oqp_handle_t *c_handle,
         int64_t *nsh, int64_t *nprim, int64_t *nbf,
         int64_t **bt, int64_t **at, int64_t **cdeg, double **ex, double **cc);
 
+/* Per-shell "stored as spherical harmonics" flag, 1 = spherical.
+   This is the EFFECTIVE flag: a shell is spherical only when the run is
+   harmonic, the shell is tagged pure, and l >= 2 (s and p stay Cartesian
+   even in a spherical basis). Needed to know the AO layout; do not try to
+   reconstruct it from the angular momenta alone. */
+int64_t oqp_get_basis_spherical(struct oqp_handle_t *c_handle,
+        int64_t *nsh, int64_t **spherical);
+
 /* `mass` is optional, pass NULL if not needed */
 int oqp_set_atoms(struct oqp_handle_t * c_handle, int64_t natoms, double * x, double * y, double * z, double * q, double * mass);
 void oqp_set_harmonic_active(bool flag);

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -500,14 +500,33 @@ class Molecule:
         """Stage petite-list maps for the Fortran SCF (requires the basis).
 
         Fail-safe: any inconsistency leaves the run on the C1 path with the
-        reason recorded in the metadata.
+        reason recorded in the metadata -- and, unlike before, printed. The
+        fallback produces an identical energy, so a silent one is invisible:
+        the reduction was disabled on every spherical basis for as long as it
+        existed and no output said so.
         """
         meta = self.symmetry_metadata
         if not meta or not meta.get('use_integral_symmetry'):
             return False
+        staged = self._stage_integral_symmetry_maps(meta)
+        if not staged and not meta.get('integral_symmetry', {}).get('status', '').startswith('skipped'):
+            meta.setdefault('integral_symmetry', {})
+            meta['integral_symmetry'].setdefault('status', 'skipped_unknown')
+        try:
+            self._dump_symmetry_log()
+        except Exception:
+            pass
+        return staged
+
+    def _stage_integral_symmetry_maps(self, meta):
+        """Body of :meth:`stage_integral_symmetry_maps`; records a status and
+        returns True only when the reduction is actually active."""
         detection = meta.get('detection')
         if not detection:
+            meta['integral_symmetry'] = {'status': 'skipped_no_detection'}
             return False
+        # reorient_for_integral_symmetry records its own reason (a runtype the
+        # allow-list rejects, a frame that would not converge, ...); keep it.
         if meta.get('integral_symmetry', {}).get('status') != 'reoriented':
             return False
 
@@ -518,10 +537,30 @@ class Molecule:
             if not basis:
                 meta['integral_symmetry'] = {'status': 'skipped_no_basis'}
                 return False
-            shells = [(int(at), int(l)) for at, l in zip(basis['centers'], basis['angs'])]
+            # Per-shell sphericity comes from the library (OQP::basis
+            # 'spherical'), which reports the EFFECTIVE flag including the
+            # l >= 2 rule. Passing (atom, l) pairs without it makes
+            # _normalize_shells default to pure=False, so n_ao is the
+            # Cartesian count and every spherical basis -- cc-pVXZ, def2 and
+            # the whole 6-311G family -- failed the check below and silently
+            # ran C1. Do not reintroduce a dimension-matching guess here: the
+            # Cartesian and spherical sizes agree for l <= 1, so the AO total
+            # cannot distinguish "all shells pure" (wrong: it applies the
+            # spherical component order to p shells) from OpenQP's real
+            # convention.
+            spherical = basis.get('spherical')
+            if spherical is None:
+                meta['integral_symmetry'] = {'status': 'skipped_no_shell_purity'}
+                return False
+            shells = [(int(at), int(l), bool(p)) for at, l, p
+                      in zip(basis['centers'], basis['angs'], spherical)]
             maps = build_reduction_maps(shells, detection['operations'])
             if maps['n_ao'] != int(basis['nbf']):
-                meta['integral_symmetry'] = {'status': 'skipped_basis_mismatch'}
+                meta['integral_symmetry'] = {
+                    'status': 'skipped_basis_mismatch',
+                    'n_ao': int(maps['n_ao']),
+                    'nbf': int(basis['nbf']),
+                }
                 return False
 
             # Defense-in-depth: the maps must leave the real overlap matrix
@@ -648,10 +687,6 @@ class Molecule:
                 'reoriented': True,
                 'input_to_standard': input_to_standard,
             }
-            try:
-                self._dump_symmetry_log()
-            except Exception:
-                pass
             return True
         except Exception as exc:
             # Fail safe to the C1 path.
@@ -948,11 +983,23 @@ class Molecule:
             if full:
                 lines.append(f"   full group order     : {full.get('n_operations')}")
             if active:
-                lines.append(f"   integral reduction   : {active.get('status')}"
+                status = active.get('status')
+                lines.append(f"   integral reduction   : {status}"
                              + (f" (|G| = {active.get('n_operations')}"
                                 + (', full group' if active.get('full_group')
                                    else ', abelian subgroup') + ')'
-                                if active.get('status') == 'active' else ''))
+                                if status == 'active' else ''))
+                if status != 'active':
+                    # The C1 fallback gives a numerically identical answer, so
+                    # without this line a user who explicitly asked for the
+                    # reduction has no way to discover it never ran.
+                    lines.append('   *** the petite-list reduction is NOT active:'
+                                 ' this run used the full (C1) integral list ***')
+                    if status == 'skipped_basis_mismatch':
+                        lines.append(f"   AO count from the symmetry maps ({active.get('n_ao')})"
+                                     f" disagrees with the basis ({active.get('nbf')})")
+                    elif active.get('error'):
+                        lines.append(f"   reason: {active.get('error')}")
                 if active.get('reoriented'):
                     lines.append('   geometry reoriented to the symmetry standard orientation')
             response = meta.get('response_symmetry')

--- a/pyoqp/oqp/molecule/oqpdata.py
+++ b/pyoqp/oqp/molecule/oqpdata.py
@@ -1506,9 +1506,24 @@ class OQPData:
             alpha = np.frombuffer(ffi.buffer(pex[0], ffi.sizeof('double') * nprim))
             coef = np.frombuffer(ffi.buffer(pcc[0], ffi.sizeof('double') * nprim))
 
+            # Per-shell "stored as spherical harmonics" flag. This cannot be
+            # derived from angs/nbf: the Cartesian and spherical sizes agree
+            # for l <= 1, so the AO total alone cannot say whether s and p are
+            # pure -- and in OpenQP they never are, even in a spherical basis.
+            # The library answers that question directly; anything else is a
+            # guess that fails silently.
+            pspher = ffi.new('int64_t **')
+            pnsh_s = ffi.new('int64_t *')
+            spherical = None
+            if lib.oqp_get_basis_spherical(self._data, pnsh_s, pspher) == 0:
+                spherical = np.copy(np.frombuffer(
+                    ffi.buffer(pspher[0], ffi.sizeof('int64_t') * pnsh_s[0]),
+                    dtype=np.int64))
+
             basis = {
                 'centers': np.copy(centers) - 1,  # make zero-based indexing of atoms
                 'angs': np.copy(angs),
+                'spherical': spherical,
                 'ncontr': np.copy(ncontr),
                 'alpha': np.copy(alpha),
                 'coef': np.copy(coef),

--- a/source/c_interop.F90
+++ b/source/c_interop.F90
@@ -47,6 +47,7 @@ module c_interop
   integer(c_int64_t), allocatable, target :: basis_am_i64(:)
   integer(c_int64_t), allocatable, target :: basis_origin_i64(:)
   integer(c_int64_t), allocatable, target :: basis_ncontr_i64(:)
+  integer(c_int64_t), allocatable, target :: basis_spherical_i64(:)
 
 contains
 
@@ -273,6 +274,57 @@ contains
     am   = c_loc(basis_am_i64)
     at   = c_loc(basis_origin_i64)
     cdeg = c_loc(basis_ncontr_i64)
+
+    ret = 0
+
+  end function
+
+!--------------------------------------------------------------------------------
+
+!> @brief Export the per-shell "stored as spherical harmonics" flag.
+!> @detail This is the EFFECTIVE flag, deliberately not a raw copy of
+!>   `bas%harmonic`. OpenQP transforms a shell to the solid-harmonic set only
+!>   when the run is harmonic, the shell is tagged pure, AND l >= 2 -- see
+!>   c2s_ncomp in source/integrals/cart2sph.F90, which keeps s and p Cartesian
+!>   (x, y, z) even in a spherical basis.
+!>
+!>   Consumers need that exact combination to know the AO layout, and deriving
+!>   it outside this file has already gone wrong twice: tagging every shell
+!>   pure applies the spherical component permutation to p shells and produces
+!>   confidently WRONG signs, while tagging none pure (the previous state of
+!>   the symmetry staging code) miscounts the AOs and silently disables the
+!>   reduction on every spherical basis. Export the answer, not the ingredients.
+!> @param[out] nsh        number of shells
+!> @param[out] spherical  address of an nsh-long int64 array, 1 = spherical
+!> @return 0 on success, -1 if the handle or the basis is not usable
+  function oqp_get_basis_spherical(c_handle, nsh, spherical) result(ret) &
+      bind(C, name='oqp_get_basis_spherical')
+    use basis_tools, only: basis_set
+    use constants, only: HARMONIC_ACTIVE
+    type(oqp_handle_t) :: c_handle
+    integer(c_int64_t) :: nsh
+    type(c_ptr), intent(out) :: spherical
+    integer(c_int64_t) :: ret
+
+    type(information), pointer :: inf
+    type(basis_set), pointer :: bas
+
+    ret = -1
+    nsh = 0
+    if (.not.c_associated(c_handle%inf)) return
+    call c_f_pointer(c_handle%inf, inf)
+
+    bas => inf%basis
+    nsh = bas%nshell
+    if (nsh <= 0) return
+    if (.not. allocated(bas%harmonic)) return
+    if (.not. allocated(bas%am)) return
+
+    basis_spherical_i64 = merge(1_c_int64_t, 0_c_int64_t, &
+        HARMONIC_ACTIVE .and. &
+        bas%harmonic(1:bas%nshell) == 1 .and. &
+        bas%am(1:bas%nshell) >= 2)
+    spherical = c_loc(basis_spherical_i64)
 
     ret = 0
 

--- a/tests/test_petite_engages_on_spherical_basis.py
+++ b/tests/test_petite_engages_on_spherical_basis.py
@@ -1,0 +1,129 @@
+"""The petite-list reduction must actually engage on a spherical basis.
+
+This is the regression test for a bug that survived because it was invisible:
+``stage_integral_symmetry_maps`` built its shell list without per-shell purity,
+computed a Cartesian AO count, failed the ``n_ao != nbf`` guard and fell back to
+the full C1 integral list -- on *every* spherical basis, which is cc-pVXZ,
+aug-cc-pVXZ, def2 and the whole 6-311G family.
+
+Two properties of that failure are worth stating, because they dictate the shape
+of this test:
+
+1. The fallback is a fail-safe, so the energy is **identical** either way. No
+   assertion on energies, gradients or any physical quantity can detect it. The
+   test must assert on the recorded status.
+2. Cartesian and spherical shell sizes agree for l <= 1, so the AO total cannot
+   distinguish "all shells pure" from OpenQP's real convention (only l >= 2 is
+   spherical). A test that merely checks ``n_ao == nbf`` would pass on maps that
+   apply the spherical component order to p shells and are silently wrong. So we
+   also assert the per-shell purity flags directly.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+
+INPUT = """\
+[input]
+system=
+   8   0.000000000   0.000000000   0.117300000
+   1   0.000000000   0.757200000  -0.469200000
+   1   0.000000000  -0.757200000  -0.469200000
+charge=0
+runtype=energy
+basis={basis}
+method=hf
+
+[symmetry]
+{symmetry}
+
+[guess]
+type=huckel
+
+[scf]
+type=rhf
+multiplicity=1
+conv=1.0e-9
+"""
+
+
+def _run(workdir, name, basis, symmetry):
+    from oqp.pyoqp import Runner
+
+    case = os.path.join(workdir, name)
+    os.makedirs(case, exist_ok=True)
+    path = os.path.join(case, f'{name}.inp')
+    with open(path, 'w', encoding='utf-8') as handle:
+        handle.write(INPUT.format(basis=basis, symmetry=symmetry))
+    runner = Runner(project=name, input_file=path,
+                    log=os.path.join(case, f'{name}.log'), usempi=False)
+    runner.run()
+    return runner.mol
+
+
+class PetiteEngagesOnSphericalBasisTests(unittest.TestCase):
+    """Water/C2v, cc-pVDZ (spherical d) -- the case that silently ran C1."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.workdir = tempfile.mkdtemp(prefix='oqp_petite_spherical_')
+        cls.c1 = _run(cls.workdir, 'water_c1', 'cc-pvdz', 'enabled=false')
+        cls.sym = _run(cls.workdir, 'water_petite', 'cc-pvdz',
+                       'enabled=true\nuse_integral_symmetry=true')
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.workdir, ignore_errors=True)
+
+    def test_reduction_is_active_not_silently_skipped(self):
+        state = self.sym.symmetry_metadata.get('integral_symmetry', {})
+        self.assertEqual(
+            state.get('status'), 'active',
+            'the petite reduction did not engage on a spherical basis; it fell '
+            f'back to C1 with status {state.get("status")!r}. The energy is '
+            'identical either way, so this assertion is the only thing that '
+            'can catch it.')
+        self.assertGreater(int(state.get('n_operations', 0)), 1)
+
+    def test_energy_is_unchanged_by_the_reduction(self):
+        e_c1 = float(np.asarray(self.c1.energies).ravel()[0])
+        e_sym = float(np.asarray(self.sym.energies).ravel()[0])
+        # Orbit weighting is algebraically exact for a totally symmetric
+        # density; the residual is summation order only.
+        self.assertLess(abs(e_sym - e_c1), 5.0e-9,
+                        f'C1 {e_c1!r} vs petite {e_sym!r}')
+
+    def test_shell_purity_follows_the_l_ge_2_rule(self):
+        basis = self.sym.data.get_basis()
+        spherical = basis.get('spherical')
+        self.assertIsNotNone(
+            spherical, 'per-shell purity is not exported; staging cannot know '
+                       'the AO layout and will fall back to C1')
+        angs = np.asarray(basis['angs'])
+        spherical = np.asarray(spherical)
+        # OpenQP transforms a shell only for l >= 2 (c2s_ncomp in
+        # source/integrals/cart2sph.F90), so s and p stay Cartesian even here.
+        self.assertTrue(np.all(spherical[angs < 2] == 0),
+                        's or p shells reported as spherical')
+        self.assertTrue(np.any(spherical[angs >= 2] == 1),
+                        'cc-pVDZ must have spherical d shells')
+
+    def test_cartesian_basis_reports_no_spherical_shells(self):
+        """Guards the other direction: 6-31G* d shells are Cartesian."""
+        mol = _run(self.workdir, 'water_cart', '6-31g*',
+                   'enabled=true\nuse_integral_symmetry=true')
+        basis = mol.data.get_basis()
+        spherical = np.asarray(basis.get('spherical'))
+        self.assertTrue(np.all(spherical == 0),
+                        '6-31G* has Cartesian d shells; reporting them pure '
+                        'would apply the wrong component order')
+        self.assertEqual(
+            mol.symmetry_metadata.get('integral_symmetry', {}).get('status'),
+            'active')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_petite_engages_on_spherical_basis.py
+++ b/tests/test_petite_engages_on_spherical_basis.py
@@ -23,8 +23,28 @@ import os
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _runtime_available():
+    """True when the compiled OpenQP runtime can actually be driven.
+
+    These are live calculations, so without this guard setUpClass raises
+    during collection in a source-only or dependency-light checkout, turning
+    an environment limitation into a test failure.
+    """
+    try:
+        os.environ.setdefault("OPENQP_ROOT", str(ROOT))
+        os.environ.setdefault("OMP_NUM_THREADS", "1")
+        import oqp  # noqa: F401
+        from oqp.pyoqp import Runner  # noqa: F401
+        return True
+    except Exception:
+        return False
 
 INPUT = """\
 [input]
@@ -64,6 +84,7 @@ def _run(workdir, name, basis, symmetry):
     return runner.mol
 
 
+@unittest.skipUnless(_runtime_available(), "compiled OpenQP runtime not available")
 class PetiteEngagesOnSphericalBasisTests(unittest.TestCase):
     """Water/C2v, cc-pVDZ (spherical d) -- the case that silently ran C1."""
 


### PR DESCRIPTION
## Correction to this PR's original premise

This PR was opened recording the reduction as **measured and worth nothing** — benzene/cc-pVTZ, 40.1 s with symmetry off vs 40.5 s on. That benchmark compared C1 against C1. At cc-pVTZ the reduction never engaged, and nothing in the output said so.

## What it is actually worth

Freshly built binary each time, 8 threads, D2h, RHF, SCF-module wall time (process wall clock is dominated by Python startup and the molden write, which is how the effect was missed originally).

| system | nbf | `enabled=false` | petite, \|G\|=8 | speedup |
|---|---|---|---|---|
| benzene / cc-pVTZ (macOS, Accelerate) | 264 | 39.414 s | **10.937 s** | **3.60x** |
| benzene / cc-pVTZ (chc4, Linux/MKL) | 264 | 74.471 s | **20.003 s** | **3.72x** |
| anthracene / 6-31G* | 230 | 7.694 s | 2.295 s | 3.37x |
| naphthalene / 6-31G* | 166 | 2.921 s | 0.849 s | 3.40x |

Energies agree to 1e-10 or better with identical iteration counts. The non-abelian `full` tier reaches **8.1x** on benzene/cc-pVTZ.

Calibration: the ceiling for a **planar** molecule is 4x, not \|G\| = 8. σ_h fixes every shell, so it is in every quartet's stabiliser and `q4 ≤ |G|/2`. The measured 3.4–3.7x is 85–90% of the real ceiling.

## Root cause

`stage_integral_symmetry_maps` built its shell list as `(atom, l)` pairs with no purity flag, so `_normalize_shells` defaulted every shell to Cartesian, `maps['n_ao']` came out 300 against `nbf = 264`, and it took the fail-safe exit with status `skipped_basis_mismatch`.

The blast radius was wider than cc-pVTZ. Shell purity comes from the Basis Set Exchange per-shell tag, so the **6-311G family is spherical too** — measured, naphthalene/6-311++G** gives nbf = 276, not the Cartesian 286. The reduction worked **only** on 6-31G*-class bases; every cc-pVXZ, aug-cc-pVXZ, def2 and 6-311G run silently fell back to the full integral list.

## The fix

Shell purity is now exported from the library rather than inferred: `oqp_get_basis_spherical` returns the **effective** per-shell flag, `HARMONIC_ACTIVE .and. harmonic(i) == 1 .and. am(i) >= 2`, matching `c2s_ncomp` in `source/integrals/cart2sph.F90`.

Inference is not good enough here, and this is the substance of the change rather than an implementation detail. Cartesian and spherical shell sizes agree for `l <= 1`, so the AO total cannot distinguish "every shell pure" from OpenQP's actual convention — and the two are not equally wrong. Verified against the real overlap matrix from live benzene runs:

| shells passed to `build_reduction_maps` | n_ao vs nbf | max\|T S Tᵀ − S\| | |
|---|---|---|---|
| all Cartesian (the old code) | 300 vs 264 | — | bails, silent C1 |
| all pure (the plausible fix) | 264 vs 264 | **1.2** | wrong maps |
| effective, `l >= 2` | 264 vs 264 | **3.1e-16** | exact |

Measured flags: 6-31G* reports 0 spherical shells of 48, so the staging input is byte-identical to before on Cartesian bases; cc-pVTZ reports 24 of 96 — 18 d and 6 f, with s and p correctly Cartesian.

## The fallback is no longer silent

`_dump_symmetry_log` ran only on the success path, and the C1 fallback is energy-identical, so a user who asked for the reduction by name had no way to learn it never ran. It is now emitted on every exit; a non-active status prints an explicit `*** the petite-list reduction is NOT active ***` line, and `skipped_basis_mismatch` reports the two AO counts.

## Test

`tests/test_petite_engages_on_spherical_basis.py`, 4 assertions in 0.8 s. Its shape is dictated by the bug: on the unfixed code **3 of its 4 assertions fail, and the one that passes is the energy comparison**. The fail-safe path returns the identical energy, so no assertion on a physical quantity can detect this class of defect.

## Verification

chc4 (Linux, GCC 12.3, MKL ILP64), full suite, rebuilt for each side:

| | failed | passed |
|---|---|---|
| main (ff3b299) | 31 | 1004 |
| this branch | 30 | 1009 |

The failure sets are identical except `test_soc_examples::test_h2o_soc`, which passes 3/3 in isolation on main — pre-existing cross-test pollution, not a real difference. **Zero regressions.** The +5 passes are this PR's 4 new tests plus that flaky one.

## Landing order

This must land **after** #323 (grd2 per-caller opt-in) and #319 (finite-difference child reorientation). Widening engagement to spherical bases makes both bite on far more runs. A `runtype=hess` run here reproduced the #319 defect directly: the parent is correctly excluded (`skipped_runtype_hess`) while its children stage into *different* frames — c2v, cs, and one `skipped_orientation_not_converged` — inside a single run.

## Found here, not fixed here

- **`tests/smoke_petite_*.py` are never collected.** `testpaths = ["tests"]` but pytest's default `python_files` does not match `smoke_*.py`. `smoke_petite_benchmark.py` already asserts `status == 'active'` on two cc-pVTZ cases — the test that would have caught this existed and had never run.
- **`benzene_full_dft` fails that benchmark**, dE = 3.14e-04 against a 5e-7 gate. Pre-existing and unrelated to this change (a 6-31G* case, where the staging input is unchanged).
- `nint` and `thr_nshq` are in the `reduction(+:...)` clause in `int2_twoei` but never initialised before the parallel region — only `nschwz` is.
