### PR TITLE
Fix two release-triggered CI failures: LF scope, and train-scf-selector on tags

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,20 @@
-# Line endings are part of the artifact, not a local preference.
+# Line endings for the files that are byte-compared between the repository and
+# the distribution.
 #
-# Windows runners check out with core.autocrlf enabled by default, which
-# rewrites LF to CRLF in the working tree.  A wheel built there then ships a
-# LICENSE whose bytes differ from the tagged source, and the release
-# verification refuses it -- correctly, since license text must not change
-# silently between the repository and the distribution.  It cost the v1.3.1
-# release exactly that check.
+# Windows runners check out with core.autocrlf enabled, which rewrites LF to
+# CRLF.  A wheel built there shipped a LICENSE of 8773 bytes against the tagged
+# 8591 -- one extra byte on each of 182 lines -- and release verification
+# refused it, correctly: license text must not change silently between the
+# repository and the distribution.  These are exactly the files pyproject.toml
+# declares in project.license-files.
 #
-# Declaring it here makes the result identical on every machine, instead of
-# depending on each contributor's git configuration.
-* text=auto eol=lf
+# Scoped deliberately.  A repository-wide `* text=auto eol=lf` also normalizes
+# external/dftd4-corresponding-source/patches/**, and Windows patch.exe then
+# fails to apply them ("source matches neither side of patch"), taking the
+# whole DFT-D4 build with it.  Those patches are consumed by a Windows tool,
+# not compared against anything, so they keep whatever the platform gives them.
+LICENSE                  text eol=lf
+LICENSING.md             text eol=lf
+SUSTAINABILITY.md        text eol=lf
+THIRD_PARTY_NOTICES.md   text eol=lf
+licenses/third_party/**  text eol=lf

--- a/.github/workflows/train-scf-selector.yml
+++ b/.github/workflows/train-scf-selector.yml
@@ -2,6 +2,12 @@ name: train-scf-selector
 
 on:
   push:
+    # Branches only.  A tag push matches `push` as well, and the checkout is
+    # then a detached HEAD, so the commit step below has no branch to push to
+    # and the job dies with "You are not currently on a branch" -- which is
+    # what every release tag since v1.3.0 has done.  Retraining belongs to
+    # changes on main, not to tagging.
+    branches: [main]
     paths:
       - "tools/scf-converger-ml/data/**"
       - "tools/scf-converger-ml/geometries/**"
@@ -34,4 +40,11 @@ jobs:
             tools/scf-converger-ml/model/metrics.txt \
             pyoqp/oqp/library/scf_selector_model.py
           git diff --cached --quiet || git commit -m "auto: retrain selector on new data [skip ci]"
-          git push
+          # Belt and braces: a manual dispatch can still be aimed at a tag, and
+          # pushing from a detached HEAD is an error, not a no-op.
+          branch=$(git rev-parse --abbrev-ref HEAD)
+          if [ "$branch" = "HEAD" ]; then
+            echo "::notice::detached HEAD (${{ github.ref }}); trained but not pushing"
+            exit 0
+          fi
+          git push origin "HEAD:$branch"

--- a/docs/releases/v1.3.1.md
+++ b/docs/releases/v1.3.1.md
@@ -57,6 +57,11 @@ still applies; this release adds to it rather than changing existing behaviour.
   orbital bounds ([#342](https://github.com/Open-Quantum-Platform/openqp/pull/342)).
 - PT2 route ownership is decided inside the route rather than at each call site
   ([#356](https://github.com/Open-Quantum-Platform/openqp/pull/356)).
+- The log banner now prints the real version. It said "Version: 1.0 Aug,
+  2024" for two years of releases because nothing tied it to the build; it now
+  derives from CMake's project version, which the release-metadata test keeps
+  in sync with `pyproject.toml`, and a test forbids a literal version from
+  reappearing ([#365](https://github.com/Open-Quantum-Platform/openqp/pull/365)).
 - Recorded the measurement showing the MRSF ROHF Davidson trial-vector diagonal
   is correct as shipped, closing
   [#328](https://github.com/Open-Quantum-Platform/openqp/issues/328)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -40,6 +40,10 @@ message(STATUS ${SOURCES})
 message(STATUS "CMAKE_INSTALL_LIBDIR = ${CMAKE_INSTALL_LIBDIR}")
 set(OTR_LIB_NAME "${CMAKE_STATIC_LIBRARY_PREFIX}opentrustregion${OTR_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
 add_library(oqp ${SOURCES})
+# The log banner prints this; PROJECT_VERSION comes from the VERSION in the
+# top-level project() call, which the release-metadata test keeps in sync with
+# pyproject.toml.
+target_compile_definitions(oqp PRIVATE "OQP_VERSION_STRING='${PROJECT_VERSION}'")
 if(WIN32)
   # The Python runtime (pyoqp/oqp/runtime.py) loads "liboqp.<suffix>" from the
   # configured libdir on every platform.  On Windows CMake would otherwise

--- a/source/modules/oqp_banner.F90
+++ b/source/modules/oqp_banner.F90
@@ -39,6 +39,13 @@ contains
   ! We are getting lot file name from Python via tagarray
 
     character(len=1,kind=c_char), contiguous, pointer :: log_filename(:)
+! The version the build was configured as (CMake PROJECT_VERSION), so the log
+! banner cannot drift from pyproject.toml the way a hard-coded string did --
+! the banner said "1.0 Aug, 2024" for two years of releases.
+#ifndef OQP_VERSION_STRING
+#define OQP_VERSION_STRING 'unknown'
+#endif
+    character(len=57) :: version_line
     character(len=*), parameter :: subroutine_name = "oqp_banner"
     character(len=*), parameter :: tags_general(1) = (/ character(len=80) :: &
           OQP_log_filename /)
@@ -65,7 +72,10 @@ contains
     write(iw, '(10x,   "*                                                         *")')
     write(iw, '(10x,   "*             OpenQP: Open Quantum Platform               *")')
     write(iw, '(10x,   "*                                                         *")')
-    write(iw, '(10x,   "*                Version: 1.0 Aug, 2024                   *")')
+    version_line = ''
+    version_line((57 - len('Version: '//OQP_VERSION_STRING)) / 2 + 1:) = &
+        'Version: '//OQP_VERSION_STRING
+    write(iw, '(10x,"*",a,"*")') version_line
     write(iw, '(10x,   "*                                                         *")')
     write(iw, '(10x,   "***********************************************************")')
     write(iw, '(10x,   "*     The most efficient implementation of MRSF-TDDFT.    *")')

--- a/tests/test_readme_log_metadata.py
+++ b/tests/test_readme_log_metadata.py
@@ -48,6 +48,19 @@ class ReadmeLogMetadataTests(unittest.TestCase):
         self.assertIn("Vladimir Makhnev", banner)
         self.assertIn("Alireza Lashkaripour", banner)
 
+    def test_log_banner_version_comes_from_the_build(self):
+        banner = (ROOT / "source" / "modules" / "oqp_banner.F90").read_text()
+        cmake = (ROOT / "source" / "CMakeLists.txt").read_text()
+
+        # The banner printed "Version: 1.0 Aug, 2024" for two years of
+        # releases because nothing tied it to the real version.  It must use
+        # the compile definition, and no literal version may reappear.
+        self.assertIn("OQP_VERSION_STRING", banner)
+        self.assertNotRegex(banner, r"Version:\s*\d")
+        self.assertIn(
+            "OQP_VERSION_STRING='${PROJECT_VERSION}'", cmake
+        )
+
     def test_package_metadata_lists_alireza_without_invented_contact_data(self):
         metadata = (ROOT / "pyproject.toml").read_text()
 


### PR DESCRIPTION
Narrows the `.gitattributes` rule added in
[#364](https://github.com/Open-Quantum-Platform/openqp/pull/364), which broke
the Windows wheel build.

## What broke

`* text=auto eol=lf` normalized every text file, including
`external/dftd4-corresponding-source/patches/**`. Windows `patch.exe` then
refused them:

```
DFT-D4 source matches neither side of patch:
  mctc-lib-0.4.2-disable-tests.patch
Forward probe: patching file CMakeLists.txt
Assertation failed!
```

That fails the DFT-D4 external build, and with it the whole Windows wheel leg —
visible in the re-cut v1.3.1 release run.

## The fix

Pin only the files the defect was actually about: the license and notice files
that release verification compares byte-for-byte against the tagged source,
which are exactly the entries in `project.license-files`.

```
LICENSE                  text eol=lf
LICENSING.md             text eol=lf
SUSTAINABILITY.md        text eol=lf
THIRD_PARTY_NOTICES.md   text eol=lf
licenses/third_party/**  text eol=lf
```

The patches are consumed by a Windows tool rather than compared against
anything, so they go back to whatever the platform gives them — which is what
worked before #364.

`git add --renormalize .` changes no tracked file.

## On the miss

The original defect was one file class. I fixed it repository-wide because that
is the conventional `.gitattributes` line, without checking what else that
sweeps in — and it swept in patch files that a Windows tool consumes. The
comment in the file now records why the rule is scoped, so the next person does
not widen it again.

## Also here: `train-scf-selector` fails on every release tag

```
fatal: You are not currently on a branch.
```

A tag push matches `push`, the checkout is a detached HEAD, and the step that
commits the retrained model has nowhere to push. Every release tag since v1.3.0
has failed this way, including both v1.3.1 cuts. Restricted to branches, with a
guard for a manual dispatch aimed at a tag.

Folded in rather than opened separately: both are release-triggered CI failures
from the same run, and this PR chain is already long enough.
