### PR TITLE
Reorientation is left in place when the symmetry reduction does not happen

### DIFF
--- a/docs/planned/input-to-standard.md
+++ b/docs/planned/input-to-standard.md
@@ -1,33 +1,84 @@
-# Implement the `input_to_standard` back-transform
+# The `input_to_standard` back-transform
 
-## The gap
+Status: **scoped, not implemented.** The two bugs this draft originally bundled
+with the feature are fixed in this PR; the transform itself remains open.
 
-`input_to_standard` is written at `pyoqp/oqp/molecule/molecule.py:489` and copied
-at `:641` and `:649`, and **consumed nowhere**. A grep over `pyoqp/`, `source/`
-and `tests/` returns only those three sites.
+## What exists
 
-Nothing back-transforms a gradient, a normal mode, or a velocity out of the
-standard frame.
+`reorient_for_integral_symmetry` moves the molecule into the symmetry standard
+frame and records the map that takes user input axes to it:
 
-## Why it matters
+    r_std = (r_input - origin) @ rotation^T
+    v_input = v_std @ rotation
 
-This single missing piece is the concrete technical reason the reorientation
-runtype allow-list exists (`molecule.py:445-447`), which keeps the optimizer,
-Hessian, IRC, NEB and NAMD in the input frame and therefore **excludes them from
-every integral-symmetry benefit**.
+It is written to `symmetry_metadata['integral_symmetry']['input_to_standard']`,
+copied forward when the maps stage, and **read by nothing**. No gradient,
+normal mode, dipole or velocity is transformed back.
 
-It is the prerequisite for widening `use_integral_symmetry` past a single-point
-energy.
+## What this PR fixed instead
 
-## Also fix while here
+Two things were wrong today, and neither needed the transform.
 
-The non-converged branch at `:479` returns `False` **without restoring the
-geometry** the loop already mutated through `update_system()`.
+**The geometry was left moved on every failure path.** `input_coords` was
+captured in the reorientation loop and never used, so both failure exits
+returned False with the molecule already rotated -- and *translated*, because
+the standard frame is centred on the charge-weighted centroid. That moves every
+molecule, including C1, where the rotation is exactly the identity and there is
+no symmetry to exploit at all (measured: |R - I| = 0, |origin| = 2.8 bohr for a
+CHFClBr-like geometry). Staging could also decline after the basis existed, for
+reasons only visible then, leaving the same residue.
 
-## Restart hazard to document
+Both are now undone. The pre-reorient coordinates live in
+`meta['_reorient_input_coords']`, deliberately outside the `integral_symmetry`
+block -- every bail in `stage_integral_symmetry_maps` replaces that block
+wholesale, so keeping them inside silently loses them. The caller pops the key
+immediately, so it never reaches `save_data`.
 
-Reorientation is idempotent — the loop at `:456-472` iterates to the identity
-frame — so restarting from a standard-frame `.oqp` is a no-op. But the stored
-`input_to_standard` then becomes the identity, and the mapping back to the user's
-original axes is **permanently lost**. Decide and document whether the original
-frame is preserved across restarts.
+**`prop` was on the allow-list.** It is the only admitted runtype that consumes
+an *externally supplied* geometry expressed in the caller's frame:
+`load_previous_data` writes `OQP::xyz_old` from it, and `get_basis_overlap`
+overlaps that against the current -- by then rotated and translated -- structure.
+The cross-geometry MO overlap, the phase/reorder alignment built on it, and
+NACME are then all wrong. That is PR #319's finite-difference failure mode one
+level up. The allow-list is now `('energy', 'grad')`. (`'properties'` was never
+a `run_func` key, so it admitted nothing.)
+
+## The remaining feature
+
+Add `Molecule.to_input_frame()` implementing `v_input = v_std @ R` and
+`r_input = r_std @ R + O`, then:
+
+- Hook the vector back-transform into `Molecule.symmetrize_gradient`, which
+  already sits on the gradient exit path and is already gated on
+  `status == 'active'`. Apply the rotation **after** the symmetric projection --
+  the projection is only valid in the standard frame.
+- Restore the geometry at the job boundary, before the closing log dump.
+
+### The constraint that makes this more than an inverse map
+
+**The geometry cannot be restored before `save_data()` / `write_molden()`
+without also transforming the MO coefficients.** The AO basis is atom-centred
+and orientation-dependent: `OQP::VEC_MO_A/B` are expressed in the standard-frame
+AO basis. Writing input-frame coordinates next to standard-frame MOs produces a
+file that is internally inconsistent and silently wrong when read back as a
+guess. Either transform both or neither.
+
+### What this does and does not unlock
+
+It **does** unlock the finite-difference case: a child that back-transforms to
+its own input frame returns the gradient at the coordinates the parent handed
+it. (Note PR #319 currently solves that by switching the reduction off in
+children, which is the correct scope for a speed optimisation; the transform
+would let them keep it.)
+
+It does **not** by itself unlock the optimiser, IRC or NEB. Those displace the
+geometry every step, so they need per-step re-detection and have to cope with
+the point group *changing* between steps -- not just an inverse map. The draft
+previously claimed otherwise.
+
+## Prior art in this tree
+
+`grd2.F90` produces a skeleton gradient that `symmetrize_gradient` projects, and
+`scf_addons.F90` does the same for the skeleton XC matrix. The back-transform is
+the same shape of operation applied one level further out, at the frame rather
+than the group.

--- a/docs/planned/input-to-standard.md
+++ b/docs/planned/input-to-standard.md
@@ -1,0 +1,33 @@
+# Implement the `input_to_standard` back-transform
+
+## The gap
+
+`input_to_standard` is written at `pyoqp/oqp/molecule/molecule.py:489` and copied
+at `:641` and `:649`, and **consumed nowhere**. A grep over `pyoqp/`, `source/`
+and `tests/` returns only those three sites.
+
+Nothing back-transforms a gradient, a normal mode, or a velocity out of the
+standard frame.
+
+## Why it matters
+
+This single missing piece is the concrete technical reason the reorientation
+runtype allow-list exists (`molecule.py:445-447`), which keeps the optimizer,
+Hessian, IRC, NEB and NAMD in the input frame and therefore **excludes them from
+every integral-symmetry benefit**.
+
+It is the prerequisite for widening `use_integral_symmetry` past a single-point
+energy.
+
+## Also fix while here
+
+The non-converged branch at `:479` returns `False` **without restoring the
+geometry** the loop already mutated through `update_system()`.
+
+## Restart hazard to document
+
+Reorientation is idempotent — the loop at `:456-472` iterates to the identity
+frame — so restarting from a standard-frame `.oqp` is a no-op. But the stored
+`input_to_standard` then becomes the identity, and the mapping back to the user's
+original axes is **permanently lost**. Decide and document whether the original
+frame is preserved across restarts.

--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -492,6 +492,22 @@ class SinglePoint(Calculator):
 
         if symmetry_on:
             self.mol.stage_integral_symmetry_maps()
+            # Staging can decline for reasons only visible once the basis
+            # exists (shell/AO mismatch, overlap invariance, non-abelian
+            # closure). Those runs were changing frame for no benefit at all:
+            # reorientation had already rotated AND translated the molecule,
+            # and nothing put it back. Undo it, and refresh the guess -- the
+            # 1e integrals were built in the rotated frame, so the coordinates
+            # cannot go back without them. The cost lands only on a path that
+            # is already getting no reduction.
+            meta = getattr(self.mol, 'symmetry_metadata', None) or {}
+            restore = meta.pop('_reorient_input_coords', None)
+            status = (meta.get('integral_symmetry') or {}).get('status')
+            if restore is not None and status != 'active':
+                self.mol.update_system(
+                    np.asarray(restore, dtype=float).ravel())
+                self._set_petite_enabled(False)
+                self._prep_guess()
 
         scf_flag = self._run_scf()
 

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -441,7 +441,17 @@ class Molecule:
         # NEB, ...) must not have the frame rotated under them; the petite
         # reduction is restricted to single-point runtypes for now.
         runtype = str(self.config.get('input', {}).get('runtype', 'energy')).lower()
-        if runtype not in ('energy', 'grad', 'prop', 'properties'):
+        # 'prop' is deliberately NOT here. It is the only admitted runtype that
+        # consumes an EXTERNALLY supplied geometry, expressed in the caller's
+        # frame: load_previous_data writes OQP::xyz_old from it, and
+        # get_basis_overlap then overlaps that against the current -- by then
+        # rotated and translated -- structure. Because the standard frame is
+        # centred on the charge-weighted centroid, the two structures are
+        # physically displaced by a few bohr, so the cross-geometry MO overlap,
+        # the phase/reorder alignment built on it, and NACME are all wrong.
+        # That is PR #319's finite-difference failure mode one level up.
+        # ('properties' was never a run_func key, so it admitted nothing.)
+        if runtype not in ('energy', 'grad'):
             meta['integral_symmetry'] = {'status': f'skipped_runtype_{runtype}'}
             return False
 
@@ -476,6 +486,12 @@ class Molecule:
                 coords = (coords - origin) @ rotation.T
                 self.update_system(coords.ravel())
             if not converged:
+                # Put the molecule back. `input_coords` was captured above and
+                # never used, so every failure exit left the geometry rotated --
+                # and translated, since the standard frame is centred on the
+                # charge-weighted centroid, which moves EVERY molecule including
+                # C1 where the rotation is exactly the identity.
+                self.update_system(input_coords.ravel())
                 meta['integral_symmetry'] = {'status': 'skipped_orientation_not_converged'}
                 return False
 
@@ -491,8 +507,15 @@ class Molecule:
                     'origin': total_origin.tolist(),
                 },
             }
+            # Kept for the second phase, and deliberately OUTSIDE the
+            # integral_symmetry block: every bail in
+            # stage_integral_symmetry_maps replaces that block wholesale, which
+            # would take the coordinates with it. The caller pops this key
+            # immediately after staging, so it never reaches save_data.
+            meta['_reorient_input_coords'] = input_coords.tolist()
             return True
         except Exception as exc:
+            self.update_system(input_coords.ravel())
             meta['integral_symmetry'] = {'status': 'error', 'error': str(exc)}
             return False
 

--- a/tests/test_reorientation_is_undone_on_bail.py
+++ b/tests/test_reorientation_is_undone_on_bail.py
@@ -1,0 +1,135 @@
+"""Reorientation must not survive a path that does not end with the reduction.
+
+`reorient_for_integral_symmetry` moves the molecule into the symmetry standard
+frame before the basis exists. Staging the petite maps can then still decline,
+for reasons only visible once the basis is built. Those runs were left in the
+rotated frame with nothing to show for it.
+
+Two things made that worse than a frame convention:
+
+  - The standard frame is centred on the charge-weighted centroid, so every
+    molecule is also TRANSLATED -- including C1, where the rotation is exactly
+    the identity and there is no symmetry to exploit at all.
+  - `input_coords` was captured in the reorientation loop and never used, so
+    both failure exits returned False with the geometry already moved.
+"""
+
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class FailureExitsRestoreTheGeometry(unittest.TestCase):
+    """The captured coordinates must actually be used on both exits."""
+
+    def _reorient_source(self):
+        source = (ROOT / 'pyoqp/oqp/molecule/molecule.py').read_text()
+        start = source.index('def reorient_for_integral_symmetry')
+        end = source.index('def stage_integral_symmetry_maps')
+        return source[start:end]
+
+    def test_the_non_converged_exit_restores(self):
+        body = self._reorient_source()
+        bail = body.index("'skipped_orientation_not_converged'")
+        window = body[:bail]
+        self.assertIn('self.update_system(input_coords.ravel())', window,
+                      'the non-converged exit must put the molecule back')
+
+    def test_the_exception_handler_restores(self):
+        body = self._reorient_source()
+        handler = body.rindex('except Exception as exc:')
+        self.assertIn('self.update_system(input_coords.ravel())',
+                      body[handler:],
+                      'the error exit must put the molecule back')
+
+    def test_the_coordinates_survive_a_staging_bail(self):
+        """Every bail in staging replaces meta['integral_symmetry'] wholesale.
+
+        Keeping the coordinates inside that block silently loses them -- which
+        is exactly what happened first time: the restore never fired for any
+        spherical basis, because skipped_basis_mismatch had already wiped it.
+        """
+        body = self._reorient_source()
+        self.assertIn("meta['_reorient_input_coords']", body)
+        block = body[body.index("'status': 'reoriented'"):]
+        self.assertNotIn("'input_coords'", block[:block.index('return True')],
+                         'must live outside the block staging overwrites')
+
+    def test_the_caller_pops_the_key_so_it_never_reaches_save_data(self):
+        source = (ROOT / 'pyoqp/oqp/library/single_point.py').read_text()
+        self.assertIn("meta.pop('_reorient_input_coords', None)", source)
+
+    def test_the_caller_refreshes_the_guess_after_restoring(self):
+        """The 1e integrals were built in the rotated frame."""
+        source = (ROOT / 'pyoqp/oqp/library/single_point.py').read_text()
+        restore = source.index("meta.pop('_reorient_input_coords', None)")
+        window = source[restore:restore + 900]
+        self.assertIn('self.mol.update_system(', window)
+        self.assertIn('self._prep_guess()', window)
+        self.assertLess(window.index('self.mol.update_system('),
+                        window.index('self._prep_guess()'))
+
+
+class PropDoesNotGetReoriented(unittest.TestCase):
+    """`prop` consumes an externally supplied geometry in the caller's frame.
+
+    load_previous_data writes OQP::xyz_old from it, and get_basis_overlap
+    overlaps that against the current -- by then rotated and translated --
+    structure. The cross-geometry MO overlap, the phase/reorder alignment built
+    on it, and NACME are then all wrong. That is PR #319's finite-difference
+    failure mode one level up.
+    """
+
+    def test_the_allow_list_is_energy_and_grad_only(self):
+        source = (ROOT / 'pyoqp/oqp/molecule/molecule.py').read_text()
+        self.assertIn("if runtype not in ('energy', 'grad'):", source)
+
+    def test_prop_is_not_admitted(self):
+        source = (ROOT / 'pyoqp/oqp/molecule/molecule.py').read_text()
+        allow = source.index('if runtype not in (')
+        line = source[allow:source.index('\n', allow)]
+        self.assertNotIn("'prop'", line)
+        self.assertNotIn("'properties'", line)
+
+
+class ReorientationIsATranslationToo(unittest.TestCase):
+    """Not a rotation of symmetric molecules only -- everything moves."""
+
+    def test_a_c1_geometry_is_still_translated(self):
+        import importlib.util
+        import sys
+
+        spec = importlib.util.spec_from_file_location(
+            'symmetry_detect_frame_under_test',
+            ROOT / 'pyoqp/oqp/library/symmetry_detect.py')
+        detect = importlib.util.module_from_spec(spec)
+        sys.modules['symmetry_detect_frame_under_test'] = detect
+        spec.loader.exec_module(detect)
+
+        # A genuine C1 case, deliberately off-origin. Five distinct elements,
+        # non-planar -- note three atoms are always coplanar, so anything
+        # smaller is at least Cs and would not test what this claims to.
+        geometry = np.array([[1.0, 2.0, 3.0],
+                             [1.6, 2.7, 3.4],
+                             [2.1, 1.3, 2.6],
+                             [0.4, 1.4, 4.1],
+                             [0.6, 3.0, 2.2]])
+        result = detect.detect_point_group([6, 1, 9, 17, 35], geometry,
+                                           tolerance=1e-5)
+
+        self.assertEqual(result['point_group'], 'c1')
+        rotation = np.asarray(result['orientation'], dtype=float)
+        origin = np.asarray(result['origin'], dtype=float)
+        self.assertLess(float(np.max(np.abs(rotation - np.eye(3)))), 1e-9,
+                        'C1 should not be rotated')
+        # ~2.8 bohr for this geometry.
+        self.assertGreater(float(np.max(np.abs(origin))), 1.0,
+                           'but it IS translated -- which is why the restore '
+                           'matters even with no symmetry to exploit')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`reorient_for_integral_symmetry` moves the molecule into the symmetry standard frame *before* the basis exists. Staging the petite maps can still decline after that, for reasons only visible once the basis is built. Those runs were left in the moved frame with nothing to show for it.

**This is not a rotation of symmetric molecules only.** The standard frame is centred on the charge-weighted centroid, so **every** molecule is translated — including C1, where the rotation is exactly the identity and there is no symmetry to exploit at all. Measured on a CHFClBr-like geometry: `|R − I| = 0`, `|origin| = 2.8 bohr`.

## The fix was already half-written and dead

`input_coords` is captured in the reorientation loop and **never used**, so both failure exits returned `False` with the geometry already moved. They now restore it, and the caller restores it too when staging declines — re-running `_prep_guess`, since the 1e integrals were built in the moved frame and the coordinates cannot go back without them. The cost lands only on a path that was already getting no reduction.

The coordinates are carried in `meta['_reorient_input_coords']`, deliberately **outside** the `integral_symmetry` block. Every bail in `stage_integral_symmetry_maps` replaces that block wholesale, so keeping them inside silently loses them — which is exactly what happened on the first attempt: the restore never fired for any spherical basis, because `skipped_basis_mismatch` had already wiped the key. The caller pops it immediately, so it never reaches `save_data`.

## `prop` should never have been on the allow-list

Narrowed from `('energy', 'grad', 'prop', 'properties')` to `('energy', 'grad')`.

`prop` is the only admitted runtype that consumes an **externally supplied** geometry expressed in the caller's frame: `load_previous_data` writes `OQP::xyz_old` from it, and `get_basis_overlap` overlaps that against the current — by then rotated and translated — structure. The cross-geometry MO overlap, the phase/reorder alignment built on it, and NACME are then all wrong. That is #319's finite-difference failure mode one level up.

It removes petite support from `runtype=prop`, but that capability was producing wrong overlaps, so it costs nothing that was correct. (`'properties'` was never a `run_func` key, so it admitted nothing.)

## The back-transform itself is deliberately not implemented

`docs/planned/input-to-standard.md` is rewritten to scope it, including the constraint that makes it more than an inverse map:

> The geometry cannot be restored before `save_data()` / `write_molden()` without also transforming `OQP::VEC_MO_A/B`. The AO basis is atom-centred and orientation-dependent, so writing input-frame coordinates next to standard-frame MOs gives a file that is internally inconsistent and silently wrong when read back as a guess. Either transform both or neither.

The doc also drops the draft's claim that the transform alone unlocks the optimiser, IRC and NEB — those displace the geometry every step, so they need per-step re-detection and must cope with the point group *changing* between steps. It does genuinely unlock the finite-difference case, which #319 currently solves by switching the reduction off in children.

## Verification

Water displaced off-origin to (0.3, 0.4, 0.6173):

| basis | outcome | energy | geometry |
|---|---|---|---|
| 6-31G* | reduction active | −76.0107348518 | stays in the standard frame (the documented contract) |
| cc-pVDZ | staging bails | −76.0269850877 | **restored to the input frame** |

Both match their `use_integral_symmetry=false` runs exactly, dE = 0.

Tests: new `tests/test_reorientation_is_undone_on_bail.py` 8 passed; symmetry 96 passed; prop/nac/overlap/track 45 passed; scf/grad/mrsf 185 passed.

## Note

#318 makes `skipped_basis_mismatch` rare (it was firing on every spherical basis). That does not change this PR — any bail should restore — it just moves this from the common case to a genuine corner.