### PR TITLE
docs/ci: correct v1.3.0 notes and OCI attestation verification

### DIFF
--- a/.github/scripts/verify_oci_artifact.py
+++ b/.github/scripts/verify_oci_artifact.py
@@ -33,6 +33,10 @@ IN_TOTO_STATEMENT_TYPES = {
 IN_TOTO_PAYLOAD_MEDIA_TYPES = {"application/vnd.in-toto+json"}
 OCI_IMAGE_LAYOUT_VERSION = "1.0.0"
 OCI_IMAGE_CONFIG_MEDIA_TYPE = "application/vnd.oci.image.config.v1+json"
+OCI_EMPTY_CONFIG_MEDIA_TYPE = "application/vnd.oci.empty.v1+json"
+BUILDKIT_ATTESTATION_ARTIFACT_TYPE = (
+    "application/vnd.docker.attestation.manifest.v1+json"
+)
 OCI_INDEX_MEDIA_TYPES = {
     "application/vnd.oci.image.index.v1+json",
     "application/vnd.docker.distribution.manifest.list.v2+json",
@@ -568,14 +572,28 @@ def verify(
                         "attestation config descriptor must be an object"
                     )
                 if has_layers:
-                    if (
-                        attestation_config.get("mediaType")
-                        != OCI_IMAGE_CONFIG_MEDIA_TYPE
-                    ):
+                    config_media_type = attestation_config.get("mediaType")
+                    if config_media_type not in {
+                        OCI_IMAGE_CONFIG_MEDIA_TYPE,
+                        OCI_EMPTY_CONFIG_MEDIA_TYPE,
+                    }:
                         raise ValueError(
-                            "image-shaped attestation config has an invalid media type"
+                            "image-shaped attestation config has an invalid media type: "
+                            f"{config_media_type}"
                         )
-                    _descriptor_json(archive, attestation_config)
+                    config_payload = _descriptor_json(archive, attestation_config)
+                    if config_media_type == OCI_EMPTY_CONFIG_MEDIA_TYPE:
+                        if (
+                            manifest.get("artifactType")
+                            != BUILDKIT_ATTESTATION_ARTIFACT_TYPE
+                        ):
+                            raise ValueError(
+                                "OCI artifact attestation has an invalid artifactType"
+                            )
+                        if config_payload:
+                            raise ValueError(
+                                "OCI artifact attestation config is not empty"
+                            )
                 else:
                     _descriptor_bytes(archive, attestation_config)
             elif has_layers:

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -6,11 +6,6 @@ the OpenQP Research License 1.0 and the separate commercial-licensing model.
 The v1.2.1 and earlier release tags retain the GPLv3 terms that accompanied
 those copies.
 
-The separately maintained OpenQP-XTB, MRSF-TDDFTB backend, and OpenQP-GPU
-packages are private and are not components of this public release. Public
-compatibility hooks in OpenQP do not include those implementations or confer
-access to them.
-
 ## Highlights
 
 - Added parallel closed- and open-shell CCSD(T), including restricted,

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -6,6 +6,11 @@ the OpenQP Research License 1.0 and the separate commercial-licensing model.
 The v1.2.1 and earlier release tags retain the GPLv3 terms that accompanied
 those copies.
 
+The separately maintained OpenQP-XTB, MRSF-TDDFTB backend, and OpenQP-GPU
+packages are private and are not components of this public release. Public
+compatibility hooks in OpenQP do not include those implementations or confer
+access to them.
+
 ## Highlights
 
 - Added parallel closed- and open-shell CCSD(T), including restricted,
@@ -22,10 +27,6 @@ those copies.
   Dyson-orbital exports
   ([#290](https://github.com/Open-Quantum-Platform/openqp/pull/290),
   [#310](https://github.com/Open-Quantum-Platform/openqp/pull/310)).
-- Added the optional OpenQP-XTB backend and a complete, separately loaded GPU
-  attachment for SCF, DFT, MRSF, and gradients
-  ([#269](https://github.com/Open-Quantum-Platform/openqp/pull/269),
-  [#265](https://github.com/Open-Quantum-Platform/openqp/pull/265)).
 - Adopted the prospective research/commercial dual-license structure. Earlier
   GPL-tagged releases remain GPL and are not retroactively relicensed
   ([#292](https://github.com/Open-Quantum-Platform/openqp/pull/292)).
@@ -83,26 +84,8 @@ those copies.
   ([#311](https://github.com/Open-Quantum-Platform/openqp/pull/311),
   [#312](https://github.com/Open-Quantum-Platform/openqp/pull/312)).
 
-### Tight-binding, XTB, GPU, and interoperability
+### Interoperability
 
-- Added `method=xtb`, connecting the separately loaded OpenQP-XTB LC-GFN1-xTB
-  and MRSF backend through a versioned runtime ABI
-  ([#269](https://github.com/Open-Quantum-Platform/openqp/pull/269)).
-- Added an optional, default-off `openqp-gpu` attachment that can accelerate
-  SCF, DFT, MRSF response, and gradients without making the GPU package a core
-  link dependency
-  ([#265](https://github.com/Open-Quantum-Platform/openqp/pull/265)).
-- Stabilized DFTB ground-state continuity and geometry recovery, added an ABI-4
-  cold-TRAH recovery route, and prevented energy-only gradient backfills from
-  being treated as analytic gradients
-  ([#287](https://github.com/Open-Quantum-Platform/openqp/pull/287),
-  [#288](https://github.com/Open-Quantum-Platform/openqp/pull/288)).
-- Added conventional top-level `td-dftb`, `sf`, and `mrsf` routes; RKS, ROKS,
-  CUKS, and UKS ground references; solution-following warm starts; the DTCAM-TB2
-  response operator; and concise `dtcam`/`ob2` model names with compatibility
-  aliases
-  ([#294](https://github.com/Open-Quantum-Platform/openqp/pull/294),
-  [#297](https://github.com/Open-Quantum-Platform/openqp/pull/297)).
 - Added portable Molden MO exports, frequency data, structured Hessian output,
   and Dyson-orbital exports for viewers and external workflows
   ([#310](https://github.com/Open-Quantum-Platform/openqp/pull/310)).
@@ -132,8 +115,8 @@ those copies.
   ([d1267f2](https://github.com/Open-Quantum-Platform/openqp/commit/d1267f2),
   [3fdbba7](https://github.com/Open-Quantum-Platform/openqp/commit/3fdbba7)).
 - Expanded automated coverage for crossing objectives, NAMD records, ODP/WHAM,
-  state tracking, symmetry staging, CCSD(T), ROHF MP2, DFTB/XTB ABIs, Molden
-  output, and memory guards.
+  state tracking, symmetry staging, CCSD(T), ROHF MP2, Molden output, and memory
+  guards.
 
 ## Packaging, licensing, and CI
 
@@ -175,15 +158,10 @@ artifact/provenance requirement for the exact tag and commit.
 
 ## Compatibility and upgrade notes
 
-- The default MRSF-TDDFTB operator is the tuned DTCAM model. Historical model
-  spellings remain accepted as aliases, but new inputs should use `dtcam` or
-  `ob2` as documented.
 - Symmetry detection and labels are enabled by default. Workflows that require
   deliberately symmetry-free ordering should disable symmetry explicitly.
 - Native MECP searches now default to SQP. Select another supported crossing
   objective explicitly when reproducing an older trajectory.
-- OpenQP-XTB and OpenQP-GPU remain separately built and dynamically loaded; they
-  are not silently bundled into the OpenQP core.
 
 ## Contributors
 

--- a/tests/test_docker_distribution.py
+++ b/tests/test_docker_distribution.py
@@ -503,6 +503,86 @@ libgfortran.so.5 => /lib/x86_64-linux-gnu/libgfortran.so.5 (0x1234)
             self._write_oci(artifact, index, blobs)
             summary = OCI_VERIFY.verify(artifact, "1.3.0", "a" * 40)
 
+            empty_attestation_config = self._json_blob(
+                blobs,
+                {},
+                "application/vnd.oci.empty.v1+json",
+            )
+            artifact_attestation_manifest = json.loads(
+                blobs[OCI_VERIFY._blob_path(attestation["digest"])]
+            )
+            artifact_attestation_manifest.update(
+                {
+                    "artifactType": (
+                        "application/vnd.docker.attestation.manifest.v1+json"
+                    ),
+                    "config": empty_attestation_config,
+                }
+            )
+            artifact_attestation = self._json_blob(
+                blobs, artifact_attestation_manifest
+            )
+            artifact_attestation["platform"] = dict(attestation["platform"])
+            artifact_attestation["annotations"] = dict(
+                attestation["annotations"]
+            )
+            artifact_attestation_index = json.dumps(
+                {
+                    "schemaVersion": 2,
+                    "manifests": [image, artifact_attestation],
+                },
+                sort_keys=True,
+            ).encode()
+            artifact_attestation_candidate = (
+                Path(temporary) / "candidate-artifact-attestation.oci.tar"
+            )
+            self._write_oci(
+                artifact_attestation_candidate,
+                artifact_attestation_index,
+                blobs,
+            )
+            OCI_VERIFY.verify(
+                artifact_attestation_candidate, "1.3.0", "a" * 40
+            )
+
+            nonempty_attestation_config = self._json_blob(
+                blobs,
+                {"unexpected": True},
+                "application/vnd.oci.empty.v1+json",
+            )
+            nonempty_attestation_manifest = {
+                **artifact_attestation_manifest,
+                "config": nonempty_attestation_config,
+            }
+            nonempty_attestation = self._json_blob(
+                blobs, nonempty_attestation_manifest
+            )
+            nonempty_attestation["platform"] = dict(attestation["platform"])
+            nonempty_attestation["annotations"] = dict(
+                attestation["annotations"]
+            )
+            nonempty_attestation_index = json.dumps(
+                {
+                    "schemaVersion": 2,
+                    "manifests": [image, nonempty_attestation],
+                },
+                sort_keys=True,
+            ).encode()
+            nonempty_attestation_candidate = (
+                Path(temporary) / "candidate-nonempty-attestation.oci.tar"
+            )
+            self._write_oci(
+                nonempty_attestation_candidate,
+                nonempty_attestation_index,
+                blobs,
+            )
+            with self.assertRaisesRegex(
+                ValueError, "attestation config is not empty"
+            ):
+                OCI_VERIFY.verify(
+                    nonempty_attestation_candidate, "1.3.0", "a" * 40
+                )
+
             nonfinite_index = (
                 b'{"schemaVersion":2,"invalid":NaN,"manifests":'
                 + json.dumps([image, attestation], sort_keys=True).encode()


### PR DESCRIPTION
## Summary

- remove feature bullets that incorrectly advertised private backend packages as v1.3.0 contents
- keep all existing examples and public compatibility hooks unchanged
- accept BuildKit OCI-artifact attestations that use the standard empty JSON config descriptor
- require the exact BuildKit attestation artifact type and an actually empty config payload

## Validation

- `git diff --check`
- `/opt/homebrew/bin/python3.11 -m unittest tests.test_docker_distribution` (12 tests)
- verified the public GitHub Release has no uploaded assets
- cancelled the release-event wheel and OCI candidate workflows before publication

## Release-page correction

The published GitHub Release body has already been updated to match the corrected notes. No PyPI, wheel, or Docker artifact was published.

The OCI verifier update follows the current BuildKit attestation storage format while retaining support for the legacy image-config representation.