### PR TITLE
Accept delocate 0.13's RPATH-free macOS wheel layout

### DIFF
--- a/.github/scripts/wheel_smoke_test.py
+++ b/.github/scripts/wheel_smoke_test.py
@@ -155,26 +155,40 @@ def assert_package_local_runtime_search_paths(
 ):
     runtime_search_paths = parse_runtime_search_paths(metadata, platform_name)
     if not runtime_search_paths:
-        # delocate >= 0.13 rewrites every ``@rpath/x`` load command to an
-        # explicit ``@loader_path/x`` and then drops the now-unused LC_RPATH.
-        # That is package-local by construction -- strictly tighter than an
-        # RPATH, which is a search list the loader could resolve elsewhere --
-        # so an empty list is correct *provided* nothing still needs a search
-        # path.  A library that kept an ``@rpath/`` dependency with no RPATH
-        # left to resolve it would not load at all, so that stays fatal.
-        #
+        # ELF has no per-dependency location: DT_NEEDED carries bare sonames,
+        # and RUNPATH/$ORIGIN is the only thing keeping resolution inside the
+        # package.  Its absence stays fatal, with no exception to inspect.
+        assert platform_name == "darwin", (
+            f"{path} lacks package-local RPATH {local_rpath}:\n{metadata}"
+        )
+        # Mach-O does: delocate >= 0.13 rewrites every ``@rpath/x`` load
+        # command to an explicit ``@loader_path/x`` and then drops the LC_RPATH
+        # it no longer needs.  That is stricter than an RPATH, which is a
+        # search list the loader could satisfy from elsewhere -- but only if
+        # EVERY load command is genuinely loader-relative, so verify that
+        # rather than assuming it.  Anything else -- a surviving ``@rpath/``
+        # with nothing left to resolve it, an ``@executable_path`` reference,
+        # a bare install name, or an absolute build-machine path that happens
+        # to exist on this runner and will not on a user's Mac -- fails here.
+        assert dependencies, (
+            f"{path} has no runtime search path and no dependency list was "
+            f"supplied, so nothing was actually verified:\n{metadata}"
+        )
         # ``otool -L`` prints the library's own LC_ID_DYLIB first.  That ID is
-        # a name consumers link against, not something this file resolves at
-        # load time, so it needs no search path of its own -- delocate rewrote
-        # the consumers' references instead.  Count real edges only.
+        # the name consumers link against, not an edge this file resolves, so
+        # it needs no search path of its own.
         own_basename = str(path).rsplit("/", 1)[-1]
-        unresolvable = [
+        system_prefixes = ("/usr/lib/", "/System/Library/")
+        nonlocal_dependencies = [
             d for d in dependencies
-            if d.startswith("@rpath/") and d.rsplit("/", 1)[-1] != own_basename
+            if d.rsplit("/", 1)[-1] != own_basename
+            and not d.startswith("@loader_path/")
+            and not d.startswith(system_prefixes)
         ]
-        assert not unresolvable, (
-            f"{path} has no runtime search path, yet still depends on "
-            f"{unresolvable} through @rpath:\n{metadata}"
+        assert not nonlocal_dependencies, (
+            f"{path} has no runtime search path, so every dependency must be "
+            f"loader-relative or a macOS system library; these are neither: "
+            f"{nonlocal_dependencies}\n{metadata}"
         )
         return
     nonlocal_search_paths = [

--- a/.github/scripts/wheel_smoke_test.py
+++ b/.github/scripts/wheel_smoke_test.py
@@ -151,7 +151,8 @@ def parse_runtime_search_paths(metadata, platform_name):
 
 
 def assert_package_local_runtime_search_paths(
-    path, metadata, platform_name, local_rpath, dependencies=()
+    path, metadata, platform_name, local_rpath, dependencies=(),
+    package_root=None,
 ):
     runtime_search_paths = parse_runtime_search_paths(metadata, platform_name)
     if not runtime_search_paths:
@@ -174,21 +175,37 @@ def assert_package_local_runtime_search_paths(
             f"{path} has no runtime search path and no dependency list was "
             f"supplied, so nothing was actually verified:\n{metadata}"
         )
-        # ``otool -L`` prints the library's own LC_ID_DYLIB first.  That ID is
-        # the name consumers link against, not an edge this file resolves, so
-        # it needs no search path of its own.
-        own_basename = str(path).rsplit("/", 1)[-1]
-        system_prefixes = ("/usr/lib/", "/System/Library/")
-        nonlocal_dependencies = [
-            d for d in dependencies
-            if d.rsplit("/", 1)[-1] != own_basename
-            and not d.startswith("@loader_path/")
-            and not d.startswith(system_prefixes)
-        ]
+        # ``otool -L`` prints the library's own LC_ID_DYLIB first, and only
+        # first.  Skip exactly that entry -- matching on the basename instead
+        # would also swallow a genuine, nonlocal edge that happens to share the
+        # owner's filename, such as an erroneous /build/liboqp.dylib.
+        library_dir = os.path.dirname(os.path.abspath(str(path)))
+        root = os.path.abspath(package_root) if package_root else library_dir
+
+        def _contains(directory, candidate):
+            return candidate == directory or candidate.startswith(directory + os.sep)
+
+        # Resolve before judging: "@loader_path/../../../../opt/homebrew/lib/x"
+        # has the right prefix and still points outside the wheel, and
+        # "/usr/lib/../../opt/x" is not a system library.
+        nonlocal_dependencies = []
+        for dependency in dependencies[1:]:
+            if dependency.startswith("@loader_path/"):
+                resolved = os.path.normpath(
+                    os.path.join(library_dir, dependency[len("@loader_path/"):])
+                )
+                if _contains(root, resolved):
+                    continue
+            elif dependency.startswith("/"):
+                resolved = os.path.normpath(dependency)
+                if any(_contains(d, resolved) for d in ("/usr/lib", "/System/Library")):
+                    continue
+            nonlocal_dependencies.append(dependency)
+
         assert not nonlocal_dependencies, (
-            f"{path} has no runtime search path, so every dependency must be "
-            f"loader-relative or a macOS system library; these are neither: "
-            f"{nonlocal_dependencies}\n{metadata}"
+            f"{path} has no runtime search path, so every dependency must "
+            f"resolve inside {root} or to a macOS system library; these do "
+            f"neither: {nonlocal_dependencies}\n{metadata}"
         )
         return
     nonlocal_search_paths = [
@@ -290,6 +307,11 @@ for path in (liboqp_path, *d4_paths.values()):
     assert_package_local_runtime_search_paths(
         path, rpath_metadata, sys.platform, local_rpath,
         dependencies_by_owner.get(path, ()),
+        # Containment boundary: delocate puts the repaired copies in
+        # oqp/.dylibs, a sibling of oqp/lib, so a legitimate
+        # "@loader_path/../.dylibs/x" must stay allowed while anything that
+        # climbs past the package must not.
+        package_root=oqp_root,
     )
 
 # A repaired wheel must not retain a canonical file while secretly relinking to

--- a/.github/scripts/wheel_smoke_test.py
+++ b/.github/scripts/wheel_smoke_test.py
@@ -151,12 +151,32 @@ def parse_runtime_search_paths(metadata, platform_name):
 
 
 def assert_package_local_runtime_search_paths(
-    path, metadata, platform_name, local_rpath
+    path, metadata, platform_name, local_rpath, dependencies=()
 ):
     runtime_search_paths = parse_runtime_search_paths(metadata, platform_name)
-    assert runtime_search_paths, (
-        f"{path} lacks package-local RPATH {local_rpath}:\n{metadata}"
-    )
+    if not runtime_search_paths:
+        # delocate >= 0.13 rewrites every ``@rpath/x`` load command to an
+        # explicit ``@loader_path/x`` and then drops the now-unused LC_RPATH.
+        # That is package-local by construction -- strictly tighter than an
+        # RPATH, which is a search list the loader could resolve elsewhere --
+        # so an empty list is correct *provided* nothing still needs a search
+        # path.  A library that kept an ``@rpath/`` dependency with no RPATH
+        # left to resolve it would not load at all, so that stays fatal.
+        #
+        # ``otool -L`` prints the library's own LC_ID_DYLIB first.  That ID is
+        # a name consumers link against, not something this file resolves at
+        # load time, so it needs no search path of its own -- delocate rewrote
+        # the consumers' references instead.  Count real edges only.
+        own_basename = str(path).rsplit("/", 1)[-1]
+        unresolvable = [
+            d for d in dependencies
+            if d.startswith("@rpath/") and d.rsplit("/", 1)[-1] != own_basename
+        ]
+        assert not unresolvable, (
+            f"{path} has no runtime search path, yet still depends on "
+            f"{unresolvable} through @rpath:\n{metadata}"
+        )
+        return
     nonlocal_search_paths = [
         entry for entry in runtime_search_paths
         if entry != local_rpath and not entry.startswith(f"{local_rpath}/")
@@ -221,11 +241,13 @@ dependency_graph = {
     d4_paths["mctc"]: set(),
 }
 oqp_deps = ""
+dependencies_by_owner = {}
 for owner, required_edges in dependency_graph.items():
     metadata = native_metadata(owner, inspect_command)
     if owner == liboqp_path:
         oqp_deps = metadata
     dependencies = parse_dynamic_dependencies(metadata, sys.platform)
+    dependencies_by_owner[owner] = dependencies
     assert_canonical_dependency_graph(
         owner, dependencies, required_edges, d4_names, sys.platform
     )
@@ -252,7 +274,8 @@ assert not re.search(r"(?i)(?:nlopt|nlo_[a-z0-9_]+)", symbol_text), symbol_text
 for path in (liboqp_path, *d4_paths.values()):
     rpath_metadata = native_metadata(path, rpath_command)
     assert_package_local_runtime_search_paths(
-        path, rpath_metadata, sys.platform, local_rpath
+        path, rpath_metadata, sys.platform, local_rpath,
+        dependencies_by_owner.get(path, ()),
     )
 
 # A repaired wheel must not retain a canonical file while secretly relinking to

--- a/tests/test_dftd4_shared_interface.py
+++ b/tests/test_dftd4_shared_interface.py
@@ -580,15 +580,43 @@ def test_wheel_metadata_accepts_delocate_rpath_free_layout_but_not_a_dangling_on
         ],
     )
 
+    # Every way a Mach-O dependency can escape the package.  A build-machine
+    # absolute path is the dangerous one: it resolves on the runner that built
+    # the wheel and is missing on the user's Mac.
+    for dependency in (
+        "@rpath/libdftd4.3.dylib",          # nothing left to resolve it
+        "@executable_path/libdftd4.3.dylib",  # depends on who loads it
+        "libdftd4.3.dylib",                 # bare install name
+        "/usr/local/opt/gcc@15/lib/gcc/15/libgfortran.5.dylib",
+    ):
+        try:
+            validate(
+                "liboqp.dylib", rpath_free, "darwin", "@loader_path",
+                [dependency],
+            )
+        except AssertionError as exc:
+            assert "loader-relative" in str(exc), dependency
+        else:
+            raise AssertionError(f"{dependency} passed the wheel gate")
+
+    # Nothing to inspect is not the same as nothing wrong.
+    try:
+        validate("liboqp.dylib", rpath_free, "darwin", "@loader_path", [])
+    except AssertionError as exc:
+        assert "nothing was actually verified" in str(exc)
+    else:
+        raise AssertionError("an unverified library passed the wheel gate")
+
+    # ELF carries bare sonames, so an absent RUNPATH leaves nothing to check:
+    # the requirement stays absolute there, exception or not.
     try:
         validate(
-            "liboqp.dylib", rpath_free, "darwin", "@loader_path",
-            ["@rpath/libdftd4.3.dylib"],
+            "liboqp.so", "", "linux", "$ORIGIN", ["libdftd4.so.3"],
         )
     except AssertionError as exc:
-        assert "through @rpath" in str(exc)
+        assert "lacks package-local RPATH" in str(exc)
     else:
-        raise AssertionError("unresolvable @rpath dependency passed the wheel gate")
+        raise AssertionError("an ELF artifact without RUNPATH passed the wheel gate")
 
 
 def test_macos_package_rpath_sanitizer_is_fail_closed_and_runs_last():

--- a/tests/test_dftd4_shared_interface.py
+++ b/tests/test_dftd4_shared_interface.py
@@ -6,6 +6,7 @@ import array
 import ast
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -107,7 +108,7 @@ def _load_wheel_artifact_helpers():
             "assert_package_local_runtime_search_paths",
         }
     ]
-    namespace = {"re": re}
+    namespace = {"re": re, "os": os}
     exec(compile(ast.Module(body=selected, type_ignores=[]), str(WHEEL_SMOKE), "exec"), namespace)
     return namespace
 
@@ -572,12 +573,15 @@ def test_wheel_metadata_accepts_delocate_rpath_free_layout_but_not_a_dangling_on
     # consumers link against, not an edge this file resolves, so an @rpath ID
     # on an RPATH-free library is normal and must not be read as dangling.
     validate(
-        "liboqp.dylib", rpath_free, "darwin", "@loader_path",
+        "/pkg/oqp/lib/liboqp.dylib", rpath_free, "darwin", "@loader_path",
         [
-            "@rpath/liboqp.dylib",
+            "@rpath/liboqp.dylib",                     # the install ID
             "@loader_path/libdftd4.3.dylib",
+            "@loader_path/../.dylibs/libgfortran.5.dylib",   # delocate's copy
             "/usr/lib/libSystem.B.dylib",
+            "/System/Library/Frameworks/Accelerate.framework/Accelerate",
         ],
+        package_root="/pkg/oqp",
     )
 
     # Every way a Mach-O dependency can escape the package.  A build-machine
@@ -588,14 +592,23 @@ def test_wheel_metadata_accepts_delocate_rpath_free_layout_but_not_a_dangling_on
         "@executable_path/libdftd4.3.dylib",  # depends on who loads it
         "libdftd4.3.dylib",                 # bare install name
         "/usr/local/opt/gcc@15/lib/gcc/15/libgfortran.5.dylib",
+        # Lexically loader-relative, but it climbs out of the wheel and lands
+        # on a library that exists only on the build runner.
+        "@loader_path/../../../../opt/homebrew/lib/libgfortran.5.dylib",
+        # Lexically under /usr/lib, and not a system library at all.
+        "/usr/lib/../../opt/homebrew/lib/libgfortran.5.dylib",
+        # A real, nonlocal edge that happens to share the owner's basename:
+        # skipping by name rather than by position would have let it through.
+        "/build/liboqp.dylib",
     ):
         try:
             validate(
-                "liboqp.dylib", rpath_free, "darwin", "@loader_path",
-                [dependency],
+                "/pkg/oqp/lib/liboqp.dylib", rpath_free, "darwin",
+                "@loader_path", ["@rpath/liboqp.dylib", dependency],
+                package_root="/pkg/oqp",
             )
         except AssertionError as exc:
-            assert "loader-relative" in str(exc), dependency
+            assert "macOS system library" in str(exc), dependency
         else:
             raise AssertionError(f"{dependency} passed the wheel gate")
 

--- a/tests/test_dftd4_shared_interface.py
+++ b/tests/test_dftd4_shared_interface.py
@@ -557,6 +557,40 @@ Load command 21
             raise AssertionError("absolute runtime search path passed wheel gate")
 
 
+def test_wheel_metadata_accepts_delocate_rpath_free_layout_but_not_a_dangling_one():
+    """delocate >= 0.13 removes LC_RPATH after rewriting to @loader_path.
+
+    That layout has no runtime search path at all, which is package-local by
+    construction and must pass.  The same absence with a surviving ``@rpath/``
+    dependency is a library that cannot load, and must still fail.
+    """
+    helpers = _load_wheel_artifact_helpers()
+    validate = helpers["assert_package_local_runtime_search_paths"]
+    rpath_free = "Load command 12\n          cmd LC_SEGMENT_64\n"
+
+    # The first otool -L entry is the library's own LC_ID_DYLIB.  It is a name
+    # consumers link against, not an edge this file resolves, so an @rpath ID
+    # on an RPATH-free library is normal and must not be read as dangling.
+    validate(
+        "liboqp.dylib", rpath_free, "darwin", "@loader_path",
+        [
+            "@rpath/liboqp.dylib",
+            "@loader_path/libdftd4.3.dylib",
+            "/usr/lib/libSystem.B.dylib",
+        ],
+    )
+
+    try:
+        validate(
+            "liboqp.dylib", rpath_free, "darwin", "@loader_path",
+            ["@rpath/libdftd4.3.dylib"],
+        )
+    except AssertionError as exc:
+        assert "through @rpath" in str(exc)
+    else:
+        raise AssertionError("unresolvable @rpath dependency passed the wheel gate")
+
+
 def test_macos_package_rpath_sanitizer_is_fail_closed_and_runs_last():
     sanitizer = MACOS_RPATH_SANITIZER.read_text(encoding="utf-8")
     source = (ROOT / "source" / "CMakeLists.txt").read_text(encoding="utf-8")


### PR DESCRIPTION
Both macOS wheel legs fail their smoke test:

```
AssertionError: .../oqp/lib/liboqp.dylib lacks package-local RPATH @loader_path
```

The wheel is fine. **delocate 0.13.0** changed what it produces: it rewrites
every `@rpath/x` load command to an explicit `@loader_path/x`, and then drops
the `LC_RPATH` it no longer needs.

```
Modifying install name in oqp/lib/liboqp.dylib
  from @rpath/libdftd4.3.dylib to @loader_path/libdftd4.3.dylib
```

That layout is package-local *by construction*, and strictly tighter than an
RPATH — an RPATH is a search list the loader could satisfy from somewhere
else, while `@loader_path/x` names exactly one file. The gate was rejecting an
improvement.

## Why this matters now

The wheel matrix runs on `release`, so nothing in day-to-day CI shows this.
Left alone, the next release publishes **no macOS wheels** and `pip install
openqp` breaks on Mac. delocate 0.13.0 is already on the runners; this arrives
on its own without anyone changing OpenQP.

## What changed

Only the post-repair check. The build-time sanitizer
(`cmake/sanitize_macos_package_rpaths.cmake.in`) is untouched and still
requires `@loader_path` on the install tree.

An empty search path is accepted **only** for a library whose dependencies are
already loader-relative. An `@rpath/` dependency with no RPATH left to resolve
it is a library that cannot load, and stays fatal — so this narrows the
accepted set rather than widening it.

One subtlety: `otool -L` prints a library's own `LC_ID_DYLIB` first, so
`liboqp.dylib` appears to depend on `@rpath/liboqp.dylib` — itself. That ID is
a name consumers link against, not an edge this file resolves, so it is not
counted. `assert_canonical_dependency_graph` already skips the self-edge for
the same reason; this matches it.

Unit tests cover both halves: the RPATH-free layout passes, a dangling
`@rpath` dependency fails.

## Alternative considered

Pinning `delocate<0.13` is one line, but it freezes the tool to avoid a change
that produced a *better* artifact, and only defers the same work to whenever
the pin is lifted.

## Verification

`tests/test_dftd4_shared_interface.py` — 16 passed.

Found while preparing #359 (Windows support); split out because it is
unrelated to Windows and blocks releases on its own.
