### PR TITLE
The XC symmetry reduction is dead code — revive it on the path the SCF actually uses

### DIFF
--- a/docs/planned/xc-orbit-weight.md
+++ b/docs/planned/xc-orbit-weight.md
@@ -1,0 +1,34 @@
+# Plumb the existing XC atom-orbit weight into the gradient and response kernels
+
+## The finding
+
+`symAtomWeight` — the symmetry-orbit weight for the DFT quadrature — exists and
+is consumed at `source/dftlib/dft_gridint.F90:2467` and `:2665`, but it has
+**exactly one setter in the whole tree**: `dft_gridint_energy.F90:358`.
+
+It is absent from:
+- `source/dftlib/dft_gridint_grad.F90`
+- `source/dftlib/dft_gridint_fxc.F90`
+- `source/dftlib/dft_gridint_gxc.F90`
+- `source/dftlib/dft_gridint_giao.F90`
+
+So the reduction is written and validated on the energy path, and every gradient
+recomputes the full grid.
+
+## Value
+
+1.5–3.0x on the **XC portion** of every DFT gradient — which means every
+optimisation step, every NAMD step, every excited-state gradient. This is the
+cheapest of the XC items because only the plumbing is missing.
+
+Be skeptical about the response-kernel version: prior profiling on this machine
+puts int2 METC at 96–98% of CPU MRSF response cost, so the `fxc`/`gxc` variants
+are worth much less than they look.
+
+## Verification
+
+`E_xc` and `N_elec` against a C1 run to 1e-10; gradient parity to 1e-9.
+
+## Machinery
+
+Partial — the weight array exists; the consumers need the optional argument.

--- a/source/dftlib/dft_gridint_energy.F90
+++ b/source/dftlib/dft_gridint_energy.F90
@@ -408,7 +408,8 @@ contains
 
   subroutine dmatd_density_blk(basis, molGrid, dena, denb, fa, fb, &
                        exc, totele, totkin, &
-                       mxAngMom, nbf, dft_threshold, urohf, infos)
+                       mxAngMom, nbf, dft_threshold, urohf, infos, &
+                       sym_atom_weight)
     use mod_dft_molgrid, only: dft_grid_t
     use basis_tools, only: basis_set
     use mod_dft_gridint, only: xc_options_t, run_xc
@@ -424,6 +425,8 @@ contains
     real(kind=fp), target, intent(in) :: dena(nbf,nbf), denb(nbf,nbf)
     real(kind=fp), intent(inout) :: fa(*), fb(*)
     real(kind=fp), intent(in) :: dft_threshold
+    !> Optional symmetry-reduction atom weights (orbit size or zero).
+    real(kind=fp), intent(in), optional, contiguous, target :: sym_atom_weight(:)
 
     type(xc_consumer_ks_t) :: dat
     type(xc_options_t) :: xc_opts
@@ -468,10 +471,20 @@ contains
     xc_opts%ao_threshold = infos%dft%grid_ao_threshold
     xc_opts%ao_sparsity_ratio = 0.0_fp
 
+    if (present(sym_atom_weight)) xc_opts%symAtomWeight => sym_atom_weight
+
     ! Opt 1: the SCF Fock build reaches the grid through this density-driven path
     ! (calc_fock passes the packed density as dens_in). Enable the cross-iteration
     ! Phi cache from [scf] xc_phi_cache (infos%control%xc_phi_cache).
     xc_opts%use_phi_cache = (infos%control%xc_phi_cache /= 0)
+
+    ! ...but never together with the symmetry reduction. run_xc bakes symw into
+    ! the grid weights BEFORE they are stored in the cache, and replay
+    ! deliberately does not re-apply it, while the cache validity signature
+    ! carries no symmetry key. The petite gate is toggled off mid-run at a fixed
+    ! geometry by the stability/TRAH stage, so a cached slice built under the
+    ! reduction would be replayed unreduced -- silently wrong E_xc.
+    if (associated(xc_opts%symAtomWeight)) xc_opts%use_phi_cache = .false.
 
     call dat%pe%init(infos%mpiinfo%comm, infos%mpiinfo%usempi)
     call run_xc(xc_opts, dat, basis)

--- a/source/scf_addons.F90
+++ b/source/scf_addons.F90
@@ -1485,6 +1485,38 @@ contains
   !> @param[inout] mo_b    AO→MO coefficients for β (nbf×nbf). For ROHF, set to mo_a.
   !> @author Mohsen Mazaherifar
   !> @date August 2025
+  !> @brief Fetch the symmetry XC atom-orbit weights, if the reduction is live.
+  !> @detail Shared by both XC dispatch branches. It used to be inline in
+  !>         calc_dft_xc, which is dead code -- its only caller sits in the
+  !>         `else` of `if (use_density_xc)`, and every calc_fock call site in
+  !>         the tree passes a density, so use_density_xc is always true. The
+  !>         XC reduction therefore never executed at all: it landed live in
+  !>         PR #184 and was orphaned by the density branch added in PR #202.
+  subroutine get_sym_atom_weight(infos, weight, active)
+    use precision, only: dp
+    use types, only: information
+    use oqp_tagarray_driver
+    use tagarray, only: TA_OK
+    implicit none
+
+    type(information), intent(inout) :: infos
+    real(kind=dp), contiguous, pointer, intent(out) :: weight(:)
+    logical, intent(out) :: active
+
+    integer(8), contiguous, pointer :: petite_flag(:)
+    integer(4) :: status
+
+    active = .false.
+    weight => null()
+    call tagarray_get_data(infos%dat, OQP_sym_petite, petite_flag, status=status)
+    if (status /= TA_OK) return
+    if (petite_flag(1) == 0) return
+    call tagarray_get_data(infos%dat, OQP_sym_atom_weight, weight, status=status)
+    active = status == TA_OK
+    if (active) active = size(weight) == infos%mol_prop%natom
+    if (.not. active) weight => null()
+  end subroutine get_sym_atom_weight
+
   subroutine calc_dft_xc(infos, basis, molgrid, pfxc, eexc, totele, totkin, mo_a, mo_b)
     use precision, only: dp
     use types, only: information
@@ -1525,17 +1557,7 @@ contains
     ! (orbit-weighted) and symmetrize the resulting skeleton XC matrix.
     ! Gated by the same petite flag as the two-electron reduction, so the
     ! stability-stage fail-safe applies here as well.
-    sym_active = .false.
-    sym_atom_weight => null()
-    call tagarray_get_data(infos%dat, OQP_sym_petite, sym_petite_flag, status=sym_status)
-    if (sym_status == TA_OK) then
-      if (sym_petite_flag(1) /= 0) then
-        call tagarray_get_data(infos%dat, OQP_sym_atom_weight, sym_atom_weight, &
-                               status=sym_status)
-        sym_active = sym_status == TA_OK
-        if (sym_active) sym_active = size(sym_atom_weight) == infos%mol_prop%natom
-      end if
-    end if
+    call get_sym_atom_weight(infos, sym_atom_weight, sym_active)
 
     ! Calculate exchange-correlation based on SCF type
     if (sym_active) then
@@ -1572,7 +1594,8 @@ contains
   end subroutine calc_dft_xc
 
   !> @brief Computes DFT exchange-correlation contributions from explicit AO density matrices.
-  subroutine calc_dft_xc_density(infos, basis, molgrid, dmat, pfxc, eexc, totele, totkin)
+  subroutine calc_dft_xc_density(infos, basis, molgrid, dmat, pfxc, eexc, totele, totkin, &
+                                 sym_atom_weight)
     use precision, only: dp
     use types, only: information
     use mod_dft_molgrid, only: dft_grid_t
@@ -1587,6 +1610,8 @@ contains
     real(kind=dp), intent(in) :: dmat(:,:)
     real(kind=dp), intent(out) :: pfxc(:,:)
     real(kind=dp), intent(out) :: eexc, totele, totkin
+    !> Symmetry-reduction atom weights. Present => integrate unique atoms only.
+    real(kind=dp), intent(in), optional, contiguous, target :: sym_atom_weight(:)
 
     integer :: scf_type, nbf, nbf_tri, nang
     logical :: urohf
@@ -1607,9 +1632,20 @@ contains
     end if
 
     pfxc = 0.0_dp
-    call dmatd_density_blk(basis, molgrid, da, db, pfxc(:,1), pfxc(:,min(2,size(pfxc,2))), &
-                          eexc, totele, totkin, nang, nbf, infos%dft%grid_density_cutoff, &
-                          urohf, infos)
+    if (present(sym_atom_weight)) then
+      call dmatd_density_blk(basis, molgrid, da, db, pfxc(:,1), pfxc(:,min(2,size(pfxc,2))), &
+                            eexc, totele, totkin, nang, nbf, infos%dft%grid_density_cutoff, &
+                            urohf, infos, sym_atom_weight)
+      ! The reduced-grid XC matrix is a skeleton: project onto the totally
+      ! symmetric component. Without this the SCF converges to a wrong energy.
+      ! (The XC energy and electron count are already exact -- run_xc scales the
+      ! surviving slices by the orbit size.)
+      call symmetrize_skeleton_fock(infos, basis, pfxc)
+    else
+      call dmatd_density_blk(basis, molgrid, da, db, pfxc(:,1), pfxc(:,min(2,size(pfxc,2))), &
+                            eexc, totele, totkin, nang, nbf, infos%dft%grid_density_cutoff, &
+                            urohf, infos)
+    end if
 
     deallocate(da, db)
   end subroutine calc_dft_xc_density
@@ -1677,6 +1713,8 @@ contains
     integer :: ii
     real(dp), allocatable :: pfxc(:,:)
     logical :: is_dft = .false., use_density_xc
+    real(dp), contiguous, pointer :: xc_sym_weight(:)
+    logical :: xc_sym_active
     logical :: xc_reused
     logical :: xc_diverted
     ! Env-gated (OQP_XC_TIMING) per-iteration wall split: J/K vs XC build.
@@ -1783,7 +1821,15 @@ contains
       end if
       if (.not. xc_diverted) then
         if (use_density_xc) then
-          call calc_dft_xc_density(infos, basis, molgrid, d, pfxc, E%eexc, E%totele, E%totkin)
+          ! The live path. It had no symmetry gate at all, which is how the
+          ! XC reduction came to be dead code -- see get_sym_atom_weight.
+          call get_sym_atom_weight(infos, xc_sym_weight, xc_sym_active)
+          if (xc_sym_active) then
+            call calc_dft_xc_density(infos, basis, molgrid, d, pfxc, E%eexc, E%totele, &
+                                     E%totkin, xc_sym_weight)
+          else
+            call calc_dft_xc_density(infos, basis, molgrid, d, pfxc, E%eexc, E%totele, E%totkin)
+          end if
         else
           call calc_dft_xc(infos, basis, molgrid, pfxc, E%eexc, E%totele, E%totkin, mo_a, mo_b)
         end if

--- a/tests/test_xc_symmetry_reduction_live.py
+++ b/tests/test_xc_symmetry_reduction_live.py
@@ -1,0 +1,128 @@
+"""The XC symmetry reduction must be reachable from the path the SCF uses.
+
+`symAtomWeight` lets run_xc integrate only one atom per symmetry orbit and
+scale the surviving slices by the orbit size. It landed live in PR #184, and
+PR #202 then added a density-driven XC branch that orphaned it:
+
+  - the only setter sat in `dmatd_blk`, reachable only via `calc_dft_xc`;
+  - `calc_dft_xc` has one call site, in the `else` of `if (use_density_xc)`;
+  - `use_density_xc` is `present(dens_in)`, and every `calc_fock` call site in
+    the tree passes a density.
+
+So the branch was unreachable and the reduction never executed anywhere --
+while the log still reported the feature as enabled. Benzene/6-31G*/BHHLYP,
+D2h, 12 SCF iterations: XC build 0.311 s -> 0.108 s once revived, with the
+total energy unchanged at -232.1002160904.
+
+These tests pin the structure rather than the timing, so they stay meaningful
+without a build.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SCF_ADDONS = ROOT / 'source/scf_addons.F90'
+GRIDINT_ENERGY = ROOT / 'source/dftlib/dft_gridint_energy.F90'
+
+
+def subroutine_body(path, name):
+    """Text of `subroutine <name>` up to its `end subroutine`."""
+    source = path.read_text()
+    start = re.search(r'^\s*subroutine\s+%s\b' % name, source,
+                      flags=re.IGNORECASE | re.MULTILINE)
+    assert start, f'{name} not found in {path.name}'
+    end = re.search(r'^\s*end\s+subroutine\s+%s\b' % name, source[start.end():],
+                    flags=re.IGNORECASE | re.MULTILINE)
+    assert end, f'end of {name} not found'
+    return source[start.start():start.end() + end.end()]
+
+
+class TheLivePathCanReachTheReduction(unittest.TestCase):
+    def test_the_density_branch_gates_on_symmetry(self):
+        """This branch is the one the SCF actually takes."""
+        body = subroutine_body(SCF_ADDONS, 'calc_jk_xc')
+        density_branch = body[body.index('if (use_density_xc) then'):]
+        self.assertIn('get_sym_atom_weight', density_branch,
+                      'the live XC path must consult the symmetry gate')
+
+    def test_the_weight_reaches_the_grid_driver(self):
+        body = subroutine_body(GRIDINT_ENERGY, 'dmatd_density_blk')
+        self.assertIn('xc_opts%symAtomWeight => sym_atom_weight', body,
+                      'dmatd_density_blk must set the weight run_xc consumes')
+
+    def test_the_gate_is_shared_by_both_branches(self):
+        """One helper, so the two branches cannot drift apart again."""
+        source = SCF_ADDONS.read_text()
+        self.assertEqual(source.count('subroutine get_sym_atom_weight'), 2,
+                         'expected exactly one definition (and its end)')
+        self.assertEqual(source.count('call get_sym_atom_weight'), 2,
+                         'both XC branches must use the shared gate')
+
+
+class ReducedGridsAreProjected(unittest.TestCase):
+    def test_the_density_path_symmetrizes_its_skeleton(self):
+        """Without this the SCF converges to a wrong energy.
+
+        run_xc scales surviving slices by the orbit size, so E_xc and the
+        electron count come out exact, but the XC MATRIX is a skeleton and
+        must be projected onto the totally symmetric component.
+        """
+        body = subroutine_body(SCF_ADDONS, 'calc_dft_xc_density')
+        reduced = body[body.index('if (present(sym_atom_weight)) then'):]
+        cut = reduced.index('else')
+        self.assertIn('symmetrize_skeleton_fock', reduced[:cut],
+                      'the reduced branch must project its skeleton')
+
+    def test_the_unreduced_branch_does_not_project(self):
+        body = subroutine_body(SCF_ADDONS, 'calc_dft_xc_density')
+        after_else = body[body.rindex('else'):]
+        self.assertNotIn('symmetrize_skeleton_fock', after_else)
+
+
+class PhiCacheCannotServeReducedWeights(unittest.TestCase):
+    """The one way this change could produce a silently wrong number.
+
+    run_xc bakes symw into the grid weights *before* they are stored, replay
+    deliberately does not re-apply it, and the cache validity signature carries
+    no symmetry key. The petite gate is toggled off mid-run at a fixed geometry
+    by the stability/TRAH stage, so a slice cached under the reduction would be
+    replayed unreduced.
+    """
+
+    def test_the_cache_is_disabled_whenever_a_weight_is_set(self):
+        body = subroutine_body(GRIDINT_ENERGY, 'dmatd_density_blk')
+        enable = body.index('xc_opts%use_phi_cache = (infos%control%xc_phi_cache')
+        guard = body.index(
+            'if (associated(xc_opts%symAtomWeight)) xc_opts%use_phi_cache = .false.')
+        self.assertGreater(guard, enable,
+                           'the guard must come after the enable, or it is '
+                           'overwritten')
+
+    def test_the_guard_precedes_the_grid_call(self):
+        body = subroutine_body(GRIDINT_ENERGY, 'dmatd_density_blk')
+        guard = body.index('xc_opts%use_phi_cache = .false.')
+        run = body.index('call run_xc(')
+        self.assertLess(guard, run)
+
+
+class ResponseKernelsAreDeliberatelyNotPlumbed(unittest.TestCase):
+    """Extending this to fxc/gxc/giao would be a correctness bug, not plumbing.
+
+    Those kernels act on trial vectors that are not totally symmetric, so an
+    orbit-reduced grid does not reproduce the full-grid result and there is no
+    totally-symmetric projector to repair it.
+    """
+
+    def test_no_response_grid_path_sets_the_weight(self):
+        for name in ('dft_gridint_fxc.F90', 'dft_gridint_gxc.F90',
+                     'dft_gridint_giao.F90'):
+            with self.subTest(file=name):
+                text = (ROOT / 'source/dftlib' / name).read_text()
+                self.assertNotIn('symAtomWeight', text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`symAtomWeight` lets `run_xc` integrate one atom per symmetry orbit and scale the surviving slices by the orbit size. It landed live in #184. #202 then added a density-driven XC branch, and that **orphaned it**:

- the only setter sat in `dmatd_blk`, reachable only via `calc_dft_xc`;
- `calc_dft_xc` has exactly one call site, in the `else` of `if (use_density_xc)`;
- `use_density_xc` is `present(dens_in)`, and **all nine** `calc_fock` call sites in the tree pass a density positionally.

So the branch is unreachable and the reduction has not executed anywhere — not in the gradient, and **not in the SCF either** — while the log goes on reporting `use integral symmetry: yes` and a detected `d2h`.

The draft that motivated this assumed the energy path was working and only the gradient needed plumbing. It is the other way round.

## The fix

Give the live density path the same treatment the dead one had: `dmatd_density_blk` takes the optional weight and points `xc_opts` at it, `calc_dft_xc_density` forwards it, and the tagarray gate is hoisted into `get_sym_atom_weight` so both branches share one implementation and cannot drift apart again.

## Two things that would otherwise have made this silently wrong

**The reduced-grid XC matrix is a skeleton** and must be projected onto the totally symmetric component. E_xc and the electron count come out exact — `run_xc` scales by the orbit size — so a missing projection would *not* show up as an obviously broken integral. The SCF would simply converge to a wrong energy. The dead branch did this correctly and is the template.

**The Phi cache cannot serve reduced weights.** `run_xc` bakes `symw` into the grid weights *before* they are stored, replay deliberately does not re-apply it, and the cache validity signature carries no symmetry key. `dmatd_density_blk` is precisely the routine that opts into that cache, and the petite gate is toggled off mid-run at a fixed geometry by the stability/TRAH stage — so a slice cached under the reduction would later be replayed unreduced. The cache is now disabled whenever a weight is set.

## Measured

Benzene, 6-31G*, BHHLYP, D2h, 12 SCF iterations, 8 threads:

| `use_integral_symmetry` | XC build | total energy |
|---|---|---|
| `false` | 0.311 s | −232.1002160904 |
| `true` | **0.108 s** (2.9×) | −232.1002160904 |

12 atoms reduce to 4 orbit representatives under D2h, predicting 0.33×; the measured 0.35× matches. Instrumentation confirmed the gate reports active on all 12 iterations, rather than the reduction quietly not engaging — which is the failure mode this whole PR is about.

Incidentally the same run shows the **two-electron** reduction working too (JK 0.440 s → 0.138 s). That is worth recording against #318, where the reduction measured at zero benefit on a *spherical* basis — there the shell-list purity bail (`skipped_basis_mismatch`) is in play.

## Deliberately not extended to the response kernels

Not plumbed into `dft_gridint_fxc`/`gxc`/`giao`. Those kernels act on trial vectors that are **not** totally symmetric, so an orbit-reduced grid does not reproduce the full-grid result and there is no totally-symmetric projector to repair it. That would be a correctness bug, not plumbing.

The ground-state XC gradient is a defensible follow-up and is left out so the energy-path fix can be measured on its own.

## Tests

New `tests/test_xc_symmetry_reduction_live.py`, 8 passed — pinning the structure rather than the timing, so they stay meaningful without a build.

The 18 failures under a `dft or xc or scf or symmetry` selection are **pre-existing and an identical set** on the branch base (301 passed / 18 failed before, 309 passed / 18 failed after — the delta is this PR's new tests). Most are the MO-labelling tests that #317 fixes; this branch does not carry it.