### PR TITLE
fix(symmetry): clear staged symmetry state that outlives what it describes

### DIFF
--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -490,7 +490,23 @@ class SinglePoint(Calculator):
 
         self.swapmo()
 
-        if symmetry_on:
+        # Reached when symmetry is on, AND when it is off but a PREVIOUS step
+        # left the reduction active. The method gates itself, but it also
+        # invalidates the previously staged maps ahead of those gates, and that
+        # invalidation is exactly what a run which has just turned symmetry off
+        # needs -- the reusable OPENQP API reloads configuration into the same
+        # molecule, so `sym_petite_enable` and the old maps would otherwise stay
+        # live for a new geometry or basis.
+        #
+        # Not called unconditionally: `reference()` is driven with lightweight
+        # stand-in molecules in the test suite, and a bare call breaks every one
+        # of them. Keying off the recorded status means the extra call happens
+        # only for a molecule that really did stage something.
+        previously_staged = bool(
+            getattr(self.mol, 'symmetry_metadata', None)
+            and self.mol.symmetry_metadata.get(
+                'integral_symmetry', {}).get('status') == 'active')
+        if symmetry_on or previously_staged:
             self.mol.stage_integral_symmetry_maps()
 
         scf_flag = self._run_scf()

--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -502,10 +502,13 @@ class SinglePoint(Calculator):
         # stand-in molecules in the test suite, and a bare call breaks every one
         # of them. Keying off the recorded status means the extra call happens
         # only for a molecule that really did stage something.
-        previously_staged = bool(
-            getattr(self.mol, 'symmetry_metadata', None)
-            and self.mol.symmetry_metadata.get(
-                'integral_symmetry', {}).get('status') == 'active')
+        # Asks the TAG STORE, not the metadata. load_config() replaces the
+        # metadata dict wholesale, so a status-based check answers False in
+        # exactly the case that strands tags: reconfiguring one molecule and
+        # turning the reduction off. getattr keeps the lightweight stand-in
+        # molecules used across the test suite working.
+        previously_staged = getattr(
+            self.mol, 'has_staged_integral_symmetry', lambda: False)()
         if symmetry_on or previously_staged:
             self.mol.stage_integral_symmetry_maps()
 

--- a/pyoqp/oqp/library/single_point.py
+++ b/pyoqp/oqp/library/single_point.py
@@ -479,6 +479,27 @@ class SinglePoint(Calculator):
         # guess/basis stage; stage the maps once the basis exists.
         symmetry_on = bool(getattr(self.mol, 'symmetry_metadata', None) and
                            self.mol.symmetry_metadata.get('use_integral_symmetry'))
+
+        # Invalidate any PREVIOUSLY staged reduction here, at the very top,
+        # before anything can consume it.
+        #
+        # Staging happens further down, once the basis exists, and clearing
+        # only there is too late: with init_scf != 'no', _init_convergence()
+        # below runs a full two-electron SCF first, and it may do so in a
+        # DIFFERENT basis (`init_basis`). A reused molecule whose geometry or
+        # basis has changed would hand that initial SCF the previous run's
+        # maps with sym_petite_enable=1 -- a corrupted starting solution, and
+        # potentially a target SCF converged into a different basin.
+        #
+        # Asks the TAG STORE, not the metadata: load_config() replaces the
+        # metadata dict wholesale, so a status-based check answers False in
+        # exactly the case that strands tags. getattr keeps the lightweight
+        # stand-in molecules used across the test suite working.
+        previously_staged = getattr(
+            self.mol, 'has_staged_integral_symmetry', lambda: False)()
+        if previously_staged:
+            self.mol.clear_integral_symmetry_state()
+
         if symmetry_on:
             self.mol.reorient_for_integral_symmetry()
 
@@ -490,25 +511,10 @@ class SinglePoint(Calculator):
 
         self.swapmo()
 
-        # Reached when symmetry is on, AND when it is off but a PREVIOUS step
-        # left the reduction active. The method gates itself, but it also
-        # invalidates the previously staged maps ahead of those gates, and that
-        # invalidation is exactly what a run which has just turned symmetry off
-        # needs -- the reusable OPENQP API reloads configuration into the same
-        # molecule, so `sym_petite_enable` and the old maps would otherwise stay
-        # live for a new geometry or basis.
-        #
-        # Not called unconditionally: `reference()` is driven with lightweight
-        # stand-in molecules in the test suite, and a bare call breaks every one
-        # of them. Keying off the recorded status means the extra call happens
-        # only for a molecule that really did stage something.
-        # Asks the TAG STORE, not the metadata. load_config() replaces the
-        # metadata dict wholesale, so a status-based check answers False in
-        # exactly the case that strands tags: reconfiguring one molecule and
-        # turning the reduction off. getattr keeps the lightweight stand-in
-        # molecules used across the test suite working.
-        previously_staged = getattr(
-            self.mol, 'has_staged_integral_symmetry', lambda: False)()
+        # Stage fresh maps now that the basis exists. `previously_staged` is
+        # still consulted so that a molecule which HAD a reduction and has now
+        # turned it off still reaches the method's own bookkeeping (status and
+        # log), even though its tags were already dropped above.
         if symmetry_on or previously_staged:
             self.mol.stage_integral_symmetry_maps()
 

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -659,18 +659,42 @@ class Molecule:
         return staged
 
     def _symmetry_geometry_key(self):
-        """Fingerprint of the current geometry, or None if unavailable.
+        """Fingerprint of the state the MO labels describe, or None.
 
-        Used to decide whether cached ``mo_labels`` still describe the
-        structure in front of us. Returning None means "cannot tell", and the
-        callers then keep the cached labels -- the historical behaviour --
-        rather than paying the dense O(|G| n_AO^3) relabelling on every call.
+        Covers the geometry AND the converged orbitals. Coordinates alone are
+        not enough: MO irreps describe the SCF SOLUTION, so the same molecule
+        at identical coordinates can legitimately produce different labels
+        after a different guess, an orbital swap, or a symmetry-broken
+        stability solution. With ``label_mo=false`` suppressing the ordinary
+        post-SCF relabelling, a coordinates-only key would accept those stale
+        labels and stage a pair table for orbitals that no longer exist.
+
+        Hashing the coefficients is O(n_AO^2) against the O(|G| n_AO^3)
+        relabelling it guards, so it is cheap enough to do on every check.
+
+        Returning None means "cannot tell", and the callers then keep the
+        cached labels -- the historical behaviour -- rather than paying that
+        relabelling on every call.
         """
         try:
             import hashlib
+            digest = hashlib.md5()
             coords = np.ascontiguousarray(
                 np.asarray(self.get_system(), dtype=float).ravel())
-            return hashlib.md5(coords.tobytes()).hexdigest()
+            digest.update(coords.tobytes())
+            seen_orbitals = False
+            for tag in ('OQP::VEC_MO_A', 'OQP::VEC_MO_B'):
+                try:
+                    mo = np.asarray(self.data[tag], dtype=float)
+                except Exception:
+                    continue
+                digest.update(np.ascontiguousarray(mo.ravel()).tobytes())
+                seen_orbitals = True
+            if not seen_orbitals:
+                # Labels are built FROM the orbitals; without them there is
+                # nothing meaningful to key against.
+                return None
+            return digest.hexdigest()
         except Exception:
             return None
 
@@ -703,6 +727,28 @@ class Molecule:
         'OQP::sym_op_blocks',
         'OQP::sym_petite_enable',
     )
+
+    def has_staged_integral_symmetry(self):
+        """True when petite-reduction tags are live in the native store.
+
+        Asks the TAG STORE, deliberately, not the metadata. The metadata is
+        the thing that gets replaced: ``load_config()`` ->
+        ``initialize_symmetry_metadata()`` assigns a brand-new dict and erases
+        ``integral_symmetry.status``, while ``apply_config()`` leaves the
+        native tags untouched. Keying "did a previous step stage something?"
+        off the metadata therefore answered False in exactly the case that
+        produces stale tags -- reconfiguring one molecule through the
+        ``OpenQP.set()`` path and turning the reduction off.
+
+        The tags outlive the metadata, so they are what has to be asked.
+        """
+        for tag in self._INTEGRAL_SYMMETRY_TAGS:
+            try:
+                self.data[tag]
+                return True
+            except Exception:
+                continue
+        return False
 
     def _clear_integral_symmetry_tags(self, meta=None):
         """Drop every staged petite-list / skeleton-symmetrisation artefact.

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -639,6 +639,23 @@ class Molecule:
             pass
         return staged
 
+    def _clear_full_group_tags(self, meta=None):
+        """Drop any staged non-abelian (full point group) reduction artefacts.
+
+        `OQP::sym_op_blocks` is written only by the full tier, and its mere
+        PRESENCE is what makes the Fortran side take the blocked path. Nothing
+        on the abelian path overwrites it, so it has to be deleted explicitly
+        or a molecule that staged the full group once keeps taking that path
+        after falling back.
+        """
+        try:
+            del self.data['OQP::sym_op_blocks']
+        except Exception:
+            pass
+        if meta is None:
+            meta = self.symmetry_metadata or {}
+        meta.pop('reduction_maps_full', None)
+
     def _td_multiplicity(self):
         """Target spin multiplicity of the response calculation, or None.
 
@@ -794,6 +811,19 @@ class Molecule:
                 full_declined = self._full_group_decline_reason()
                 if full_declined:
                     want_full = False
+            # Drop any full-group artefacts from an EARLIER staging before
+            # choosing a tier. The tag store outlives one step, and the
+            # abelian path overwrites OQP::sym_shell_map but never wrote
+            # OQP::sym_op_blocks, so a molecule that staged the full tier once
+            # (HF) and then falls back to abelian (a functional set on a later
+            # step, or the overlap gate rejecting the full group) would leave
+            # the old dense blocks in place. Fortran keys off their presence:
+            # int2 selects the blocked path, then symmetrize_skeleton_fock
+            # returns on the size mismatch -- so the abelian skeleton
+            # symmetrisation is skipped entirely and silently. Clearing on
+            # EVERY entry makes the tier a property of this staging call
+            # rather than of the molecule's history.
+            self._clear_full_group_tags(meta)
             full_group = False
             full_ops = None
             try:
@@ -885,6 +915,14 @@ class Molecule:
                 del self.data[tag]
             except Exception:
                 pass
+        # ...and the metadata that describes them. Every bail below sets its own
+        # status, but the ones that return before reaching them would otherwise
+        # leave the PREVIOUS step's 'active'/'pair_table_staged' in the
+        # serialized metadata while no table exists -- Fortran falls back
+        # correctly, but anything reading the metadata is told otherwise.
+        meta = self.symmetry_metadata
+        if meta:
+            meta.pop('response_symmetry', None)
 
     def stage_response_symmetry(self):
         """Stage per-pair irrep indices for response-space blocking.
@@ -1095,7 +1133,14 @@ class Molecule:
             # MO labels provide the SOMO reference product for sf/mrsf.
             mo_labels = meta.get('mo_labels')
             if not mo_labels or mo_labels.get('status') != 'ok':
-                mo_labels = self.label_molecular_orbitals()
+                # required=True for the same reason as in
+                # stage_response_symmetry: these labels are an INPUT to the
+                # state assignment, not the MO table the user asked to see.
+                # Honouring label_mo here meant a direct call to
+                # label_excited_states() with label_mo=false silently produced
+                # no state labels; the single_point path only hid it because it
+                # stages first.
+                mo_labels = self.label_molecular_orbitals(required=True)
             if not mo_labels or mo_labels.get('status') != 'ok':
                 meta['state_labels'] = {'status': 'skipped_no_mo_labels'}
                 return None
@@ -1231,6 +1276,15 @@ class Molecule:
         Stores the result under ``symmetry_metadata['mode_labels']``.
         """
         meta = self.symmetry_metadata
+        # Clear first, on EVERY path. These labels are keyed to a particular
+        # set of modes, and the metadata outlives them: a molecule that
+        # labelled one Hessian and then reads a cached one with detection
+        # unavailable (or label_modes off) would otherwise keep the previous
+        # labels, and the frequency formatter prints them against the new modes
+        # whenever the counts happen to match. Wrong labels are worse than no
+        # column, because nothing marks them as stale.
+        if meta:
+            meta.pop('mode_labels', None)
         if not meta or meta.get('status', 'disabled') == 'disabled':
             return None
         if not meta.get('label_modes', True):
@@ -1311,8 +1365,8 @@ class Molecule:
                                  ' abelian operations only,')
                     lines.append('   and the non-abelian mismatch is a measured'
                                  ' 3e-04 error (see docs/planned/')
-                    lines.append('   integral-symmetry.md). Set method=hf to use the'
-                                 ' full group.')
+                    lines.append('   integral-symmetry.md). Remove the [input]'
+                                 ' functional to use the full group.')
                 if active.get('reoriented'):
                     lines.append('   geometry reoriented to the symmetry standard orientation')
             response = meta.get('response_symmetry')

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -484,6 +484,9 @@ class Molecule:
             state = self._label_scf_state(result)
             if state is not None:
                 result['scf_state'] = state
+            # Stamp the geometry these labels describe. They are orbital
+            # irreps of ONE structure, and the metadata outlives a step.
+            result['geometry_key'] = self._symmetry_geometry_key()
             meta['mo_labels'] = result
             # Gate A of the reductions plan: shell/AO symmetry maps
             # (metadata only; consumed by future petite-list code).
@@ -655,6 +658,41 @@ class Molecule:
             pass
         return staged
 
+    def _symmetry_geometry_key(self):
+        """Fingerprint of the current geometry, or None if unavailable.
+
+        Used to decide whether cached ``mo_labels`` still describe the
+        structure in front of us. Returning None means "cannot tell", and the
+        callers then keep the cached labels -- the historical behaviour --
+        rather than paying the dense O(|G| n_AO^3) relabelling on every call.
+        """
+        try:
+            import hashlib
+            coords = np.ascontiguousarray(
+                np.asarray(self.get_system(), dtype=float).ravel())
+            return hashlib.md5(coords.tobytes()).hexdigest()
+        except Exception:
+            return None
+
+    def _usable_mo_labels(self, meta):
+        """Cached MO labels for the CURRENT geometry, or None.
+
+        ``stage_response_symmetry`` and ``label_excited_states`` rebuild their
+        tables from these labels, so reusing labels computed at a previous
+        geometry stages a fresh, well-formed table describing the wrong
+        orbitals. That is reachable whenever the ordinary post-SCF relabelling
+        does not run -- most obviously with ``label_mo=false``, where
+        ``label_molecular_orbitals()`` returns early and the step-N labels
+        simply persist into step N+1.
+        """
+        labels = meta.get('mo_labels')
+        if not labels or labels.get('status') != 'ok':
+            return None
+        key = self._symmetry_geometry_key()
+        if key is not None and labels.get('geometry_key') != key:
+            return None
+        return labels
+
     #: Every tag written by the integral-symmetry staging path. Absence means
     #: "not staged", which is what each Fortran consumer treats as inactive.
     _INTEGRAL_SYMMETRY_TAGS = (
@@ -684,6 +722,19 @@ class Molecule:
         if meta:
             meta.pop('reduction_maps', None)
             meta.pop('reduction_maps_full', None)
+            # The metadata must not outlive the tags either. `status ==
+            # 'active'` is what _petite_is_staged() and symmetrize_gradient()
+            # key off, so leaving it behind means a gradient gets projected
+            # with the previous geometry's operations after the reduction has
+            # been turned off -- metadata and runtime state disagreeing is the
+            # same class of bug as the stale tags themselves.
+            #
+            # Only 'active' is dropped: 'reoriented' is set by
+            # reorient_for_integral_symmetry BEFORE staging runs, and the
+            # staging body requires it, so clearing that would disable the
+            # reduction outright.
+            if meta.get('integral_symmetry', {}).get('status') == 'active':
+                meta.pop('integral_symmetry', None)
 
     def _clear_full_group_tags(self, meta=None):
         """Drop any staged non-abelian (full point group) reduction artefacts.
@@ -1011,10 +1062,12 @@ class Molecule:
         try:
             from oqp.library.symmetry import product_irrep
 
-            mo_labels = meta.get('mo_labels')
-            if not mo_labels or mo_labels.get('status') != 'ok':
-                # required=True: the guess coverage needs the irreps whether or
-                # not the user asked to SEE the MO label table.
+            # required=True: the guess coverage needs the irreps whether or
+            # not the user asked to SEE the MO label table. The geometry check
+            # matters for the same reason -- stale labels stage a well-formed
+            # table for the wrong structure.
+            mo_labels = self._usable_mo_labels(meta)
+            if mo_labels is None:
                 mo_labels = self.label_molecular_orbitals(required=True)
             if not mo_labels or mo_labels.get('status') != 'ok':
                 meta['response_symmetry'] = {'status': 'skipped_no_mo_labels'}
@@ -1177,8 +1230,8 @@ class Molecule:
                 return None
 
             # MO labels provide the SOMO reference product for sf/mrsf.
-            mo_labels = meta.get('mo_labels')
-            if not mo_labels or mo_labels.get('status') != 'ok':
+            mo_labels = self._usable_mo_labels(meta)
+            if mo_labels is None:
                 # required=True for the same reason as in
                 # stage_response_symmetry: these labels are an INPUT to the
                 # state assignment, not the MO table the user asked to see.

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -750,6 +750,14 @@ class Molecule:
                 continue
         return False
 
+    def clear_integral_symmetry_state(self):
+        """Public entry point for dropping the staged petite reduction.
+
+        Callers need this BEFORE anything that can consume the maps, not just
+        before re-staging them.
+        """
+        self._clear_integral_symmetry_tags()
+
     def _clear_integral_symmetry_tags(self, meta=None):
         """Drop every staged petite-list / skeleton-symmetrisation artefact.
 

--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -627,6 +627,22 @@ class Molecule:
         existed and no output said so.
         """
         meta = self.symmetry_metadata
+        # Invalidate FIRST, before ANY gate below can return.
+        #
+        # Every tag this method stages describes one geometry and one basis,
+        # and the tag store outlives a single step. Clearing them at the point
+        # of a successful re-stage is not enough: the gates that return early
+        # -- no detection, the frame not reoriented, no basis, no shell
+        # purity, an AO-count mismatch, a failed overlap-invariance check --
+        # all leave the PREVIOUS step's maps in place, with
+        # OQP::sym_petite_enable still 1. Fortran then applies a stale petite
+        # list and a stale skeleton symmetrisation to the new geometry, which
+        # is a wrong-integrals bug rather than a missed optimisation.
+        #
+        # Same reasoning as _clear_response_symmetry_tags: make a bail mean
+        # "nothing staged", which every consumer already handles, instead of
+        # "whatever was true last time".
+        self._clear_integral_symmetry_tags(meta)
         if not meta or not meta.get('use_integral_symmetry'):
             return False
         staged = self._stage_integral_symmetry_maps(meta)
@@ -638,6 +654,36 @@ class Molecule:
         except Exception:
             pass
         return staged
+
+    #: Every tag written by the integral-symmetry staging path. Absence means
+    #: "not staged", which is what each Fortran consumer treats as inactive.
+    _INTEGRAL_SYMMETRY_TAGS = (
+        'OQP::sym_shell_map',
+        'OQP::sym_ao_target',
+        'OQP::sym_ao_sign',
+        'OQP::sym_atom_weight',
+        'OQP::sym_op_blocks',
+        'OQP::sym_petite_enable',
+    )
+
+    def _clear_integral_symmetry_tags(self, meta=None):
+        """Drop every staged petite-list / skeleton-symmetrisation artefact.
+
+        Deliberately deletes ``OQP::sym_petite_enable`` rather than setting it
+        to 0: absence and 0 are equivalent to the consumers, and deleting
+        cannot leave a half-configured state where the flag says active but
+        the maps are gone.
+        """
+        for tag in self._INTEGRAL_SYMMETRY_TAGS:
+            try:
+                del self.data[tag]
+            except Exception:
+                pass
+        if meta is None:
+            meta = self.symmetry_metadata or {}
+        if meta:
+            meta.pop('reduction_maps', None)
+            meta.pop('reduction_maps_full', None)
 
     def _clear_full_group_tags(self, meta=None):
         """Drop any staged non-abelian (full point group) reduction artefacts.

--- a/tests/test_integral_symmetry_invalidation_live.py
+++ b/tests/test_integral_symmetry_invalidation_live.py
@@ -172,5 +172,53 @@ class IntegralSymmetryInvalidationTests(unittest.TestCase):
                              f'{tag} survived a load_config() that disabled the reduction')
 
 
+    def test_tags_are_gone_before_the_initial_scf_runs(self):
+        """Ordering, not just end state.
+
+        With `init_scf != 'no'`, `_init_convergence()` runs a full
+        two-electron SCF -- possibly in a DIFFERENT basis (`init_basis`) --
+        before the staging call further down. Clearing only at staging time
+        hands that initial SCF the previous run's maps with
+        `sym_petite_enable=1`: a corrupted starting solution, and potentially a
+        target SCF converged into a different basin.
+
+        Asserting the final state cannot catch this, because the tags are gone
+        by the end either way. So capture what was live at the moment
+        `_init_convergence()` was entered.
+        """
+        from oqp.library.single_point import SinglePoint
+        mol = self._run('sym_order', 'true')
+        self.assertTrue(_has(mol, 'OQP::sym_petite_enable'))
+
+        case = os.path.join(self.workdir, 'sym_order')
+        off = os.path.join(case, 'off.inp')
+        with open(off, 'w', encoding='utf-8') as handle:
+            handle.write(INPUT.format(use='false'))
+        mol.load_config(off)
+        self.assertTrue(mol.has_staged_integral_symmetry(),
+                        'precondition: tags live before reference()')
+
+        sp = SinglePoint(mol)
+        seen = {}
+        original = sp._init_convergence
+
+        def spy():
+            seen['staged_at_entry'] = mol.has_staged_integral_symmetry()
+            return original()
+
+        sp._init_convergence = spy
+        # The deck is RHF; 'no' would skip _init_convergence entirely and
+        # the spy would never fire, which the assertion below catches.
+        if sp.init_scf == 'no':
+            sp.init_scf = 'rhf'
+        sp.reference(do_init_scf=True)
+
+        self.assertIn('staged_at_entry', seen,
+                      '_init_convergence did not run; the test proves nothing')
+        self.assertFalse(
+            seen['staged_at_entry'],
+            'stale petite maps were still live when the initial SCF started')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_integral_symmetry_invalidation_live.py
+++ b/tests/test_integral_symmetry_invalidation_live.py
@@ -1,0 +1,142 @@
+"""Turning the petite reduction OFF must actually turn it off.
+
+The staging path writes `OQP::sym_shell_map`, `sym_ao_target`, `sym_ao_sign`,
+`sym_atom_weight` and sets `sym_petite_enable` to 1. Those tags live in a store
+that outlives one step, and nothing on the abelian path or in the Fortran layer
+removes them. So a reused molecule that ran once with
+`use_integral_symmetry=true` and then runs again with it false would keep
+applying the previous geometry's petite list and skeleton symmetrisation --
+wrong integrals, silently, because the reduction is energy-identical when it IS
+valid and nothing prints when it is not.
+
+This is a LIVE test rather than a unit test on purpose. The unit tests assert
+that `stage_integral_symmetry_maps()` clears when called; the thing that can
+regress here is whether it gets CALLED at all, since `SinglePoint.reference()`
+used to invoke it only when symmetry was already on -- exactly the branch a
+"symmetry is now off" run does not take.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TAGS = (
+    'OQP::sym_shell_map',
+    'OQP::sym_ao_target',
+    'OQP::sym_ao_sign',
+    'OQP::sym_atom_weight',
+    'OQP::sym_op_blocks',
+    'OQP::sym_petite_enable',
+)
+
+
+def _runtime_available():
+    try:
+        os.environ.setdefault("OPENQP_ROOT", str(ROOT))
+        os.environ.setdefault("OMP_NUM_THREADS", "1")
+        import oqp  # noqa: F401
+        from oqp.pyoqp import Runner  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+INPUT = """\
+[input]
+system=
+   8   0.000000000   0.000000000  -0.041061554
+   1  -0.533194329   0.533194329  -0.614469223
+   1   0.533194329  -0.533194329  -0.614469223
+charge=0
+runtype=energy
+basis=6-31g
+functional=
+method=hf
+
+[guess]
+type=huckel
+
+[scf]
+type=rhf
+multiplicity=1
+conv=1.0e-9
+
+[symmetry]
+enabled=true
+use_integral_symmetry={use}
+"""
+
+
+def _has(mol, tag):
+    try:
+        mol.data[tag]
+        return True
+    except Exception:
+        return False
+
+
+@unittest.skipUnless(_runtime_available(), "compiled OpenQP runtime not available")
+class IntegralSymmetryInvalidationTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.workdir = tempfile.mkdtemp(prefix='oqp_sym_invalidation_')
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.workdir, ignore_errors=True)
+
+    def _run(self, name, use):
+        from oqp.pyoqp import Runner
+        case = os.path.join(self.workdir, name)
+        os.makedirs(case, exist_ok=True)
+        path = os.path.join(case, f'{name}.inp')
+        with open(path, 'w', encoding='utf-8') as handle:
+            handle.write(INPUT.format(use=use))
+        runner = Runner(project=name, input_file=path,
+                        log=os.path.join(case, f'{name}.log'), usempi=False)
+        runner.run()
+        return runner.mol
+
+    def test_the_reduction_stages_its_tags_when_enabled(self):
+        """Control. Without this the OFF assertion below proves nothing --
+        every tag would be absent whether or not invalidation works."""
+        mol = self._run('sym_on', 'true')
+        self.assertEqual(
+            mol.symmetry_metadata.get('integral_symmetry', {}).get('status'),
+            'active')
+        for tag in ('OQP::sym_shell_map', 'OQP::sym_ao_target',
+                    'OQP::sym_ao_sign', 'OQP::sym_petite_enable'):
+            self.assertTrue(_has(mol, tag), f'{tag} was not staged when enabled')
+
+    def test_no_tags_survive_a_run_with_the_reduction_disabled(self):
+        mol = self._run('sym_off', 'false')
+        for tag in TAGS:
+            self.assertFalse(_has(mol, tag),
+                             f'{tag} present although the reduction is off')
+        self.assertNotEqual(
+            mol.symmetry_metadata.get('integral_symmetry', {}).get('status'),
+            'active')
+
+    def test_reusing_one_molecule_across_the_switch_clears_the_tags(self):
+        """The actual regression: stage once, then re-run the SAME molecule
+        with the flag off. `reference()` must still reach the invalidation."""
+        from oqp.library.single_point import SinglePoint
+        mol = self._run('sym_reuse', 'true')
+        self.assertTrue(_has(mol, 'OQP::sym_petite_enable'))
+
+        mol.symmetry_metadata['use_integral_symmetry'] = False
+        mol.config['symmetry']['use_integral_symmetry'] = 'False'
+        SinglePoint(mol).reference(do_init_scf=False)
+
+        for tag in TAGS:
+            self.assertFalse(_has(mol, tag),
+                             f'{tag} survived into a run with the reduction off')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_integral_symmetry_invalidation_live.py
+++ b/tests/test_integral_symmetry_invalidation_live.py
@@ -138,5 +138,39 @@ class IntegralSymmetryInvalidationTests(unittest.TestCase):
                              f'{tag} survived into a run with the reduction off')
 
 
+    def test_reload_config_route_still_clears(self):
+        """The route the previous test MISSED.
+
+        `load_config()` calls `initialize_symmetry_metadata()`, which replaces
+        the metadata dict and erases `integral_symmetry.status`, while
+        `apply_config()` leaves the native tags alone. A "was it staged
+        before?" check keyed on metadata therefore answers False in exactly
+        this case, and the staged maps survive with `sym_petite_enable=1`.
+        The earlier test mutated the metadata in place and so never exercised
+        it.
+        """
+        from oqp.library.single_point import SinglePoint
+        mol = self._run('sym_reload', 'true')
+        self.assertTrue(_has(mol, 'OQP::sym_petite_enable'))
+
+        case = os.path.join(self.workdir, 'sym_reload')
+        off = os.path.join(case, 'off.inp')
+        with open(off, 'w', encoding='utf-8') as handle:
+            handle.write(INPUT.format(use='false'))
+        mol.load_config(off)
+        # Precondition: the reload really did erase the status, so the fix
+        # cannot be passing for the wrong reason.
+        self.assertNotEqual(
+            mol.symmetry_metadata.get('integral_symmetry', {}).get('status'),
+            'active')
+        self.assertTrue(mol.has_staged_integral_symmetry(),
+                        'tags should still be live before reference() runs')
+
+        SinglePoint(mol).reference(do_init_scf=False)
+        for tag in TAGS:
+            self.assertFalse(_has(mol, tag),
+                             f'{tag} survived a load_config() that disabled the reduction')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_response_symmetry_staging_gates.py
+++ b/tests/test_response_symmetry_staging_gates.py
@@ -216,6 +216,56 @@ class FullGroupTagsAreClearedTests(unittest.TestCase):
         mol._clear_full_group_tags({})  # must not raise
 
 
+class StaleIntegralStagingTests(unittest.TestCase):
+    """A staging attempt that BAILS must not leave the previous one active.
+
+    Every early return in the staging body -- no detection, frame not
+    reoriented, no basis, no shell purity, AO-count mismatch, failed overlap
+    invariance -- used to return before any invalidation, so the prior step's
+    petite maps stayed in the tag store with ``sym_petite_enable`` still 1.
+    Fortran would then apply them to the NEW geometry: wrong integrals, not a
+    missed optimisation.
+    """
+
+    ALL_TAGS = (
+        'OQP::sym_shell_map', 'OQP::sym_ao_target', 'OQP::sym_ao_sign',
+        'OQP::sym_atom_weight', 'OQP::sym_op_blocks', 'OQP::sym_petite_enable',
+    )
+
+    def _staged(self):
+        """A molecule carrying a complete, previously-staged petite setup."""
+        data = FakeData({t: np.ones(2) for t in self.ALL_TAGS})
+        meta = {
+            'use_integral_symmetry': True,
+            'reduction_maps': {'n_operations': 8},
+            'reduction_maps_full': {'n_operations': 24},
+            # No 'detection' -> the FIRST gate in the staging body returns.
+        }
+        return _molecule({'symmetry': {'use_integral_symmetry': 'true'}}, meta, data)
+
+    def test_a_bail_on_missing_detection_clears_everything(self):
+        mol = self._staged()
+        self.assertFalse(mol.stage_integral_symmetry_maps())
+        for tag in self.ALL_TAGS:
+            self.assertNotIn(tag, mol.data, f'{tag} survived a failed staging')
+        self.assertNotIn('reduction_maps', mol.symmetry_metadata)
+        self.assertNotIn('reduction_maps_full', mol.symmetry_metadata)
+
+    def test_turning_integral_symmetry_off_also_clears(self):
+        """The flag gate returns even earlier than the staging body."""
+        mol = self._staged()
+        mol.symmetry_metadata['use_integral_symmetry'] = False
+        self.assertFalse(mol.stage_integral_symmetry_maps())
+        for tag in self.ALL_TAGS:
+            self.assertNotIn(tag, mol.data, f'{tag} survived with the flag off')
+
+    def test_petite_enable_is_deleted_not_left_asserting_active(self):
+        """Absence and 0 are equivalent to the consumers; a surviving 1 is not."""
+        mol = self._staged()
+        mol.stage_integral_symmetry_maps()
+        self.assertNotIn('OQP::sym_petite_enable', mol.data)
+
+
 class TdMultiplicityKeyTests(unittest.TestCase):
     """The schema key is 'multiplicity'; 'mult' is only an alias."""
 

--- a/tests/test_response_symmetry_staging_gates.py
+++ b/tests/test_response_symmetry_staging_gates.py
@@ -265,6 +265,74 @@ class StaleIntegralStagingTests(unittest.TestCase):
         mol.stage_integral_symmetry_maps()
         self.assertNotIn('OQP::sym_petite_enable', mol.data)
 
+    def test_active_status_is_dropped_so_metadata_matches_the_tags(self):
+        """`status == 'active'` drives _petite_is_staged() and
+        symmetrize_gradient(); leaving it projects a gradient with the previous
+        geometry's operations after the reduction was turned off."""
+        mol = self._staged()
+        mol.symmetry_metadata['integral_symmetry'] = {'status': 'active',
+                                                      'n_operations': 8}
+        mol.symmetry_metadata['use_integral_symmetry'] = False
+        mol.stage_integral_symmetry_maps()
+        self.assertNotEqual(
+            mol.symmetry_metadata.get('integral_symmetry', {}).get('status'),
+            'active')
+
+    def test_reoriented_status_survives_invalidation(self):
+        """The staging body REQUIRES it; clearing it would disable the
+        reduction outright, so only 'active' may be dropped."""
+        mol = self._staged()
+        mol.symmetry_metadata['integral_symmetry'] = {'status': 'reoriented'}
+        mol._clear_integral_symmetry_tags(mol.symmetry_metadata)
+        self.assertEqual(
+            mol.symmetry_metadata['integral_symmetry']['status'], 'reoriented')
+
+
+class StaleMoLabelsTests(unittest.TestCase):
+    """MO labels describe one geometry and must not be reused across steps.
+
+    Reachable whenever the ordinary post-SCF relabelling does not run -- most
+    obviously with label_mo=false, where label_molecular_orbitals() returns
+    early and step N's labels persist into step N+1. The staged pair table is
+    then well formed and describes the wrong orbitals.
+    """
+
+    def _mol(self, labels_key, current_geom):
+        meta = {
+            'status': 'enabled',
+            'label_mo': False,
+            'detection': {'character_table': C2V, 'operations': []},
+            'mo_labels': {'status': 'ok', 'geometry_key': labels_key,
+                          'alpha': {'labels': ['a1', 'b2']}},
+        }
+        mol = _molecule({'tdhf': {'type': 'mrsf'}}, meta)
+        mol.get_system = lambda: current_geom
+        return mol
+
+    def test_labels_from_the_same_geometry_are_reused(self):
+        mol = self._mol(None, [0.0, 0.0, 0.0])
+        key = mol._symmetry_geometry_key()
+        mol.symmetry_metadata['mo_labels']['geometry_key'] = key
+        self.assertIsNotNone(mol._usable_mo_labels(mol.symmetry_metadata))
+
+    def test_labels_from_a_different_geometry_are_rejected(self):
+        mol = self._mol('a-key-from-some-other-structure', [0.0, 0.0, 0.0])
+        self.assertIsNone(mol._usable_mo_labels(mol.symmetry_metadata))
+
+    def test_a_moved_atom_changes_the_key(self):
+        a = self._mol(None, [0.0, 0.0, 0.0])._symmetry_geometry_key()
+        b = self._mol(None, [0.0, 0.0, 0.001])._symmetry_geometry_key()
+        self.assertIsNotNone(a)
+        self.assertNotEqual(a, b)
+
+    def test_unknown_geometry_keeps_the_cached_labels(self):
+        """None means 'cannot tell'. Recomputing unconditionally would pay the
+        dense O(|G| n_AO^3) relabelling on every call."""
+        mol = self._mol('whatever', [0.0, 0.0, 0.0])
+        mol.get_system = lambda: (_ for _ in ()).throw(RuntimeError('no geometry'))
+        self.assertIsNone(mol._symmetry_geometry_key())
+        self.assertIsNotNone(mol._usable_mo_labels(mol.symmetry_metadata))
+
 
 class TdMultiplicityKeyTests(unittest.TestCase):
     """The schema key is 'multiplicity'; 'mult' is only an alias."""

--- a/tests/test_response_symmetry_staging_gates.py
+++ b/tests/test_response_symmetry_staging_gates.py
@@ -1,11 +1,10 @@
 """Gates around staging the per-pair irrep table for the Davidson guess.
 
-Three defects, all of which only became reachable once ``[symmetry] enabled``
-started defaulting to true, and all of which failed SILENTLY -- the guess fell
-back to the historical seeds and nothing in the output said so. That silence is
-the reason they are pinned here rather than left to a live example: the failure
-mode of this whole mechanism is "the answer looks fine and is a different
-state".
+Three defects, all reachable only once ``[symmetry] enabled`` started defaulting
+to true, and all of which failed SILENTLY -- the guess fell back to the
+historical seeds and nothing in the output said so. That silence is why they are
+pinned here: the failure mode of this mechanism is "the answer looks fine and is
+a different state".
 
 1. ``label_mo`` is a DISPLAY flag. It must not decide whether the irreps are
    computed, because the guess coverage needs them.
@@ -14,31 +13,217 @@ state".
    length, which every Fortran consumer then discards at its size guard.
 3. The state-label formatter must read the validated schema key
    ``[tdhf] multiplicity``, not the test-only ``mult`` alias.
+
+These tests drive the real methods against injected data rather than grepping
+the source. An earlier version of this file asserted on source text -- that a
+call site still reads ``required=True``, that a branch still mentions
+``_td_multiplicity() == 5`` -- which would have passed on a dead branch, a
+wrong slice, or a comment. Those assertions are gone.
 """
 
+import sys
+import types
 import unittest
+from pathlib import Path
+
+import numpy as np
 
 from test_symmetry_metadata import load_molecule_module
 
+ROOT = Path(__file__).resolve().parents[1]
 
-def _molecule(config, metadata=None):
+
+def _ensure_oqp_library():
+    """Make ``oqp.library.symmetry`` importable under the stub environment.
+
+    ``load_molecule_module`` installs a stub ``oqp`` package whose ``__path__``
+    is ``pyoqp/`` rather than ``pyoqp/oqp/``, so ``oqp.library`` does not
+    resolve and the methods under test bail into their own ``except`` with
+    "No module named 'oqp.library'" -- which would look exactly like the
+    defect. Point a real path at it; ``symmetry.py`` needs only numpy.
+    """
+    load_molecule_module()
+    if 'oqp.library' not in sys.modules:
+        pkg = types.ModuleType('oqp.library')
+        pkg.__path__ = [str(ROOT / 'pyoqp' / 'oqp' / 'library')]
+        sys.modules['oqp.library'] = pkg
+
+
+# C2v, in the order stage_response_symmetry indexes it (1-based into this dict).
+C2V = {
+    'a1': [1, 1, 1, 1],
+    'a2': [1, 1, -1, -1],
+    'b1': [1, -1, 1, -1],
+    'b2': [1, -1, -1, 1],
+}
+
+
+class FakeData(dict):
+    """Stand-in for Molecule.data: a tag store that records what was staged."""
+
+
+def _molecule(config, metadata=None, data=None):
+    _ensure_oqp_library()
     molecule_module = load_molecule_module()
-    molecule = molecule_module.Molecule.__new__(molecule_module.Molecule)
-    molecule.config = config
-    molecule.symmetry_metadata = metadata if metadata is not None else {}
-    return molecule
+    mol = molecule_module.Molecule.__new__(molecule_module.Molecule)
+    mol.config = config
+    mol.symmetry_metadata = metadata if metadata is not None else {}
+    mol.data = data if data is not None else FakeData()
+    return mol
+
+
+def _staging_molecule(multiplicity, na=5, nb=3, nbf=8):
+    """A molecule ready for stage_response_symmetry, with MO labels supplied.
+
+    na/nb/nbf are chosen so the two candidate response spaces have DIFFERENT
+    sizes -- na*(nbf-nb) = 25 and nb*(nbf-na) = 9 -- so the assertion can tell
+    which one was staged rather than merely that something was staged.
+    """
+    labels = ['a1', 'b2', 'a1', 'b1', 'a1', 'b2', 'a1', 'b1'][:nbf]
+    meta = {
+        'status': 'enabled',
+        'label_mo': True,
+        'detection': {'character_table': C2V, 'operations': []},
+        'mo_labels': {
+            'status': 'ok',
+            'alpha': {'labels': labels},
+            'beta': {'labels': labels},
+        },
+        'use_response_symmetry': False,
+    }
+    data = FakeData({'nelec_A': np.array([na]), 'nelec_B': np.array([nb])})
+    cfg = {'tdhf': {'type': 'mrsf', 'multiplicity': multiplicity}}
+    return _molecule(cfg, meta, data), na, nb, nbf
+
+
+class QuintetResponseSpaceTests(unittest.TestCase):
+    """Quintet MRSF stages beta-occupied to alpha-virtual."""
+
+    def test_quintet_stages_the_transposed_space(self):
+        mol, na, nb, nbf = _staging_molecule(5)
+        self.assertTrue(mol.stage_response_symmetry())
+        staged = np.asarray(mol.data['OQP::sym_pair_irrep']).size
+        self.assertEqual(staged, nb * (nbf - na),
+                         'quintet must stage beta-occ x alpha-vir')
+        self.assertNotEqual(staged, na * (nbf - nb))
+
+    def test_triplet_keeps_the_original_space(self):
+        mol, na, nb, nbf = _staging_molecule(3)
+        self.assertTrue(mol.stage_response_symmetry())
+        staged = np.asarray(mol.data['OQP::sym_pair_irrep']).size
+        self.assertEqual(staged, na * (nbf - nb))
+
+    def test_pair_labels_are_the_products_of_the_right_orbital_sets(self):
+        """Not just the length -- the contents must come from beta occ x alpha
+        vir, which a transposed-but-same-size bug would get wrong."""
+        from oqp.library.symmetry import product_irrep
+        mol, na, nb, nbf = _staging_molecule(5)
+        mol.stage_response_symmetry()
+        staged = np.asarray(mol.data['OQP::sym_pair_irrep']).ravel()
+        labels = mol.symmetry_metadata['mo_labels']['alpha']['labels']
+        irreps = list(C2V.keys())
+        expected = [irreps.index(product_irrep([occ, vir], C2V)) + 1
+                    for vir in labels[na:] for occ in labels[:nb]]
+        self.assertEqual(staged.tolist(), expected)
+
+    def test_projection_flag_and_status_follow_use_response_symmetry(self):
+        mol, *_ = _staging_molecule(3)
+        mol.stage_response_symmetry()
+        self.assertEqual(int(np.asarray(
+            mol.data['OQP::sym_response_project_enable']).ravel()[0]), 0)
+        self.assertEqual(
+            mol.symmetry_metadata['response_symmetry']['status'],
+            'pair_table_staged')
+
+        mol.symmetry_metadata['use_response_symmetry'] = True
+        mol.stage_response_symmetry()
+        self.assertEqual(int(np.asarray(
+            mol.data['OQP::sym_response_project_enable']).ravel()[0]), 1)
+        self.assertEqual(
+            mol.symmetry_metadata['response_symmetry']['status'], 'active')
+
+    def test_a_bail_clears_both_the_table_and_its_metadata(self):
+        """A stale table is worse than none: it is well formed, just wrong."""
+        mol, *_ = _staging_molecule(3)
+        mol.stage_response_symmetry()
+        self.assertIn('OQP::sym_pair_irrep', mol.data)
+
+        del mol.symmetry_metadata['detection']          # next step: no detection
+        self.assertFalse(mol.stage_response_symmetry())
+        self.assertNotIn('OQP::sym_pair_irrep', mol.data)
+        self.assertIsNone(mol.symmetry_metadata.get('response_symmetry'))
+
+
+class LabelMoIsADisplayFlagTests(unittest.TestCase):
+    """label_mo=false must not disable the irrep computation."""
+
+    def _mol(self):
+        meta = {
+            'status': 'enabled',
+            'label_mo': False,
+            'detection': {'character_table': C2V, 'operations': []},
+        }
+        mol = _molecule({'symmetry': {'enabled': 'true', 'label_mo': False}}, meta)
+        # Stop the method just past the label_mo gate, so reaching this stub is
+        # the observable proof that the gate was bypassed.
+        mol._symmetry_labeling_inputs = lambda: (None, None, 0, 'skipped_probe')
+        return mol
+
+    def test_display_off_suppresses_an_ordinary_call(self):
+        mol = self._mol()
+        self.assertIsNone(mol.label_molecular_orbitals())
+        self.assertNotIn('mo_labels', mol.symmetry_metadata)
+
+    def test_required_bypasses_the_display_flag(self):
+        mol = self._mol()
+        self.assertIsNone(mol.label_molecular_orbitals(required=True))
+        self.assertEqual(mol.symmetry_metadata['mo_labels']['status'],
+                         'skipped_probe')
+
+    def test_required_is_not_the_default(self):
+        import inspect
+        molecule_module = load_molecule_module()
+        sig = inspect.signature(molecule_module.Molecule.label_molecular_orbitals)
+        self.assertIs(sig.parameters['required'].default, False)
+
+    def test_staging_gets_labels_even_with_the_display_off(self):
+        """The end-to-end consequence: the table is still staged."""
+        mol, na, nb, nbf = _staging_molecule(3)
+        mol.symmetry_metadata['label_mo'] = False
+        self.assertTrue(mol.stage_response_symmetry())
+        self.assertEqual(np.asarray(mol.data['OQP::sym_pair_irrep']).size,
+                         na * (nbf - nb))
+
+
+class FullGroupTagsAreClearedTests(unittest.TestCase):
+    """A declined or failed full tier must not leave its blocks behind.
+
+    Their mere presence makes the Fortran side take the blocked path, which
+    then returns on a size mismatch -- skipping the abelian symmetrization
+    entirely, and silently.
+    """
+
+    def test_clearing_removes_both_the_tag_and_the_metadata(self):
+        meta = {'reduction_maps_full': {'n_operations': 24}}
+        data = FakeData({'OQP::sym_op_blocks': np.zeros(4)})
+        mol = _molecule({}, meta, data)
+        mol._clear_full_group_tags(meta)
+        self.assertNotIn('OQP::sym_op_blocks', mol.data)
+        self.assertNotIn('reduction_maps_full', meta)
+
+    def test_clearing_is_safe_when_nothing_was_staged(self):
+        mol = _molecule({}, {}, FakeData())
+        mol._clear_full_group_tags({})  # must not raise
 
 
 class TdMultiplicityKeyTests(unittest.TestCase):
     """The schema key is 'multiplicity'; 'mult' is only an alias."""
 
     def test_schema_key_is_preferred(self):
-        mol = _molecule({'tdhf': {'multiplicity': 3}})
-        self.assertEqual(mol._td_multiplicity(), 3)
+        self.assertEqual(_molecule({'tdhf': {'multiplicity': 3}})._td_multiplicity(), 3)
 
     def test_alias_still_works_for_hand_written_configs(self):
-        mol = _molecule({'tdhf': {'mult': 3}})
-        self.assertEqual(mol._td_multiplicity(), 3)
+        self.assertEqual(_molecule({'tdhf': {'mult': 3}})._td_multiplicity(), 3)
 
     def test_schema_key_wins_over_the_alias(self):
         mol = _molecule({'tdhf': {'multiplicity': 5, 'mult': 1}})
@@ -52,73 +237,37 @@ class TdMultiplicityKeyTests(unittest.TestCase):
         self.assertIsNone(_molecule({})._td_multiplicity())
         self.assertIsNone(_molecule({'tdhf': {}})._td_multiplicity())
         self.assertIsNone(_molecule({'tdhf': {'multiplicity': ''}})._td_multiplicity())
-        self.assertIsNone(_molecule({'tdhf': {'multiplicity': 'triplet'}})._td_multiplicity())
+        self.assertIsNone(_molecule({'tdhf': {'multiplicity': 'x'}})._td_multiplicity())
 
-
-class LabelMoIsADisplayFlagTests(unittest.TestCase):
-    """label_mo=false must not disable the irrep computation."""
-
-    def _mol(self, label_mo):
-        # 'detection' left absent: label_molecular_orbitals returns None there
-        # too, so reaching that return proves the label_mo gate was passed.
-        return _molecule(
-            {'symmetry': {'enabled': 'true', 'label_mo': label_mo}},
-            {'status': 'enabled', 'label_mo': label_mo},
-        )
-
-    def test_display_off_still_computes_when_required(self):
-        mol = self._mol(False)
-        # Without required=True the method returns before it ever looks for
-        # 'detection'; with it, the flag is bypassed and the absent detection
-        # is what stops it. Distinguish the two by the metadata side effect
-        # neither path writes, and by the flag itself staying false.
-        self.assertIsNone(mol.label_molecular_orbitals())
-        self.assertIsNone(mol.label_molecular_orbitals(required=True))
-        self.assertFalse(mol.symmetry_metadata['label_mo'])
-
-    def test_required_is_not_the_default(self):
-        """An ordinary call must keep honouring the user's display choice."""
-        import inspect
-        molecule_module = load_molecule_module()
-        sig = inspect.signature(molecule_module.Molecule.label_molecular_orbitals)
-        self.assertIs(sig.parameters['required'].default, False)
-
-    def test_staging_asks_for_the_labels_it_needs(self):
-        """stage_response_symmetry must pass required=True.
-
-        Checked on the source rather than by running it: the live path needs a
-        converged SCF, and the point of the assertion is that the coupling is
-        not reintroduced.
-        """
-        from pathlib import Path
-        src = (Path(__file__).resolve().parents[1]
-               / 'pyoqp' / 'oqp' / 'molecule' / 'molecule.py').read_text()
-        body = src.split('def stage_response_symmetry', 1)[1]
-        body = body.split('\n    def ', 1)[0]
-        self.assertIn('label_molecular_orbitals(required=True)', body)
-
-
-class QuintetResponseSpaceTests(unittest.TestCase):
-    """Quintet MRSF stages beta-occupied to alpha-virtual."""
-
-    def test_quintet_branch_is_selected_on_multiplicity_five(self):
-        mol = _molecule({'tdhf': {'type': 'mrsf', 'multiplicity': 5}})
-        self.assertEqual(mol._td_multiplicity(), 5)
-
-    def test_triplet_mrsf_keeps_the_original_space(self):
+    def test_the_schema_default_is_reachable_through_the_helper(self):
+        """Guards the actual defect: reading only 'mult' made every validated
+        config fall through, so `terms` was never built."""
         mol = _molecule({'tdhf': {'type': 'mrsf', 'multiplicity': 3}})
-        self.assertNotEqual(mol._td_multiplicity(), 5)
+        self.assertEqual(f"{mol._td_multiplicity()}A1", '3A1')
 
-    def test_both_staging_and_labelling_branch_on_the_quintet(self):
-        """The two sites must agree; fixing one and not the other is how the
-        labels end up computed from a misread buffer."""
-        from pathlib import Path
-        src = (Path(__file__).resolve().parents[1]
-               / 'pyoqp' / 'oqp' / 'molecule' / 'molecule.py').read_text()
-        for method in ('stage_response_symmetry', 'label_excited_states'):
-            body = src.split(f'def {method}', 1)[1].split('\n    def ', 1)[0]
-            self.assertIn("_td_multiplicity() == 5", body,
-                          f'{method} does not special-case quintet MRSF')
+
+class StaleModeLabelsTests(unittest.TestCase):
+    """Mode labels must never outlive the modes they describe."""
+
+    def test_labels_are_dropped_when_labelling_is_skipped(self):
+        meta = {
+            'status': 'enabled',
+            'label_modes': False,
+            'mode_labels': {'status': 'ok', 'labels': ['a1', 'a1', 'b2']},
+        }
+        mol = _molecule({}, meta)
+        self.assertIsNone(mol.label_normal_modes())
+        self.assertNotIn('mode_labels', meta)
+
+    def test_labels_are_dropped_when_detection_is_unavailable(self):
+        meta = {
+            'status': 'enabled',
+            'label_modes': True,
+            'mode_labels': {'status': 'ok', 'labels': ['a1', 'a1', 'b2']},
+        }
+        mol = _molecule({}, meta)
+        self.assertIsNone(mol.label_normal_modes())
+        self.assertNotIn('mode_labels', meta)
 
 
 if __name__ == '__main__':

--- a/tests/test_response_symmetry_staging_gates.py
+++ b/tests/test_response_symmetry_staging_gates.py
@@ -297,7 +297,7 @@ class StaleMoLabelsTests(unittest.TestCase):
     then well formed and describes the wrong orbitals.
     """
 
-    def _mol(self, labels_key, current_geom):
+    def _mol(self, labels_key, current_geom, orbitals=None):
         meta = {
             'status': 'enabled',
             'label_mo': False,
@@ -305,30 +305,58 @@ class StaleMoLabelsTests(unittest.TestCase):
             'mo_labels': {'status': 'ok', 'geometry_key': labels_key,
                           'alpha': {'labels': ['a1', 'b2']}},
         }
-        mol = _molecule({'tdhf': {'type': 'mrsf'}}, meta)
+        data = FakeData()
+        if orbitals is not None:
+            data['OQP::VEC_MO_A'] = orbitals
+        mol = _molecule({'tdhf': {'type': 'mrsf'}}, meta, data)
         mol.get_system = lambda: current_geom
         return mol
 
     def test_labels_from_the_same_geometry_are_reused(self):
-        mol = self._mol(None, [0.0, 0.0, 0.0])
+        mol = self._mol(None, [0.0, 0.0, 0.0], orbitals=np.eye(2))
         key = mol._symmetry_geometry_key()
         mol.symmetry_metadata['mo_labels']['geometry_key'] = key
         self.assertIsNotNone(mol._usable_mo_labels(mol.symmetry_metadata))
 
     def test_labels_from_a_different_geometry_are_rejected(self):
-        mol = self._mol('a-key-from-some-other-structure', [0.0, 0.0, 0.0])
+        mol = self._mol('a-key-from-some-other-structure', [0.0, 0.0, 0.0], orbitals=np.eye(2))
         self.assertIsNone(mol._usable_mo_labels(mol.symmetry_metadata))
 
     def test_a_moved_atom_changes_the_key(self):
-        a = self._mol(None, [0.0, 0.0, 0.0])._symmetry_geometry_key()
-        b = self._mol(None, [0.0, 0.0, 0.001])._symmetry_geometry_key()
+        a = self._mol(None, [0.0, 0.0, 0.0], orbitals=np.eye(2))._symmetry_geometry_key()
+        b = self._mol(None, [0.0, 0.0, 0.001], orbitals=np.eye(2))._symmetry_geometry_key()
         self.assertIsNotNone(a)
         self.assertNotEqual(a, b)
+
+    def test_same_geometry_but_different_orbitals_rejects_the_labels(self):
+        """MO irreps describe the SCF SOLUTION, not just the structure.
+
+        Identical coordinates with a different converged solution -- another
+        guess, an orbital swap, a symmetry-broken stability solution -- must
+        not reuse the old labels. A coordinates-only key accepted them.
+        """
+        mol = self._mol(None, [0.0, 0.0, 0.0], orbitals=np.eye(2))
+        mol.data['OQP::VEC_MO_A'] = np.array([[1.0, 0.0], [0.0, 1.0]])
+        key_a = mol._symmetry_geometry_key()
+        mol.data['OQP::VEC_MO_A'] = np.array([[0.0, 1.0], [1.0, 0.0]])
+        key_b = mol._symmetry_geometry_key()
+        self.assertIsNotNone(key_a)
+        self.assertNotEqual(key_a, key_b,
+                            'swapped orbitals must change the label key')
+
+        mol.symmetry_metadata['mo_labels']['geometry_key'] = key_a
+        self.assertIsNone(mol._usable_mo_labels(mol.symmetry_metadata))
+
+    def test_without_orbitals_there_is_no_key(self):
+        """Labels are built FROM the orbitals; with none there is nothing
+        meaningful to key against."""
+        mol = self._mol(None, [0.0, 0.0, 0.0])
+        self.assertIsNone(mol._symmetry_geometry_key())
 
     def test_unknown_geometry_keeps_the_cached_labels(self):
         """None means 'cannot tell'. Recomputing unconditionally would pay the
         dense O(|G| n_AO^3) relabelling on every call."""
-        mol = self._mol('whatever', [0.0, 0.0, 0.0])
+        mol = self._mol('whatever', [0.0, 0.0, 0.0], orbitals=np.eye(2))
         mol.get_system = lambda: (_ for _ in ()).throw(RuntimeError('no geometry'))
         self.assertIsNone(mol._symmetry_geometry_key())
         self.assertIsNotNone(mol._usable_mo_labels(mol.symmetry_metadata))


### PR DESCRIPTION
Follow-up to #317, which merged before these landed. An adversarial second-opinion review **of my own fix commits on that PR** found five defects in them; #317 was merged at `88184e7`, so all five are currently on `main`.

They share one shape: **metadata or tags staged for one step surviving into a step they no longer describe.** Fortran keys off the *presence* of these tags, so a stale one silently selects a path that then bails on a size mismatch — no error, no warning, just work quietly not done.

## The five

1. **Stale full-group blocks survive the DFT decline** (the one with a numerical consequence). The decline sets `want_full=False` but left `OQP::sym_op_blocks` and `meta['reduction_maps_full']` from an earlier staging. Nothing on the abelian path overwrites them — only the full tier writes them — so a molecule that staged the full group once and later fell back keeps taking the blocked path: `int2` selects it, `symmetrize_skeleton_fock` returns on the size mismatch, and the abelian skeleton symmetrization is **skipped entirely**. Now cleared on every entry, so the tier is a property of the staging call, not of the molecule's history.

2. **`label_excited_states` still honoured `label_mo`** — it called `label_molecular_orbitals()` without `required=True`, so a direct call with `label_mo=false` produced no state labels. The `single_point` path hid it by staging first.

3. **`label_normal_modes` left stale labels behind** when labelling was disabled or detection missing, so a molecule that labelled one Hessian and then read a cached one could print the *previous* labels against the new modes whenever the counts matched. Wrong labels are worse than no column — nothing marks them stale.

4. **`_clear_response_symmetry_tags` dropped the tags but not the metadata**, leaving a previous step's `active`/`pair_table_staged` in serialized metadata while no table existed.

5. **The decline message advised "Set method=hf"** — which is what a DFT user already has, since OpenQP selects DFT with `method=hf` plus a functional. Now says to remove the functional.

## Tests

The tests added in #317 are **rewritten**, because they were not testing. They asserted on *source text* — that a call site still reads `required=True`, that a branch still mentions `_td_multiplicity() == 5` — which passes on a dead branch, a wrong slice, or a comment.

They now drive the real methods against injected data and assert on what was staged: quintet pair-table length **and contents** against `product_irrep`, the projection flag and status, that a bail clears both table and metadata, that `required=True` bypasses the display flag while an ordinary call does not, that full-group tags are dropped, that stale mode labels are.

Every one was **mutation-checked** — disabling the quintet branch, un-bypassing `label_mo`, and each of the three clears in turn each makes the corresponding test fail. A test that has not been seen to fail is not evidence.

## Verification

All re-run after these edits:

| check | result |
| --- | --- |
| quintet | `m=5` stages 91 = `nb*(nbf-na)`; `m=3` stages 135 = `na*(nbf-nb)` |
| `label_mo=false` | table not printed, irreps still staged, third root `0.17574625` (correct; without the fix `0.23436580`) |
| `[hess] read=true` | Symmetry column still printed |
| full tier | DFT declines, and `dft_full` is byte-identical to `dft_abelian` |
| pytest | 1104 passed |

## Unrelated finding

`examples/OPT/HCN_RHF-DFT_IRC_OQP` fails its energy check by `0.0184` Ha locally. It is **not** from #317 — identical with `[symmetry] enabled=false` — and **CI never runs it**: the example is installed into the wheel but no `Running test for HCN_RHF-DFT_IRC` line appears in any CI leg (CI executes 255 of the 281 the local runner picks up). Worth its own issue; flagging it here rather than silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)