### PR TITLE
Release 1.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ unset(_oqp_env_cc)
 unset(_oqp_env_cxx)
 
 project(Open-Quantum-Package
-  VERSION 1.3.0
+  VERSION 1.3.1
   LANGUAGES C CXX Fortran)
 
 include(GNUInstallDirs)

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # docs/openqp-dev-buildenv-hardening-plan.md.
 FROM openqp/openqp-buildenv:1@sha256:83a2ba2108bc2bb1123e7dfac31320833817242681ee41f36e5ee950dfb22a3e AS builder
 
-ARG OPENQP_VERSION=1.3.0
+ARG OPENQP_VERSION=1.3.1
 ARG OPENQP_REVISION
 
 ENV CC=gcc-14 \
@@ -108,7 +108,7 @@ RUN python3 .github/scripts/collect_docker_runtime.py \
 
 FROM python:3.12.13-slim-trixie@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36 AS runtime
 
-ARG OPENQP_VERSION=1.3.0
+ARG OPENQP_VERSION=1.3.1
 ARG OPENQP_REVISION
 LABEL org.opencontainers.image.title="OpenQP" \
       org.opencontainers.image.description="Open Quantum Platform research software" \

--- a/docs/releases/v1.3.1.md
+++ b/docs/releases/v1.3.1.md
@@ -1,0 +1,121 @@
+# OpenQP v1.3.1
+
+OpenQP v1.3.1 makes Windows a supported platform and adds analytic nuclear
+gradients across the correlated-wavefunction stack. Everything from v1.3.0
+still applies; this release adds to it rather than changing existing behaviour.
+
+## Highlights
+
+- **Windows is supported.** `pip install openqp` now works on Windows, built
+  with Intel oneAPI (`ifx`/`icx`) against MKL ILP64
+  ([#359](https://github.com/Open-Quantum-Platform/openqp/pull/359)), on top of
+  Intel compiler support for every platform
+  ([#357](https://github.com/Open-Quantum-Platform/openqp/pull/357)).
+- **Analytic nuclear gradients** for RHF MP2, state-specific CASSCF, SA-CASSCF,
+  SC-NEVPT2, and CASPT2/XMS-CASPT2
+  ([#345](https://github.com/Open-Quantum-Platform/openqp/pull/345),
+  [#346](https://github.com/Open-Quantum-Platform/openqp/pull/346),
+  [#348](https://github.com/Open-Quantum-Platform/openqp/pull/348),
+  [#349](https://github.com/Open-Quantum-Platform/openqp/pull/349),
+  [#350](https://github.com/Open-Quantum-Platform/openqp/pull/350)).
+- **A DFT energy error, found while porting to Intel.** Argument aliasing in
+  the exchange-correlation density path made every DFT energy wrong by roughly
+  0.07-0.25 Ha under `ifx` while GNU builds were unaffected
+  ([#357](https://github.com/Open-Quantum-Platform/openqp/pull/357)).
+
+## New features and scientific capabilities
+
+- Analytic RHF MP2 nuclear gradients
+  ([#345](https://github.com/Open-Quantum-Platform/openqp/pull/345)).
+- Analytic state-specific CASSCF nuclear gradients
+  ([#346](https://github.com/Open-Quantum-Platform/openqp/pull/346)) and
+  analytic SA-CASSCF nuclear gradients
+  ([#348](https://github.com/Open-Quantum-Platform/openqp/pull/348)), replacing
+  the central-difference route for these methods.
+- Analytic strongly contracted NEVPT2 (SC-NEVPT2) nuclear gradients
+  ([#349](https://github.com/Open-Quantum-Platform/openqp/pull/349)).
+- Analytic CASPT2 and XMS-CASPT2 nuclear gradients
+  ([#350](https://github.com/Open-Quantum-Platform/openqp/pull/350)).
+- Numerical nuclear gradients for CASSCF and SA-CASSCF
+  ([#343](https://github.com/Open-Quantum-Platform/openqp/pull/343)), which
+  remain available as a reference route for the analytic implementations above.
+
+## Bug fixes and reliability
+
+- **DFT exchange-correlation density: argument aliasing.** `calc_dft_xc_density`
+  passed the same array as two distinct dummy arguments. Under `ifx` the
+  copy-out of the untouched second temporary zeroed the XC Fock contribution,
+  leaving every DFT energy 0.07-0.25 Ha off while `E_xc` itself looked exact.
+  GNU builds happened to alias in a way that hid it
+  ([#357](https://github.com/Open-Quantum-Platform/openqp/pull/357)).
+- Nine further latent defects surfaced by a second compiler: an unallocated
+  pivot array used before a workspace query, calls through a null `pfon`
+  pointer, `.TRUE.` reaching Python as 255, and intermittent `forrtl 184`
+  aborts from polymorphic intrinsic assignment
+  ([#357](https://github.com/Open-Quantum-Platform/openqp/pull/357)).
+- Huckel guesses with zero beta electrons now initialize and stay within
+  orbital bounds ([#342](https://github.com/Open-Quantum-Platform/openqp/pull/342)).
+- PT2 route ownership is decided inside the route rather than at each call site
+  ([#356](https://github.com/Open-Quantum-Platform/openqp/pull/356)).
+- Recorded the measurement showing the MRSF ROHF Davidson trial-vector diagonal
+  is correct as shipped, closing
+  [#328](https://github.com/Open-Quantum-Platform/openqp/issues/328)
+  ([#351](https://github.com/Open-Quantum-Platform/openqp/pull/351)).
+
+## Packaging, platforms, and CI
+
+- **Windows wheels** for CPython 3.9-3.14 on x86-64
+  ([#359](https://github.com/Open-Quantum-Platform/openqp/pull/359)). They link
+  MKL ILP64 but do not carry it: a single MKL library exceeds PyPI's per-file
+  limit, so `mkl` is a runtime dependency, pinned to the oneAPI series the
+  wheels are compiled against. Installing therefore pulls in `mkl` and
+  `intel-openmp`.
+- **Intel oneAPI is a supported toolchain on every platform**
+  ([#357](https://github.com/Open-Quantum-Platform/openqp/pull/357)).
+- **Windows source builds** require the Intel compilers, Visual Studio Build
+  Tools, and a single-configuration generator. Static builds, multi-config
+  generators, and `ENABLE_DDX` are rejected during configuration with an
+  explanation rather than failing later
+  ([#359](https://github.com/Open-Quantum-Platform/openqp/pull/359)).
+- **macOS wheels build again with delocate 0.13**, which rewrites `@rpath`
+  entries to explicit `@loader_path` and drops the now-unused `LC_RPATH`. The
+  wheel gate accepted only the older layout and would have blocked macOS wheels
+  from this release
+  ([#360](https://github.com/Open-Quantum-Platform/openqp/pull/360)).
+- `.oqp` inputs render on one line, with options that merely restate runtime
+  defaults dropped
+  ([#358](https://github.com/Open-Quantum-Platform/openqp/pull/358)).
+- Tight-binding material was removed from the public repository
+  ([#354](https://github.com/Open-Quantum-Platform/openqp/pull/354)).
+
+### Compatibility notes
+
+- **LP64 is gone.** OpenQP uses one 8-byte BLAS/LAPACK integer model on every
+  platform. `-DLINALG_LIB_INT64=OFF` now fails the configure deliberately, so a
+  stale CMake cache cannot produce a mixed-width build. macOS reaches ILP64
+  through Accelerate's `$NEWLAPACK$ILP64` interface and therefore requires
+  macOS 13.3 or newer.
+- **Windows is x86-64 only.** There is no native Windows-on-ARM wheel, and the
+  source route does not target it either.
+
+## Documentation and developer experience
+
+- Standardized OpenQP theory log output, and added Alireza as an author
+  ([#347](https://github.com/Open-Quantum-Platform/openqp/pull/347)).
+- Corrected the README claim that SA-CASSCF gradients used central differences
+  ([#355](https://github.com/Open-Quantum-Platform/openqp/pull/355)).
+- Corrected the v1.3.0 notes and the OCI attestation verification steps
+  ([#341](https://github.com/Open-Quantum-Platform/openqp/pull/341)).
+
+## Contributors
+
+- Cheol Ho Choi
+
+## Known limitations
+
+- `C2H4_BHHLYP-MRSFTDDFT_MEP` aborts intermittently with `forrtl 184` under
+  Intel builds. The polymorphic-assignment sites found during the port were
+  fixed, and a 96-run stress pass was clean, but the failure has recurred once
+  since; it is not specific to any change in this release.
+
+**Full changelog:** https://github.com/Open-Quantum-Platform/openqp/compare/v1.3.0...v1.3.1

--- a/pyoqp/setup.py
+++ b/pyoqp/setup.py
@@ -1,12 +1,12 @@
 """Retired standalone PyOQP packaging entry point.
 
-OpenQP 1.3.0 is built only from the repository root, where ``pyproject.toml``
+OpenQP 1.3.1 is built only from the repository root, where ``pyproject.toml``
 owns the license expression, bundled license files, native library, and Python
 wrapper as one distribution.  Keeping a second setuptools build below
 ``pyoqp/`` would permit an incomplete artifact without those legal files.
 """
 
-OPENQP_VERSION = "1.3.0"
+OPENQP_VERSION = "1.3.1"
 
 raise SystemExit(
     "pyoqp/setup.py is retired; build OpenQP from the repository root with "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "OpenQP"
-version = "1.3.0"
+version = "1.3.1"
 description = "Python bindings for the Open Quantum Platform (Fortran core + Python wrapper)"
 authors = [
   { name = "Mohsen Mazaherifar", email = "moh.mazaheri@gmail.com" },


### PR DESCRIPTION
Bumps the version to 1.3.1 ahead of the release.

Windows becomes a supported platform in this release: `pip install openqp` now
works there, built with Intel oneAPI (`ifx`/`icx`) against MKL ILP64
([#359](https://github.com/Open-Quantum-Platform/openqp/pull/359)), on top of
the Intel compiler support in
[#357](https://github.com/Open-Quantum-Platform/openqp/pull/357) and the macOS
wheel-repair fix in
[#360](https://github.com/Open-Quantum-Platform/openqp/pull/360).

Version updated in every place `tests/test_release_metadata.py` keeps in sync —
`pyproject.toml`, `CMakeLists.txt`, `pyoqp/setup.py` — plus the `Dockerfile`'s
two `ARG OPENQP_VERSION` lines, which the same test checks and which I would
have missed without it.

Merging this is the prerequisite for tagging `v1.3.1`: the release workflow's
`Verify release tag matches pyproject version` job compares the tag against
`pyproject.toml` and fails the release if they disagree.
