### PR TITLE
Fix zero-beta initialization across native guesses

### DIFF
--- a/source/guess.F90
+++ b/source/guess.F90
@@ -50,8 +50,11 @@ subroutine get_ab_initio_density(alpha_density,alpha_orbital,beta_density,beta_o
    call orb_to_dens(alpha_density,alpha_orbital,occno,na2,nbasis,nbasis)
 
    if (nb == 0) then
-     beta_density = 0
-     if (scftype == 2) beta_orbital = 0
+     ! A fully spin-polarized reference has an empty beta density, but it still
+     ! needs a complete beta orbital basis.  In particular, the Hückel driver
+     ! has already copied its projected alpha orbitals to beta for UHF/ROHF.
+     ! Preserve those orbitals and zero only the unoccupied-spin density.
+     if (present(beta_density)) beta_density = 0.0_dp
 
    else
      select case (scftype)

--- a/source/modules/guess_hcore.F90
+++ b/source/modules/guess_hcore.F90
@@ -96,8 +96,13 @@ contains
   !
   !  Calculate Hcore MO
     call Get_ab_initio_orbital(Hcore, MO_A, MO_Energy_A, QMat)
-  !  For ROHF/UHF
-    if (INFOS%control%scftype >= 2) MO_B = MO_A
+  !  For ROHF/UHF, both spin channels start from the same one-electron
+  !  eigenvectors and eigenvalues.  Keep the beta spectrum defined even when
+  !  the beta occupation is empty.
+    if (INFOS%control%scftype >= 2) then
+      MO_B = MO_A
+      MO_Energy_B = MO_Energy_A
+    end if
   !
   ! Calculate Density Matrix
   ! RHF

--- a/source/modules/guess_sap.F90
+++ b/source/modules/guess_sap.F90
@@ -138,7 +138,10 @@ contains
   ! Solve F C = eps S C
     call get_qmat_cached(infos, smat, qmat, nbf)
     call get_ab_initio_orbital(fock, MO_A, MO_Energy_A, QMat)
-    if (infos%control%scftype >= 2) MO_B = MO_A
+    if (infos%control%scftype >= 2) then
+      MO_B = MO_A
+      MO_Energy_B = MO_Energy_A
+    end if
 
   ! Density matrix
     if (infos%control%scftype == 1) then

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -1546,17 +1546,21 @@ contains
         ga = mo_e_a(nelec_a+1) - mo_e_a(nelec_a)
         gap_out = ga
       end if
-      if (nelec_b > 0 .and. present(mo_e_b) .and. nelec_b < size(mo_e_b)) then
-        gb = mo_e_b(nelec_b+1) - mo_e_b(nelec_b)
-        if (gap_out < 0.0_dp) then
-          gap_out = gb
-        else
-          gap_out = min(gap_out, gb)
+      if (nelec_b > 0 .and. present(mo_e_b)) then
+        if (nelec_b < size(mo_e_b)) then
+          gb = mo_e_b(nelec_b+1) - mo_e_b(nelec_b)
+          if (gap_out < 0.0_dp) then
+            gap_out = gb
+          else
+            gap_out = min(gap_out, gb)
+          end if
         end if
       end if
 
     case (scf_rohf) !ROHF
-      gap_out = mo_e_a(nelec_a+1) - mo_e_a(nelec_a)
+      if (nelec_a > 0 .and. nelec_a < size(mo_e_a)) then
+        gap_out = mo_e_a(nelec_a+1) - mo_e_a(nelec_a)
+      end if
     end select
 
     if (gap_out >= 0.0_dp .and. gap_out < gap_crit .and. vshift > 0.0_dp) then

--- a/source/scf.F90
+++ b/source/scf.F90
@@ -1538,9 +1538,22 @@ contains
       gap_out = mo_e_a(nocc+1) - mo_e_a(nocc)
 
     case (scf_uhf) !UHF
-      ga = mo_e_a(nelec_a+1) - mo_e_a(nelec_a)
-      gb = mo_e_b(nelec_b+1) - mo_e_b(nelec_b)
-      gap_out = min(ga, gb)
+      ! An empty spin channel has no HOMO and therefore contributes no
+      ! occupied-virtual gap.  Use whichever occupied spin channels have a
+      ! well-defined HOMO/LUMO pair instead of indexing orbital zero when
+      ! nelec_b == 0 (the fully spin-polarized UHF case).
+      if (nelec_a > 0 .and. nelec_a < size(mo_e_a)) then
+        ga = mo_e_a(nelec_a+1) - mo_e_a(nelec_a)
+        gap_out = ga
+      end if
+      if (nelec_b > 0 .and. present(mo_e_b) .and. nelec_b < size(mo_e_b)) then
+        gb = mo_e_b(nelec_b+1) - mo_e_b(nelec_b)
+        if (gap_out < 0.0_dp) then
+          gap_out = gb
+        else
+          gap_out = min(gap_out, gb)
+        end if
+      end if
 
     case (scf_rohf) !ROHF
       gap_out = mo_e_a(nelec_a+1) - mo_e_a(nelec_a)

--- a/tests/test_huckel_zero_beta.py
+++ b/tests/test_huckel_zero_beta.py
@@ -19,7 +19,7 @@ basis=6-31g
 method=hf
 
 [guess]
-type=huckel
+type={guess_type}
 save_mol=false
 
 [scf]
@@ -44,8 +44,8 @@ def _runtime_available():
 
 
 @unittest.skipUnless(_runtime_available(), "compiled OpenQP runtime not available")
-class HuckelZeroBetaTest(unittest.TestCase):
-    def _run_case(self, scf_type):
+class NativeGuessZeroBetaTest(unittest.TestCase):
+    def _run_case(self, guess_type, scf_type):
         import oqp
         from oqp.library.single_point import SinglePoint
         from oqp.pyoqp import Runner
@@ -53,7 +53,9 @@ class HuckelZeroBetaTest(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix=f"oqp_huckel_zero_beta_{scf_type}_") as tmp:
             root = Path(tmp)
             input_file = root / "h.inp"
-            input_file.write_text(INPUT_TEMPLATE.format(scf_type=scf_type))
+            input_file.write_text(
+                INPUT_TEMPLATE.format(guess_type=guess_type, scf_type=scf_type)
+            )
             runner = Runner(
                 project=f"h_{scf_type}",
                 input_file=str(input_file),
@@ -68,22 +70,44 @@ class HuckelZeroBetaTest(unittest.TestCase):
             self.assertEqual(int(runner.mol.data["nelec_B"]), 0)
 
             beta_density = np.asarray(runner.mol.data["OQP::DM_B"], dtype=float)
+            alpha_orbitals = np.asarray(
+                runner.mol.data["OQP::VEC_MO_A"], dtype=float
+            )
             beta_orbitals = np.asarray(
                 runner.mol.data["OQP::VEC_MO_B"], dtype=float
             )
+            alpha_energies = np.asarray(
+                runner.mol.data["OQP::E_MO_A"], dtype=float
+            )
+            beta_energies = np.asarray(
+                runner.mol.data["OQP::E_MO_B"], dtype=float
+            )
             nbf = int(runner.mol.data.get_basis()["nbf"])
+            alpha_orbitals = alpha_orbitals.reshape((nbf, nbf))
             beta_orbitals = beta_orbitals.reshape((nbf, nbf))
 
             self.assertTrue(np.all(np.isfinite(beta_orbitals)))
             self.assertEqual(np.linalg.matrix_rank(beta_orbitals), nbf)
             self.assertGreater(np.linalg.norm(beta_orbitals), 0.0)
             self.assertEqual(np.linalg.norm(beta_density), 0.0)
+            np.testing.assert_allclose(
+                beta_orbitals, alpha_orbitals, rtol=0.0, atol=0.0
+            )
+            np.testing.assert_allclose(
+                beta_energies, alpha_energies, rtol=0.0, atol=0.0
+            )
 
     def test_uhf_huckel_preserves_empty_beta_orbital_basis(self):
-        self._run_case("uhf")
+        self._run_case("huckel", "uhf")
 
     def test_rohf_huckel_preserves_empty_beta_orbital_basis(self):
-        self._run_case("rohf")
+        self._run_case("huckel", "rohf")
+
+    def test_all_native_guesses_support_empty_beta_channel(self):
+        for guess_type in ("hcore", "huckel", "modhuckel", "minao", "sap"):
+            for scf_type in ("uhf", "rohf"):
+                with self.subTest(guess_type=guess_type, scf_type=scf_type):
+                    self._run_case(guess_type, scf_type)
 
 
 if __name__ == "__main__":

--- a/tests/test_huckel_zero_beta.py
+++ b/tests/test_huckel_zero_beta.py
@@ -1,0 +1,90 @@
+"""Regression tests for Hückel guesses with an empty beta channel."""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+INPUT_TEMPLATE = """[input]
+system=
+ H  0.0  0.0  0.0
+charge=0
+runtype=energy
+basis=6-31g
+method=hf
+
+[guess]
+type=huckel
+save_mol=false
+
+[scf]
+type={scf_type}
+multiplicity=2
+maxit=50
+conv=1.0e-9
+stability=false
+save_molden=false
+"""
+
+
+def _runtime_available():
+    try:
+        os.environ.setdefault("OPENQP_ROOT", str(ROOT))
+        os.environ.setdefault("OMP_NUM_THREADS", "1")
+        import oqp  # noqa: F401
+        from oqp.pyoqp import Runner  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@unittest.skipUnless(_runtime_available(), "compiled OpenQP runtime not available")
+class HuckelZeroBetaTest(unittest.TestCase):
+    def _run_case(self, scf_type):
+        import oqp
+        from oqp.library.single_point import SinglePoint
+        from oqp.pyoqp import Runner
+
+        with tempfile.TemporaryDirectory(prefix=f"oqp_huckel_zero_beta_{scf_type}_") as tmp:
+            root = Path(tmp)
+            input_file = root / "h.inp"
+            input_file.write_text(INPUT_TEMPLATE.format(scf_type=scf_type))
+            runner = Runner(
+                project=f"h_{scf_type}",
+                input_file=str(input_file),
+                log=str(root / "h.log"),
+                silent=1,
+                usempi=False,
+            )
+            runner.mol.data["OQP::log_filename"] = str(root / "h.log")
+            oqp.oqp_banner(runner.mol)
+            SinglePoint(runner.mol)._prep_guess()
+
+            self.assertEqual(int(runner.mol.data["nelec_B"]), 0)
+
+            beta_density = np.asarray(runner.mol.data["OQP::DM_B"], dtype=float)
+            beta_orbitals = np.asarray(
+                runner.mol.data["OQP::VEC_MO_B"], dtype=float
+            )
+            nbf = int(runner.mol.data.get_basis()["nbf"])
+            beta_orbitals = beta_orbitals.reshape((nbf, nbf))
+
+            self.assertTrue(np.all(np.isfinite(beta_orbitals)))
+            self.assertEqual(np.linalg.matrix_rank(beta_orbitals), nbf)
+            self.assertGreater(np.linalg.norm(beta_orbitals), 0.0)
+            self.assertEqual(np.linalg.norm(beta_density), 0.0)
+
+    def test_uhf_huckel_preserves_empty_beta_orbital_basis(self):
+        self._run_case("uhf")
+
+    def test_rohf_huckel_preserves_empty_beta_orbital_basis(self):
+        self._run_case("rohf")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_huckel_zero_beta.py
+++ b/tests/test_huckel_zero_beta.py
@@ -1,6 +1,8 @@
 """Regression tests for Hückel guesses with an empty beta channel."""
 
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -43,59 +45,74 @@ def _runtime_available():
         return False
 
 
+def _probe_case(guess_type, scf_type):
+    """Run one native guess in a fresh process because OpenQP is not reentrant."""
+    from oqp.library.single_point import SinglePoint
+    from oqp.pyoqp import Runner
+
+    with tempfile.TemporaryDirectory(prefix=f"oqp_zero_beta_{scf_type}_") as tmp:
+        root = Path(tmp)
+        input_file = root / "h.inp"
+        input_file.write_text(
+            INPUT_TEMPLATE.format(guess_type=guess_type, scf_type=scf_type)
+        )
+        runner = Runner(
+            project=f"h_{scf_type}",
+            input_file=str(input_file),
+            log=str(root / "h.log"),
+            silent=1,
+            usempi=False,
+        )
+        runner.mol.data["OQP::log_filename"] = str(root / "h.log")
+        SinglePoint(runner.mol)._prep_guess()
+
+        if int(runner.mol.data["nelec_B"]) != 0:
+            raise AssertionError("expected an empty beta channel")
+
+        beta_density = np.asarray(runner.mol.data["OQP::DM_B"], dtype=float)
+        alpha_orbitals = np.asarray(
+            runner.mol.data["OQP::VEC_MO_A"], dtype=float
+        )
+        beta_orbitals = np.asarray(
+            runner.mol.data["OQP::VEC_MO_B"], dtype=float
+        )
+        alpha_energies = np.asarray(
+            runner.mol.data["OQP::E_MO_A"], dtype=float
+        )
+        beta_energies = np.asarray(
+            runner.mol.data["OQP::E_MO_B"], dtype=float
+        )
+        nbf = int(runner.mol.data.get_basis()["nbf"])
+        alpha_orbitals = alpha_orbitals.reshape((nbf, nbf))
+        beta_orbitals = beta_orbitals.reshape((nbf, nbf))
+
+        if not np.all(np.isfinite(beta_orbitals)):
+            raise AssertionError("beta orbitals contain non-finite values")
+        if np.linalg.matrix_rank(beta_orbitals) != nbf:
+            raise AssertionError("beta orbital basis is rank deficient")
+        if np.linalg.norm(beta_orbitals) == 0.0:
+            raise AssertionError("beta orbital basis was zeroed")
+        if np.linalg.norm(beta_density) != 0.0:
+            raise AssertionError("empty beta channel has nonzero density")
+        np.testing.assert_allclose(
+            beta_orbitals, alpha_orbitals, rtol=0.0, atol=0.0
+        )
+        np.testing.assert_allclose(
+            beta_energies, alpha_energies, rtol=0.0, atol=0.0
+        )
+
+
 @unittest.skipUnless(_runtime_available(), "compiled OpenQP runtime not available")
 class NativeGuessZeroBetaTest(unittest.TestCase):
     def _run_case(self, guess_type, scf_type):
-        import oqp
-        from oqp.library.single_point import SinglePoint
-        from oqp.pyoqp import Runner
-
-        with tempfile.TemporaryDirectory(prefix=f"oqp_huckel_zero_beta_{scf_type}_") as tmp:
-            root = Path(tmp)
-            input_file = root / "h.inp"
-            input_file.write_text(
-                INPUT_TEMPLATE.format(guess_type=guess_type, scf_type=scf_type)
-            )
-            runner = Runner(
-                project=f"h_{scf_type}",
-                input_file=str(input_file),
-                log=str(root / "h.log"),
-                silent=1,
-                usempi=False,
-            )
-            runner.mol.data["OQP::log_filename"] = str(root / "h.log")
-            oqp.oqp_banner(runner.mol)
-            SinglePoint(runner.mol)._prep_guess()
-
-            self.assertEqual(int(runner.mol.data["nelec_B"]), 0)
-
-            beta_density = np.asarray(runner.mol.data["OQP::DM_B"], dtype=float)
-            alpha_orbitals = np.asarray(
-                runner.mol.data["OQP::VEC_MO_A"], dtype=float
-            )
-            beta_orbitals = np.asarray(
-                runner.mol.data["OQP::VEC_MO_B"], dtype=float
-            )
-            alpha_energies = np.asarray(
-                runner.mol.data["OQP::E_MO_A"], dtype=float
-            )
-            beta_energies = np.asarray(
-                runner.mol.data["OQP::E_MO_B"], dtype=float
-            )
-            nbf = int(runner.mol.data.get_basis()["nbf"])
-            alpha_orbitals = alpha_orbitals.reshape((nbf, nbf))
-            beta_orbitals = beta_orbitals.reshape((nbf, nbf))
-
-            self.assertTrue(np.all(np.isfinite(beta_orbitals)))
-            self.assertEqual(np.linalg.matrix_rank(beta_orbitals), nbf)
-            self.assertGreater(np.linalg.norm(beta_orbitals), 0.0)
-            self.assertEqual(np.linalg.norm(beta_density), 0.0)
-            np.testing.assert_allclose(
-                beta_orbitals, alpha_orbitals, rtol=0.0, atol=0.0
-            )
-            np.testing.assert_allclose(
-                beta_energies, alpha_energies, rtol=0.0, atol=0.0
-            )
+        result = subprocess.run(
+            [sys.executable, __file__, "--probe", guess_type, scf_type],
+            cwd=ROOT,
+            env={**os.environ, "OPENQP_ROOT": str(ROOT), "OMP_NUM_THREADS": "1"},
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
     def test_uhf_huckel_preserves_empty_beta_orbital_basis(self):
         self._run_case("huckel", "uhf")
@@ -111,4 +128,7 @@ class NativeGuessZeroBetaTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    if len(sys.argv) == 4 and sys.argv[1] == "--probe":
+        _probe_case(sys.argv[2], sys.argv[3])
+    else:
+        unittest.main()


### PR DESCRIPTION
## Summary

- preserve a complete beta-spin MO basis when the beta electron count is zero while keeping the beta density exactly zero
- prevent UHF HOMO/LUMO diagnostics from indexing a nonexistent beta occupied orbital
- initialize beta orbital energies consistently for Hcore and SAP guesses
- cover Hcore, Huckel, modified Huckel, MINAO, and SAP for both UHF and ROHF zero-beta references

## Root cause

The ab initio guess path zeroed the entire beta MO matrix when `nelec_B = 0`, although later QMRSF and SCF paths still require a complete virtual beta orbital basis. The UHF gap diagnostic also indexed beta orbital zero. Hcore and SAP copied the alpha orbitals to beta but did not copy the corresponding orbital energies.

## Validation

- managed macOS arm64 build with Python 3.11, GCC/GFortran 15, OpenMP, and Accelerate ILP64; no LP64 BLAS/LAPACK leaks
- all ten native guess/SCF combinations (five guesses times UHF/ROHF) pass the zero-beta regression
- existing default-Huckel and advanced-guess tests pass
- H4 quintet QMRSF-DK smoke calculation converged in 9 SCF iterations and completed native, S3R, and Haar manifolds

This draft is based directly on the current upstream `main` and contains only the five zero-beta initialization files. The managed build and QMRSF smoke validation were performed on the descendant integration branch carrying the identical patch; upstream CI provides the clean-main integration check.
