### PR TITLE
MRSF: the ROHF Davidson trial-vector diagonal is correct as shipped; record the measurement (#328)

### DIFF
--- a/source/modules/tdhf_mrsf_energy.F90
+++ b/source/modules/tdhf_mrsf_energy.F90
@@ -491,35 +491,77 @@ contains
 
   ! Construct TD trial vector
     !
-    ! KNOWN DEFECT, left in place deliberately -- do not "fix" this in one line.
-    ! On the ROHF path the SAME array goes in as both ea and eb, and it holds
-    ! the ROHF canonical eigenvalues, i.e. the Guest-Saunders 0.5/0.5 average
-    ! 0.5*(fa(p,p)+fb(p,p)) -- not the alpha and beta Fock diagonals the sigma
-    ! actually uses. UMRSF above does it correctly from fa(i,i)/fb(i,i).
-    ! So mrinivec's xm, which orders the seeds and preconditions the residuals,
-    ! is not the diagonal of the operator being solved. The clearest symptom:
-    ! with ea == eb the open-open entry xm = 0.5*(eb(lr1)-ea(lr1)
-    ! +eb(lr2)-ea(lr2)) is IDENTICALLY ZERO for every ROHF MRSF run, while the
-    ! true one-electron value is not. Instrumented on CH2O 6-31G: the folded
-    ! open-open seed came out at exactly 0.00000000 and its two partners at
-    ! -0.19359070 / +0.19359070, perfectly antisymmetric, which is what ea == eb
-    ! forces. (xm also omits the two-electron part of the sigma entirely, on
-    ! every path -- that part is a preconditioner approximation, not a bug.)
+    ! PASSING THE SAME ARRAY AS BOTH ea AND eb ON THE ROHF PATH IS DELIBERATE
+    ! AND IS THE BETTER CHOICE.  Issue #328 proposed replacing it with the
+    ! alpha/beta Fock diagonals, as the UMRSF branch above does; measurement
+    ! rejects that.  Do not apply it.  What follows is the measurement.
     !
-    ! Correcting it MEASURABLY HELPS AND MEASURABLY HURTS. Filling both arrays
-    ! from fa/fb on the ROHF path makes H2O_BHHLYP_SOC at nstate=12 return
-    ! 0.60340877 as its 11th singlet -- a genuine root, stable at nstate=20 and
-    ! 30, that the shipped reference skips (already noted in 908496c0). The same
-    ! change also breaks six shipped tests, including SOC couplings by 9694 on
-    ! that very deck, numerical frequencies by 0.133, and it makes triplet MRSF
-    ! fail to converge outright on h2o_rohf_mrsf-t with bhhlyp and cam-b3lyp.
+    ! xm both orders the seeds and preconditions the Davidson residuals, so
+    ! what it has to approximate is the DIAGONAL OF THE OPERATOR, A(ij,ij) --
+    ! not the one-electron part of it.  The two candidates are
     !
-    ! So a real repair has to come with the reference regeneration and the
-    ! triplet convergence failure understood, not as a swap of two arguments.
+    !   xm_1e(i,j) = fb(j,j) - fa(i,i)                    [exact 1e diagonal]
+    !   xm_rohf    = eps(j) - eps(i)
+    !              = xm_1e - 0.5*[ (fb-fa)(i,i) + (fb-fa)(j,j) ]
+    !
+    ! because the ROHF canonical eigenvalues ARE the Guest-Saunders average,
+    ! eps(p) = 0.5*(fa(p,p) + fb(p,p)); fitting eps(j)-eps(i) to an additive
+    ! a(i)+b(j) form over all 53 (H2O) and 134 (CH2O) non-open-open amplitudes
+    ! reproduces it to 1e-10.
+    !
+    ! xm_1e really is the exact one-electron diagonal of mrsfesum: contraction
+    ! 1 there contributes fb(j,j)*X(i,j), contraction 2 contributes
+    ! -fa(i,i)*X(i,j), and the folded open-open branch contributes
+    ! 0.5*[(fb-fa)(O1,O1) + (fb-fa)(O2,O2)]*X(O1,O1) -- exactly mrinivec's two
+    ! formulas.  But the full diagonal also carries the spin-flip exchange
+    ! -c_H*(ij|ji) (JCP 149, 104101 Eq. 2.25), which xm omits on every path,
+    ! and that omitted term is NOT a small correction: hole and particle both
+    ! sit on or next to the two SOMOs, and at the folded open-open slot they
+    ! are the SAME spatial orbital, making it the SOMO self-repulsion, O(1 Eh).
+    !
+    ! The Guest-Saunders subtraction is a surrogate for precisely that omitted
+    ! exchange -- (fb-fa)(p,p) = c_H*[K(p,O1) + K(p,O2)] + dVxc(p,p) -- and a
+    ! good one.  Applying the production sigma to unit vectors gives the exact
+    ! A(ij,ij) (sigma = A e_ij on iteration 1); over 45 of the 54 amplitudes of
+    ! H2O/6-31G, triplet ROHF reference, triplet target:
+    !
+    !                    |xm_rohf - A_diag|        |xm_1e - A_diag|
+    !     MRSF-TDHF      MAE 0.315  max 0.685     MAE 0.542  max 1.133
+    !     MRSF/BHHLYP    MAE 0.142  max 0.311     MAE 0.272  max 0.567
+    !
+    ! and xm_rohf is closer on 45 amplitudes out of 45, in both.  At the folded
+    ! open-open slot it is not merely closer, it is EXACT for pure HF: the
+    ! one-electron part c_H*[0.5*(K11+K22) + K12] is cancelled term by term by
+    ! the response exchange, leaving 0.5*[dVxc(O1,O1) + dVxc(O2,O2)], which is
+    ! identically zero without a functional.  Measured A(OO,OO) = 0.0000000000
+    ! (HF) and 0.0317175663 (BHHLYP), against xm_rohf = 0 and xm_1e = 0.609 /
+    ! 0.337.  The "identically zero" open-open entry is the right answer, not
+    ! an artefact of ea == eb.
+    !
+    ! Measured consequences of substituting xm_1e:
+    !   - examples/MRSF-TDDFT/CH2O_MRSFTDDFT_SYMMETRY_BLOCK_COVERAGE LOSES its
+    !     2.039974 eV triplet.  The reordered xm drops the seed that reaches
+    !     that block and T1 is reported as 4.782 eV -- converged, silent, wrong.
+    !   - h2o_rohf_mrsf-t_6-31g_{bhhlyp,cam-b3lyp} stop converging.  Not a
+    !     divergence: the residual reaches 5.9e-08 / 8.5e-08 against a 1e-08
+    !     threshold and the run exits on "nvec = mxvec".  Both decks have
+    !     xvec_dim = 54, so mxvec = xvec_dim-3 = 51 caps the subspace and the
+    !     auto-restart above cannot rescue it -- the degraded preconditioner
+    !     needs more expansion vectors than the whole space has.
+    !
+    ! The other observation in #328 is real but belongs to a different
+    ! mechanism: H2O_BHHLYP_SOC at nstate=12 is missing the physical root at
+    ! 0.60340875 Eh (1A'', dark).  That is a trial-set COVERAGE limit, not a
+    ! diagonal one -- the shipped diagonal finds that root, unchanged, at
+    ! nstate=20 and nstate=30 (energies equal to 4.6e-14, eigenvector overlap
+    ! 1 - 7.2e-10 at conv=1e-10).  See the seed-coverage block in mrinivec.
     if (mrst==1 .or. mrst==3) then
       if (.not. umrsf) then
+        ! ROHF: mo_energy_work_a holds the Guest-Saunders spin average and goes
+        ! in as BOTH ea and eb on purpose -- see the measurement above.
         call mrinivec(infos, mo_energy_work_a, mo_energy_work_a, bvec_mo, xm, nvec)
       else
+        ! UHF reference: genuine alpha/beta eigenvalues, no spin average to undo.
         call mrinivec(infos, mo_energy_work_a, mo_energy_work_b, bvec_mo, xm, nvec)
       end if
 

--- a/source/tdhf_mrsf_lib.F90
+++ b/source/tdhf_mrsf_lib.F90
@@ -428,6 +428,17 @@ contains
 !###############################################################################
 !###############################################################################
 
+!> Choose the initial Davidson trial vectors and build the diagonal estimate xm.
+!>
+!> ea/eb are the hole-side and particle-side orbital energies.  They are NOT
+!> required to be the alpha and beta Fock diagonals: what xm has to approximate
+!> is the diagonal of the full response operator, and on the ROHF path the
+!> caller deliberately supplies the Guest-Saunders spin average for both,
+!> because 0.5*(fa+fb) absorbs a large part of the spin-flip exchange
+!> -c_H*(ij|ji) that this one-electron form omits.  Measured on H2O/6-31G, the
+!> spin-averaged input is closer to the exact operator diagonal than the
+!> alpha/beta Fock diagonals on 45 of 45 amplitudes.  See the long comment at
+!> the call site in tdhf_mrsf_energy.F90 and issue #328 before changing this.
   subroutine mrinivec(infos,ea,eb,bvec_mo,xm,nvec)
 
     use precision, only: dp

--- a/tests/test_mrsf_rohf_davidson_diagonal.py
+++ b/tests/test_mrsf_rohf_davidson_diagonal.py
@@ -39,57 +39,422 @@ Those behavioural consequences are already covered by the shipped examples.
 This file guards the source shape, so the one-line substitution cannot be
 reapplied silently -- and, if the call site is ever legitimately restructured,
 forces whoever does it to read the measurement first.
+
+How the guard identifies the two calls
+--------------------------------------
+The two ``mrinivec`` call sites cannot be told apart by their arguments alone.
+A source file whose ``if (.not. umrsf)`` predicate has been inverted, or whose
+two calls have been exchanged between the branches, still contains exactly one
+call with equal arguments and one call with unequal arguments -- while ROHF
+receives the spin-resolved diagonal and UMRSF receives the averaged one, which
+is exactly the regression this file exists to prevent.
+
+So the source is parsed instead: comments are removed, ``&`` continuations are
+joined, the ``if``/``else if``/``else``/``end if`` tree is walked, and each call
+is reported together with the value ``umrsf`` is *known* to have where that call
+stands.  Anything the walk cannot pin down (a call outside any ``umrsf``
+branch, a compound predicate, a contradictory nesting, an unbalanced
+construct) is reported as a problem rather than silently accepted.
+``test_inverting_the_branch_predicate_is_rejected`` and
+``test_exchanging_the_two_calls_is_rejected`` apply those two mutations to the
+shipped source and require the guard to reject each of them, and
+``test_inverting_and_exchanging_together_is_accepted`` applies both -- which
+restores the original meaning -- and requires the guard to accept it, so the
+guard is demonstrably reading control flow rather than line order.
 """
 
 import re
 import unittest
+from collections import namedtuple
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 ENERGY_SRC = ROOT / "source" / "modules" / "tdhf_mrsf_energy.F90"
 LIB_SRC = ROOT / "source" / "tdhf_mrsf_lib.F90"
 
-CALL_RE = re.compile(
-    r"call\s+mrinivec\s*\(\s*infos\s*,\s*(\w+)\s*,\s*(\w+)\s*,", re.IGNORECASE
-)
+IF_THEN_RE = re.compile(r"^(?:\w+\s*:\s*)?if\s*\((?P<cond>.+)\)\s*then$", re.I)
+ELSE_IF_RE = re.compile(r"^else\s*if\s*\((?P<cond>.+)\)\s*then(?:\s+\w+)?$", re.I)
+ELSE_RE = re.compile(r"^else(?:\s+\w+)?$", re.I)
+END_IF_RE = re.compile(r"^end\s*if(?:\s+\w+)?$", re.I)
+MRINIVEC_RE = re.compile(r"^call\s+mrinivec\s*\((?P<args>.*)\)$", re.I)
 
 
-def _mrinivec_calls():
-    return CALL_RE.findall(ENERGY_SRC.read_text())
+class _Unknown:
+    """``umrsf`` has a value here, but this parser refuses to guess which."""
+
+    def __repr__(self):
+        return "unknown"
+
+
+UNKNOWN = _Unknown()
+
+# One ``mrinivec`` call site: the physical lines it occupies, its actual
+# arguments, the value ``umrsf`` has there, and the line of the ``if`` /
+# ``else if`` / ``else`` that fixes that value.
+Call = namedtuple("Call", "start end args umrsf branch_line")
+
+
+def _strip_comment(line):
+    """Drop a trailing Fortran ``!`` comment, respecting quoted text."""
+    out = []
+    quote = None
+    for char in line:
+        if quote is not None:
+            out.append(char)
+            if char == quote:
+                quote = None
+        elif char in "'\"":
+            quote = char
+            out.append(char)
+        elif char == "!":
+            break
+        else:
+            out.append(char)
+    return "".join(out).strip()
+
+
+def _logical_lines(text):
+    """Yield ``(first_line, last_line, code)``, ``&`` continuations joined."""
+    lines = []
+    buf = ""
+    start = None
+    for number, raw in enumerate(text.splitlines(), 1):
+        code = _strip_comment(raw)
+        if not code:
+            # A blank or comment-only line may sit inside a continuation.
+            continue
+        if buf:
+            code = code.lstrip("&").strip()
+        else:
+            start = number
+        if code.endswith("&"):
+            buf += code[:-1].rstrip() + " "
+            continue
+        lines.append((start, number, (buf + code).strip()))
+        buf = ""
+        start = None
+    if buf:
+        raise ValueError("file ends inside a continued statement at line %d" % start)
+    return lines
+
+
+def _umrsf_says(condition, taken):
+    """What ``condition`` -- or its negation, when ``taken`` is False -- fixes.
+
+    Returns True/False when ``umrsf`` is pinned down, None when the condition
+    has nothing to do with ``umrsf``, and UNKNOWN when it mentions ``umrsf`` in
+    a form this parser will not reason about.
+    """
+    text = re.sub(r"\s+", "", condition).lower()
+    if text == "umrsf":
+        return taken
+    if text == ".not.umrsf":
+        return not taken
+    if "umrsf" in text:
+        return UNKNOWN
+    return None
+
+
+def _combine(values):
+    """Fold the branch constraints into one value for ``umrsf``."""
+    fixed = [value for value in values if value is not None]
+    if not fixed:
+        return None
+    if any(value is UNKNOWN for value in fixed):
+        return UNKNOWN
+    if len(set(fixed)) != 1:
+        return UNKNOWN  # contradictory nesting; refuse to pick a side
+    return fixed[0]
+
+
+class _IfConstruct:
+    """One open ``if`` construct and what its current branch says about umrsf."""
+
+    def __init__(self, line, condition):
+        self.branch_line = line
+        self.conditions = [condition]
+        self.umrsf = _umrsf_says(condition, True)
+
+    def else_if(self, line, condition):
+        self.branch_line = line
+        self.umrsf = _combine(
+            [_umrsf_says(prior, False) for prior in self.conditions]
+            + [_umrsf_says(condition, True)]
+        )
+        self.conditions.append(condition)
+
+    def else_(self, line):
+        self.branch_line = line
+        self.umrsf = _combine(
+            [_umrsf_says(prior, False) for prior in self.conditions]
+        )
+
+
+def _enclosing_umrsf(stack):
+    """The innermost branch that fixes ``umrsf``, as ``(value, line)``."""
+    for frame in reversed(stack):
+        if frame.umrsf is not None:
+            return frame.umrsf, frame.branch_line
+    return None, None
+
+
+def mrinivec_calls(text):
+    """Every ``mrinivec`` call in ``text``, tagged with its enclosing branch."""
+    calls = []
+    stack = []
+    for start, end, code in _logical_lines(text):
+        match = ELSE_IF_RE.match(code)
+        if match:
+            if not stack:
+                raise ValueError("'else if' outside an if construct at line %d" % start)
+            stack[-1].else_if(start, match.group("cond"))
+            continue
+        match = IF_THEN_RE.match(code)
+        if match:
+            stack.append(_IfConstruct(start, match.group("cond")))
+            continue
+        if ELSE_RE.match(code):
+            if not stack:
+                raise ValueError("'else' outside an if construct at line %d" % start)
+            stack[-1].else_(start)
+            continue
+        if END_IF_RE.match(code):
+            if not stack:
+                raise ValueError("'end if' without a matching 'if' at line %d" % start)
+            stack.pop()
+            continue
+        match = MRINIVEC_RE.match(code)
+        if match:
+            umrsf, branch_line = _enclosing_umrsf(stack)
+            calls.append(
+                Call(start, end, _split_args(match.group("args")), umrsf, branch_line)
+            )
+    if stack:
+        raise ValueError(
+            "if construct opened at line %d is never closed" % stack[-1].branch_line
+        )
+    return calls
+
+
+def _split_args(text):
+    """Split an argument list on its top-level commas."""
+    args = []
+    current = ""
+    depth = 0
+    for char in text:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        if char == "," and depth == 0:
+            args.append(current.strip())
+            current = ""
+        else:
+            current += char
+    args.append(current.strip())
+    return args
+
+
+def diagnose(text):
+    """Problems with the ``mrinivec`` branch layout; empty means the shape is right."""
+    try:
+        calls = mrinivec_calls(text)
+    except ValueError as exc:
+        return ["could not parse the if-construct tree: %s" % exc]
+
+    problems = []
+    if len(calls) != 2:
+        problems.append(
+            "expected exactly two mrinivec call sites (ROHF and UMRSF), found %d"
+            % len(calls)
+        )
+    for call in calls:
+        if call.umrsf is None:
+            problems.append(
+                "the mrinivec call at line %d is not inside any branch that fixes "
+                "umrsf, so its role cannot be established" % call.start
+            )
+        elif call.umrsf is UNKNOWN:
+            problems.append(
+                "the branch at line %d guarding the mrinivec call at line %d does "
+                "not fix umrsf to a single value" % (call.branch_line, call.start)
+            )
+        elif len(call.args) < 3:
+            problems.append(
+                "the mrinivec call at line %d has too few arguments to carry ea and "
+                "eb: %r" % (call.start, call.args)
+            )
+
+    usable = [call for call in calls if call.umrsf in (True, False) and len(call.args) >= 3]
+    rohf = [call for call in usable if call.umrsf is False]
+    umrsf = [call for call in usable if call.umrsf is True]
+
+    if len(rohf) != 1:
+        problems.append(
+            "expected exactly one mrinivec call under '.not. umrsf' (the ROHF "
+            "path), found %d" % len(rohf)
+        )
+    elif rohf[0].args[1] != rohf[0].args[2]:
+        problems.append(
+            "the ROHF call at line %d (branch at line %d) passes ea=%s, eb=%s; the "
+            "Guest-Saunders spin average has to go in as BOTH -- see this module's "
+            "docstring and issue #328"
+            % (rohf[0].start, rohf[0].branch_line, rohf[0].args[1], rohf[0].args[2])
+        )
+
+    if len(umrsf) != 1:
+        problems.append(
+            "expected exactly one mrinivec call under 'umrsf' (the UMRSF path), "
+            "found %d" % len(umrsf)
+        )
+    elif umrsf[0].args[1] == umrsf[0].args[2]:
+        problems.append(
+            "the UMRSF call at line %d (branch at line %d) passes %s as both ea and "
+            "eb; a UHF reference has genuine alpha/beta diagonals and must keep them"
+            % (umrsf[0].start, umrsf[0].branch_line, umrsf[0].args[1])
+        )
+
+    return problems
+
+
+def _invert_the_branch_predicate(text):
+    """Rewrite the ROHF call's guard from ``.not. umrsf`` to ``umrsf``."""
+    rohf = [call for call in mrinivec_calls(text) if call.umrsf is False]
+    if len(rohf) != 1:
+        raise ValueError("cannot locate the single ROHF call to mutate")
+    lines = text.splitlines(keepends=True)
+    index = rohf[0].branch_line - 1
+    mutated, count = re.subn(r"\.not\.\s*umrsf", "umrsf", lines[index], flags=re.I)
+    if count != 1:
+        raise ValueError("no '.not. umrsf' to invert on line %d" % rohf[0].branch_line)
+    lines[index] = mutated
+    return "".join(lines)
+
+
+def _exchange_the_two_calls(text):
+    """Swap the two ``mrinivec`` call statements between their branches."""
+    calls = mrinivec_calls(text)
+    if len(calls) != 2:
+        raise ValueError("cannot exchange calls: found %d" % len(calls))
+    first, second = calls
+    lines = text.splitlines(keepends=True)
+    return "".join(
+        lines[: first.start - 1]
+        + lines[second.start - 1 : second.end]
+        + lines[first.end : second.start - 1]
+        + lines[first.start - 1 : first.end]
+        + lines[second.end :]
+    )
 
 
 class MrsfRohfDavidsonDiagonalTests(unittest.TestCase):
+    def setUp(self):
+        self.energy = ENERGY_SRC.read_text()
+
     def test_two_mrinivec_call_sites(self):
         """One ROHF call and one UMRSF call, nothing else."""
         self.assertEqual(
-            len(_mrinivec_calls()), 2,
+            len(mrinivec_calls(self.energy)), 2,
             "expected exactly two mrinivec call sites (ROHF and UMRSF); the "
             "guard below assumes that layout",
         )
 
-    def test_rohf_path_uses_the_spin_averaged_diagonal(self):
-        """The non-UMRSF call must pass one array as both ea and eb.
+    def test_rohf_branch_passes_the_spin_averaged_diagonal(self):
+        """The call inside ``.not. umrsf`` passes one array as both ea and eb.
 
-        Passing fa/fb there is the change issue #328 asked for; it degrades the
-        diagonal (45/45 amplitudes worse), loses a physical CH2O root and stops
-        two shipped decks converging.  See this module's docstring.
+        Identified by its enclosing branch, not by its arguments: passing fa/fb
+        there is the change issue #328 asked for; it degrades the diagonal
+        (45/45 amplitudes worse), loses a physical CH2O root and stops two
+        shipped decks converging.  See this module's docstring.
         """
-        calls = _mrinivec_calls()
-        rohf = [(ea, eb) for ea, eb in calls if ea == eb]
+        rohf = [c for c in mrinivec_calls(self.energy) if c.umrsf is False]
         self.assertEqual(
             len(rohf), 1,
-            "the ROHF MRSF path must pass the Guest-Saunders spin average as "
-            "both ea and eb; found %r" % (calls,),
+            "expected exactly one mrinivec call under '.not. umrsf'; found %r" % (rohf,),
+        )
+        ea, eb = rohf[0].args[1], rohf[0].args[2]
+        self.assertEqual(
+            ea, eb,
+            "the ROHF MRSF path (branch at line %d, call at line %d) must pass the "
+            "Guest-Saunders spin average as both ea and eb; it passes %s and %s"
+            % (rohf[0].branch_line, rohf[0].start, ea, eb),
         )
 
-    def test_umrsf_path_keeps_spin_resolved_diagonals(self):
-        """UMRSF has a genuine UHF reference, so it keeps alpha/beta."""
-        calls = _mrinivec_calls()
-        split = [(ea, eb) for ea, eb in calls if ea != eb]
+    def test_umrsf_branch_keeps_spin_resolved_diagonals(self):
+        """UMRSF has a genuine UHF reference, so its branch keeps alpha/beta."""
+        umrsf = [c for c in mrinivec_calls(self.energy) if c.umrsf is True]
         self.assertEqual(
-            len(split), 1,
-            "the UMRSF path must keep the spin-resolved alpha/beta diagonals; "
-            "found %r" % (calls,),
+            len(umrsf), 1,
+            "expected exactly one mrinivec call under 'umrsf'; found %r" % (umrsf,),
+        )
+        ea, eb = umrsf[0].args[1], umrsf[0].args[2]
+        self.assertNotEqual(
+            ea, eb,
+            "the UMRSF path (branch at line %d, call at line %d) must keep the "
+            "spin-resolved alpha/beta diagonals; it passes %s twice"
+            % (umrsf[0].branch_line, umrsf[0].start, ea),
+        )
+
+    def test_every_call_site_is_inside_a_resolved_umrsf_branch(self):
+        """Neither call may drift out of -- or into a fuzzier -- umrsf branch."""
+        for call in mrinivec_calls(self.energy):
+            self.assertIn(
+                call.umrsf, (True, False),
+                "the mrinivec call at line %d is not guarded by a branch that fixes "
+                "umrsf to a single value (got %r); the ROHF and UMRSF diagonals can "
+                "no longer be told apart" % (call.start, call.umrsf),
+            )
+
+    def test_shipped_source_has_no_layout_problems(self):
+        """The whole guard, run over the shipped file, must be silent."""
+        self.assertEqual(diagnose(self.energy), [])
+
+    def test_inverting_the_branch_predicate_is_rejected(self):
+        """Flipping ``.not. umrsf`` hands ROHF the spin-resolved diagonal.
+
+        The argument-only classification cannot see this: there is still one
+        equal pair and one unequal pair.
+        """
+        mutated = _invert_the_branch_predicate(self.energy)
+        self.assertNotEqual(mutated, self.energy, "the mutation changed nothing")
+        problems = diagnose(mutated)
+        self.assertTrue(
+            problems,
+            "inverting the branch predicate gives ROHF the alpha/beta diagonal and "
+            "the guard accepted it",
+        )
+        self.assertTrue(
+            any("ROHF call" in problem for problem in problems),
+            "expected the ROHF call to be reported; got %r" % (problems,),
+        )
+
+    def test_exchanging_the_two_calls_is_rejected(self):
+        """Swapping the call statements has the same effect and must also fail."""
+        mutated = _exchange_the_two_calls(self.energy)
+        self.assertNotEqual(mutated, self.energy, "the mutation changed nothing")
+        problems = diagnose(mutated)
+        self.assertTrue(
+            problems,
+            "exchanging the two calls gives ROHF the alpha/beta diagonal and the "
+            "guard accepted it",
+        )
+        self.assertTrue(
+            any("ROHF call" in problem for problem in problems),
+            "expected the ROHF call to be reported; got %r" % (problems,),
+        )
+
+    def test_inverting_and_exchanging_together_is_accepted(self):
+        """Both mutations at once restore the shipped meaning, so this must pass.
+
+        Positive control: it shows the guard reads the control flow rather than
+        the order of the two call statements.
+        """
+        mutated = _invert_the_branch_predicate(_exchange_the_two_calls(self.energy))
+        self.assertNotEqual(mutated, self.energy, "the mutation changed nothing")
+        self.assertEqual(
+            diagnose(mutated), [],
+            "inverting the predicate and exchanging the calls is the shipped "
+            "assignment written the other way round; the guard must accept it",
         )
 
     def test_umrsf_branch_still_fills_both_arrays_from_fa_fb(self):
@@ -98,9 +463,8 @@ class MrsfRohfDavidsonDiagonalTests(unittest.TestCase):
         This is what makes the two paths genuinely different, and it must not
         be extended to the ROHF path.
         """
-        text = ENERGY_SRC.read_text()
         self.assertRegex(
-            text,
+            self.energy,
             r"if\s*\(\s*umrsf\s*\)\s*then\s*\n\s*do\s+i\s*=\s*1\s*,\s*nbf\s*\n"
             r"\s*mo_energy_work_a\(i\)\s*=\s*fa\(i,i\)\s*\n"
             r"\s*mo_energy_work_b\(i\)\s*=\s*fb\(i,i\)",
@@ -109,10 +473,9 @@ class MrsfRohfDavidsonDiagonalTests(unittest.TestCase):
 
     def test_measurement_is_recorded_next_to_the_code(self):
         """The reasoning must travel with the code, not only with the issue."""
-        energy = ENERGY_SRC.read_text()
         lib = LIB_SRC.read_text()
         for needle in ("#328", "Guest-Saunders", "A(ij,ij)"):
-            self.assertIn(needle, energy,
+            self.assertIn(needle, self.energy,
                           "call-site comment lost its reference to %r" % needle)
         self.assertIn("#328", lib,
                       "mrinivec lost its pointer to the measurement")

--- a/tests/test_mrsf_rohf_davidson_diagonal.py
+++ b/tests/test_mrsf_rohf_davidson_diagonal.py
@@ -1,0 +1,122 @@
+"""Regression guard for the MRSF Davidson trial-vector diagonal on the ROHF path.
+
+Background
+----------
+``mrinivec`` builds ``xm``, which both orders the initial trial vectors and
+preconditions the Davidson residuals.  What ``xm`` has to approximate is the
+diagonal of the response operator, ``A(ij,ij)`` -- not the one-electron part of
+it.  On the ROHF path ``tdhf_mrsf_energy`` passes the ROHF canonical
+eigenvalues as BOTH ``ea`` and ``eb``.  Those eigenvalues are the
+Guest-Saunders spin average, ``eps(p) = 0.5*(fa(p,p) + fb(p,p))``; fitting
+``eps(j) - eps(i)`` to an additive ``a(i) + b(j)`` form over all 53 (H2O) and
+134 (CH2O) non-open-open amplitudes reproduces that identity to 1e-10.
+
+Issue #328 proposed replacing this with the alpha/beta Fock diagonals, i.e.
+``fb(j,j) - fa(i,i)``, which is indeed the exact one-electron diagonal of
+``mrsfesum``.  Measurement rejects the substitution:
+
+* The full diagonal also carries the spin-flip exchange ``-c_H*(ij|ji)``
+  (JCP 149, 104101, Eq. 2.25), which ``xm`` omits on every path, and which is
+  O(1 Eh) here because hole and particle both sit on or next to the two SOMOs.
+  The Guest-Saunders subtraction is a surrogate for it.
+* Applying the production sigma to unit vectors gives the exact ``A(ij,ij)``.
+  Over 45 of the 54 amplitudes of H2O/6-31G (triplet ROHF reference, triplet
+  target) the shipped diagonal is closer to it on 45 amplitudes out of 45:
+  MRSF-TDHF MAE 0.315 vs 0.542 Eh, MRSF/BHHLYP MAE 0.142 vs 0.272 Eh.
+* At the folded open-open slot the shipped value is exact for pure HF.  The
+  measured ``A(OO,OO)`` is 0.0000000000 (HF) and 0.0317175663 (BHHLYP) against
+  ``xm`` = 0 and a one-electron value of 0.609 / 0.337.  The "identically zero"
+  open-open entry is the right answer, not an artefact of ``ea == eb``.
+* Substituting the one-electron diagonal loses the 2.039974 eV triplet of
+  ``examples/MRSF-TDDFT/CH2O_MRSFTDDFT_SYMMETRY_BLOCK_COVERAGE`` (T1 is then
+  reported as 4.782 eV, converged and wrong) and stops
+  ``h2o_rohf_mrsf-t_6-31g_{bhhlyp,cam-b3lyp}`` converging -- they reach
+  5.9e-08 / 8.5e-08 against a 1e-08 threshold and then exit on
+  ``nvec = mxvec``, which the auto-restart cannot rescue because
+  ``mxvec = xvec_dim - 3`` is capped by the space dimension itself.
+
+Those behavioural consequences are already covered by the shipped examples.
+This file guards the source shape, so the one-line substitution cannot be
+reapplied silently -- and, if the call site is ever legitimately restructured,
+forces whoever does it to read the measurement first.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENERGY_SRC = ROOT / "source" / "modules" / "tdhf_mrsf_energy.F90"
+LIB_SRC = ROOT / "source" / "tdhf_mrsf_lib.F90"
+
+CALL_RE = re.compile(
+    r"call\s+mrinivec\s*\(\s*infos\s*,\s*(\w+)\s*,\s*(\w+)\s*,", re.IGNORECASE
+)
+
+
+def _mrinivec_calls():
+    return CALL_RE.findall(ENERGY_SRC.read_text())
+
+
+class MrsfRohfDavidsonDiagonalTests(unittest.TestCase):
+    def test_two_mrinivec_call_sites(self):
+        """One ROHF call and one UMRSF call, nothing else."""
+        self.assertEqual(
+            len(_mrinivec_calls()), 2,
+            "expected exactly two mrinivec call sites (ROHF and UMRSF); the "
+            "guard below assumes that layout",
+        )
+
+    def test_rohf_path_uses_the_spin_averaged_diagonal(self):
+        """The non-UMRSF call must pass one array as both ea and eb.
+
+        Passing fa/fb there is the change issue #328 asked for; it degrades the
+        diagonal (45/45 amplitudes worse), loses a physical CH2O root and stops
+        two shipped decks converging.  See this module's docstring.
+        """
+        calls = _mrinivec_calls()
+        rohf = [(ea, eb) for ea, eb in calls if ea == eb]
+        self.assertEqual(
+            len(rohf), 1,
+            "the ROHF MRSF path must pass the Guest-Saunders spin average as "
+            "both ea and eb; found %r" % (calls,),
+        )
+
+    def test_umrsf_path_keeps_spin_resolved_diagonals(self):
+        """UMRSF has a genuine UHF reference, so it keeps alpha/beta."""
+        calls = _mrinivec_calls()
+        split = [(ea, eb) for ea, eb in calls if ea != eb]
+        self.assertEqual(
+            len(split), 1,
+            "the UMRSF path must keep the spin-resolved alpha/beta diagonals; "
+            "found %r" % (calls,),
+        )
+
+    def test_umrsf_branch_still_fills_both_arrays_from_fa_fb(self):
+        """UMRSF fills its work arrays from the alpha/beta Fock diagonals.
+
+        This is what makes the two paths genuinely different, and it must not
+        be extended to the ROHF path.
+        """
+        text = ENERGY_SRC.read_text()
+        self.assertRegex(
+            text,
+            r"if\s*\(\s*umrsf\s*\)\s*then\s*\n\s*do\s+i\s*=\s*1\s*,\s*nbf\s*\n"
+            r"\s*mo_energy_work_a\(i\)\s*=\s*fa\(i,i\)\s*\n"
+            r"\s*mo_energy_work_b\(i\)\s*=\s*fb\(i,i\)",
+            "the fa/fb fill must stay guarded by 'if (umrsf)' alone",
+        )
+
+    def test_measurement_is_recorded_next_to_the_code(self):
+        """The reasoning must travel with the code, not only with the issue."""
+        energy = ENERGY_SRC.read_text()
+        lib = LIB_SRC.read_text()
+        for needle in ("#328", "Guest-Saunders", "A(ij,ij)"):
+            self.assertIn(needle, energy,
+                          "call-site comment lost its reference to %r" % needle)
+        self.assertIn("#328", lib,
+                      "mrinivec lost its pointer to the measurement")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mrsf_rohf_davidson_diagonal.py
+++ b/tests/test_mrsf_rohf_davidson_diagonal.py
@@ -405,6 +405,39 @@ class MrsfRohfDavidsonDiagonalTests(unittest.TestCase):
                 "no longer be told apart" % (call.start, call.umrsf),
             )
 
+    def test_layouts_that_hide_the_branch_are_rejected(self):
+        """What the walk cannot pin down must be reported, not accepted.
+
+        These are the ways a future restructuring could stop the two calls from
+        being distinguishable; each has to fail loudly rather than pass by
+        default.
+        """
+        cases = {
+            "call outside any umrsf branch": (
+                "    call mrinivec(infos, ea, ea, bvec_mo, xm, nvec)\n"
+                "    if (umrsf) then\n"
+                "      call mrinivec(infos, ea, eb, bvec_mo, xm, nvec)\n"
+                "    end if\n"
+            ),
+            "umrsf hidden in a compound predicate": (
+                "    if ((mrst==1 .or. mrst==3) .and. .not. umrsf) then\n"
+                "      call mrinivec(infos, ea, ea, bvec_mo, xm, nvec)\n"
+                "    else\n"
+                "      call mrinivec(infos, ea, eb, bvec_mo, xm, nvec)\n"
+                "    end if\n"
+            ),
+            "unbalanced if construct": (
+                "    if (.not. umrsf) then\n"
+                "      call mrinivec(infos, ea, ea, bvec_mo, xm, nvec)\n"
+            ),
+        }
+        for name, source in cases.items():
+            with self.subTest(layout=name):
+                self.assertTrue(
+                    diagnose(source),
+                    "%s was accepted; the guard must fail closed" % name,
+                )
+
     def test_shipped_source_has_no_layout_problems(self):
         """The whole guard, run over the shipped file, must be silent."""
         self.assertEqual(diagnose(self.energy), [])


### PR DESCRIPTION
Fixes #328

## Summary

#328 asks whether the ROHF MRSF path should build the Davidson trial-vector
diagonal `xm` from the alpha/beta Fock diagonals instead of passing the ROHF
canonical eigenvalues as both `ea` and `eb`. I measured it. **The answer is
no** — the proposed substitution makes the diagonal roughly twice as far from
the operator it preconditions, on *every* amplitude, and the shipped behaviour
is correct.

So this PR changes **no numerical behaviour**. Both source diffs are
comment-only (`git diff` filtered for non-comment lines is empty). It replaces
the "KNOWN DEFECT" narrative at the call site — which invites exactly the
one-liner that breaks things — with the measurement, and adds a source-shape
guard test so the substitution cannot be reapplied silently.

## The premise is half right

`mrinivec`'s two formulas *are* the exact one-electron diagonal of `mrsfesum`
when fed `diag(fa)` / `diag(fb)`. `mrsfesum` is called with `fij = fa` (hole,
alpha) and `fab = fb` (particle, beta), and its contractions give
`+fb(j,j)·X(i,j)` and `−fa(i,i)·X(i,j)`, with the folded open-open branch
giving `0.5·[(fb−fa)(O1,O1) + (fb−fa)(O2,O2)]·X(O1,O1)`. That much of #328
is correct.

But `xm` is not used as a one-electron diagonal. It orders the seeds and forms
the preconditioner denominators, so what it must approximate is
**`A(ij,ij)`** — and the full diagonal also carries the spin-flip exchange
`−c_H·(ij|ji)` (JCP **149**, 104101 Eq. 2.25), which `xm` omits on every path.
That term is *not* small here: hole and particle both sit on or next to the two
SOMOs, and at the folded open-open slot they are the **same spatial orbital**,
making it the SOMO self-repulsion, O(1 Eh).

The ROHF canonical eigenvalues are the Guest–Saunders average — fitting
`eps(j) − eps(i)` to an additive `a(i)+b(j)` form reproduces
`eps(p) = 0.5·(fa(p,p)+fb(p,p))` to 1e-10 over all 53 (H2O) and 134 (CH2O)
non-open-open amplitudes — so

```
xm_rohf(i,j) = xm_1e(i,j) − 0.5·[ (fb−fa)(i,i) + (fb−fa)(j,j) ]
```

and since `(fb−fa)(p,p) = c_H·[K(p,O1)+K(p,O2)] + dVxc(p,p)`, that subtraction
is a surrogate for precisely the omitted exchange.

## Measurement: sigma columns vs. both candidates

An instrumented build dumped `amo(:,k) = A·bvec_mo(:,k)` on Davidson iteration
1, where each `bvec_mo(:,k)` is a unit vector — so `amo(idx,k)` is the **exact**
`A(idx,idx)`. At `nstate=45` on H2O/6-31G (triplet ROHF reference, triplet
target) this recovers 45 of the 54 amplitudes:

| deck | `|xm_rohf − A_diag|` MAE / max | `|xm_1e − A_diag|` MAE / max | shipped closer on |
|---|---|---|---|
| MRSF-TDHF | **0.315** / 0.685 | 0.542 / 1.133 | **45 / 45** |
| MRSF/BHHLYP | **0.142** / 0.311 | 0.272 / 0.567 | **45 / 45** |

### The "identically zero" open-open entry is the right answer

| deck | `xm_rohf` | `xm_1e` | exact `A(OO,OO)` |
|---|---|---|---|
| H2O MRSF-TDHF | 0.0000000000 | 0.6086709596 | **0.0000000000** |
| H2O MRSF/BHHLYP | 0.0000000000 | 0.3372397065 | **0.0317175663** |
| H2O SOC BHHLYP (singlet) | 0.0000000000 | 0.3336022600 | **0.0484756857** |
| CH2O MRSF-TDHF | 0.0000000000 | 0.6261903320 | **0.0000000000** |

Analytically the one-electron part `c_H·[0.5(K11+K22) + K12]` is cancelled term
by term by the response exchange, leaving `0.5·[dVxc(O1,O1)+dVxc(O2,O2)]` for
the triplet — identically zero without a functional, 0.0317 Eh for BHHLYP,
exactly as measured. Physically: the `M_S=0` component of the reference
triplet, `(L+R)/√2`, is a zero-eigenvalue eigenvector of the HF-level spin-flip
response.

(The CH2O reproduction #328 asked for is there too: pair 8 = folded OO gives
`xm_shipped = 0.0000000000` against a true one-electron value of
`+0.6261903320`, with the G/D partners at ∓0.1947703107.)

## Measured consequences of applying the change

**A physical root disappears.** `examples/MRSF-TDDFT/CH2O_MRSFTDDFT_SYMMETRY_BLOCK_COVERAGE`
at `nstate=3`:

| | T0 | T1 | T2 |
|---|---|---|---|
| shipped | −0.136086 eV | **2.039974 eV** | 4.782299 eV |
| with `fa`/`fb` | −0.136086 eV | 4.782298 eV | 6.377411 eV |

The reordered `xm` drops the only seed that reaches that block, and T1 is
reported as the third root — converged, silent, wrong. Forcing the open-open
entry back to 0 while correcting the rest does **not** repair it; the damage is
in the reordering of the closed→open and open→virtual slots.

**Two decks stop converging — diagnosed, not worked around.**
`h2o_rohf_mrsf-t_6-31g_bhhlyp` and `…_cam-b3lyp` reach **5.929e-08** and
**8.492e-08** against a 1e-08 threshold and then exit on
`..something is wrong.. nvec = mxvec`. This is not a divergence: the residual
falls monotonically to within one order of magnitude of the tolerance and the
Krylov subspace is then exhausted. Both decks have `xvec_dim = 6·9 = 54`, so
`mxvec = xvec_dim − 3 = 51` caps the subspace, and the
`tdhf_mrsf_energy_with_restart` wrapper (which did fire twice, doubling
`maxvec`/`maxit_dav`) cannot help because the cap is structural. The degraded
preconditioner simply needs more expansion vectors than the whole space has.

No threshold was loosened, no value clipped, no failure suppressed, and no
reference regenerated.

## The H2O_BHHLYP_SOC missing root is a different mechanism

#328 notes that the corrected diagonal surfaces a real root at 0.60340877 Eh
that the shipped `nstate=12` reference skips. The root is real — but the
**shipped** diagonal finds it too, as soon as the trial set is large enough:

| nstate | roots in 0.55–0.67 Eh |
|---|---|
| 12 | 0.55691076, 0.57022036, 0.60949897, 0.65367124 |
| 20 | …, **0.60340875**, 0.60949897, 0.65367124, 0.66905905, 0.66921943 |
| 30 | …, **0.60340875**, 0.60949897, 0.65367124, 0.66905905, 0.66921943 |

Root identity for S10 = 0.60340875 Eh (same SCF reference in all three,
`max|ΔE_MO_A|` ≤ 6.6e-13):

| gate | conv=default | conv=1e-10 |
|---|---|---|
| energy, nstate 20 vs 30 | 3.44e-12 Eh | **4.59e-14 Eh** |
| irrep (Cs) | 1A″ / 1A″ | 1A″ / 1A″ |
| `<S²>` | 0.000 | 0.000 |
| eigenvector overlap | 0.999978829597 | **0.999999999280** (gate ≥ 0.99 ✔) |
| degenerate manifold | {10} / {10} — non-degenerate | same |
| max\|P₂₀−P₃₀\| | 5.043e-03 | 3.705e-05 |

The root is non-degenerate, so the projector reduces to a rank-1 outer product
and `max|P−P|` is just `sin θ` of the overlap (6.507e-03 → 3.795e-05, matching).
It shrinks by two orders of magnitude when the Davidson threshold is tightened,
so it is set by the convergence tolerance, not by root identity; a 1e-8
projector gate would require bitwise-identical vectors and does not apply to a
non-degenerate root compared across two independent runs. Reported as measured.

The state is **dark** (all transition-dipole components 0.0000). Its absence at
`nstate=12` is a trial-set **coverage** limit — #327's territory, deliberately
out of scope here.

**Open item for a maintainer:** `examples/SOC/H2O_BHHLYP_SOC.json` therefore
records a physically incomplete spectrum. Raising the deck to `nstate=20` would
complete it but shifts the SOC coupling list, which is keyed to state ordering.
Flagged, not changed.

## Changes

* `source/modules/tdhf_mrsf_energy.F90` — comment only. Replaces the
  "KNOWN DEFECT" block with the derivation and the measurement above, and
  annotates both `mrinivec` call sites.
* `source/tdhf_mrsf_lib.F90` — comment only. Documents at `mrinivec` that
  `ea`/`eb` need not be the alpha/beta Fock diagonals and why.
* `tests/test_mrsf_rohf_davidson_diagonal.py` — **new**, 5 tests. Pins the call
  shape (ROHF passes one array twice; UMRSF keeps `fa`/`fb`) and that the
  reasoning stays next to the code. Negative mutation verified: applying the
  one-liner makes it fail; restoring makes it pass.

**UMRSF is untouched** — it has a genuine UHF reference, no spin average to
undo, and keeps its spin-resolved diagonals. The #327 seed-coverage /
root-selection algorithm in `mrinivec` is untouched.

## Validation

Ultra (macOS 26, arm64), GCC 15, Apple Accelerate **ILP64** (165 ILP64 symbols,
**0 LP64 leaks**), `USE_LIBINT=OFF`, `ENABLE_OPENMP=ON`, cached externals.

| suite | baseline (upstream `main` d4135c78) | this branch |
|---|---|---|
| `openqp --run_tests all` | 288 total, **282 passed, 0 failed, 0 errors**, 6 skipped | 288 total, **282 passed, 0 failed, 0 errors**, 6 skipped |
| `pytest tests -n auto --forked` | **24 failed, 1919 passed**, 125 skipped, 11 xfailed, 179 subtests | **24 failed, 1919 passed**, 125 skipped, 11 xfailed, 179 subtests |

Identical, as a comment-only diff must be. The 24 pytest failures are
pre-existing on this platform and byte-for-byte the same set on both builds
(`comm` of the two FAILED lists is empty in both directions) — CAM/D4/ROKS/UKS
analytic-vs-numerical Hessians, CASSCF active-Hamiltonian, FCI/`dsyevd`. None
touch MRSF. The 5 new tests pass.

All six example-suite skips are optional
dependencies, unchanged from baseline and reported here in full:

* `OH_ROHF-HF_DDPCM_ENERGY`, `H2O_RHF-HF_DDPCM_ENERGY_ISPHER` — build feature
  `OQP_ENABLE_DDX` not enabled;
* `H2CO-water_BHHLYP-MRSF-NAMD-QMMM` (×2), `…-QMMM-NVT`,
  `H2CO-water_BHHLYP-SOC-NAMD-QMMM` — optional OpenMM backend not installed.

`--run_tests all` deliberately excludes numerical Hessians, IRC, single-point
QM/MM and DFTB decks (`oqp_tester._skip_in_full_run`), so
`H2O_BHHLYP-MRSFTDDFT_NUM_HESS` — one of the six decks #328 reports as moving —
is **not** in the 288. It was run explicitly:

```
openqp --run_tests examples/HESS   ->  5 total, 5 passed, 0 failed, 0 errors, 0 skipped
   H2O_RHF-DFT_ANA_HESS, H2O_BHHLYP-MRSFTDDFT_NUM_HESS,
   H2O_RHF_NUM_HESS_SYMUNIQUE, H2O_RHF-DFT_NUM_HESS, H2O_RHF-DFT_VIEWER_EXPORT
```

So every deck named in #328 runs and passes against its **unmodified** shipped
reference: `H2O_BHHLYP_SOC`, `CH3Br-BHHLYP-SOC`,
`H2O_BHHLYP-MRSFTDDFT_NUM_HESS`, `h2o_rohf_mrsf-t_6-31g_b3lypv5`,
`…_bhhlyp`, `…_cam-b3lyp`, plus `CH2O_MRSFTDDFT_SYMMETRY_BLOCK_COVERAGE`.

MRSF theory-skill audits on this exact checkout: `check_lr_convention.py`
**PASS** (all L/R gates, including the two negative mutation gates; SSC is not
present in this tree), `verify_reference_models.py` **PASS**.
