### PR TITLE
Gate the NMR developer diagnostics behind verbose>1

### DIFF
--- a/source/modules/nmr_giao_shielding.F90
+++ b/source/modules/nmr_giao_shielding.F90
@@ -112,7 +112,7 @@ contains
     integer :: nbf, nbf2, nat, nocc, nmo, nvir, nocc_b
     integer :: i, j, m, c, t, s, ok, iat
     integer(4) :: status
-    logical :: is_dft, open_shell, iw_open
+    logical :: is_dft, open_shell, iw_open, giao_debug
     real(kind=dp) :: tol, scale_exch
 
     real(kind=dp), allocatable :: h10p(:,:), s10p(:,:)            ! packed (nbf2,3)
@@ -347,32 +347,35 @@ contains
       nmrout(5*(iat-1)+5) = nmrout(5*(iat-1)+1) + nmrout(5*(iat-1)+3)
     end do
 
-    ! --- Emit parseable records ---
+    ! --- Emit parseable records (verbose>1 only; consumed by the GIAO tests) ---
+    giao_debug = infos%control%verbose > 1
     inquire(unit=iw, opened=iw_open)
     if (.not. iw_open) open(unit=iw, file=infos%log_filename, position="append")
-    write(iw,'(/,A)') 'GIAO_SHIELDING_DEBUG_BEGIN native-giao shielding (ppm)'
-    write(iw,'(A,1X,I0)') 'GIAO_SHIELDING_DEBUG_NATOM', nat
-    write(iw,'(A,1X,F10.6)') 'GIAO_SHIELDING_DEBUG_CX', scale_exch
-    do iat = 1, nat
-      do t = 1, 3
-        do s = 1, 3
-          write(iw,'(A,1X,I0,1X,I0,1X,I0,1X,ES24.16)') 'GIAO_SHIELDING_DEBUG_PARA_UNC', &
-            iat, t, s, sig_u(t,s,iat)
-          write(iw,'(A,1X,I0,1X,I0,1X,I0,1X,ES24.16)') 'GIAO_SHIELDING_DEBUG_PARA_CPL', &
-            iat, t, s, sig_c(t,s,iat)
-          write(iw,'(A,1X,I0,1X,I0,1X,I0,1X,ES24.16)') 'GIAO_SHIELDING_DEBUG_DIA', &
-            iat, t, s, sig_dia(t,s,iat)
-          write(iw,'(A,1X,I0,1X,I0,1X,I0,1X,ES24.16)') 'GIAO_SHIELDING_DEBUG_TOTAL', &
-            iat, t, s, sig_tot(t,s,iat)
+    if (giao_debug) then
+      write(iw,'(/,A)') 'GIAO_SHIELDING_DEBUG_BEGIN native-giao shielding (ppm)'
+      write(iw,'(A,1X,I0)') 'GIAO_SHIELDING_DEBUG_NATOM', nat
+      write(iw,'(A,1X,F10.6)') 'GIAO_SHIELDING_DEBUG_CX', scale_exch
+      do iat = 1, nat
+        do t = 1, 3
+          do s = 1, 3
+            write(iw,'(A,1X,I0,1X,I0,1X,I0,1X,ES24.16)') 'GIAO_SHIELDING_DEBUG_PARA_UNC', &
+              iat, t, s, sig_u(t,s,iat)
+            write(iw,'(A,1X,I0,1X,I0,1X,I0,1X,ES24.16)') 'GIAO_SHIELDING_DEBUG_PARA_CPL', &
+              iat, t, s, sig_c(t,s,iat)
+            write(iw,'(A,1X,I0,1X,I0,1X,I0,1X,ES24.16)') 'GIAO_SHIELDING_DEBUG_DIA', &
+              iat, t, s, sig_dia(t,s,iat)
+            write(iw,'(A,1X,I0,1X,I0,1X,I0,1X,ES24.16)') 'GIAO_SHIELDING_DEBUG_TOTAL', &
+              iat, t, s, sig_tot(t,s,iat)
+          end do
         end do
+        write(iw,'(A,1X,I0,4(1X,ES24.16))') 'GIAO_SHIELDING_DEBUG_ISO', iat, &
+          (sig_u(1,1,iat)+sig_u(2,2,iat)+sig_u(3,3,iat))/3.0d0, &
+          (sig_c(1,1,iat)+sig_c(2,2,iat)+sig_c(3,3,iat))/3.0d0, &
+          (sig_dia(1,1,iat)+sig_dia(2,2,iat)+sig_dia(3,3,iat))/3.0d0, &
+          (sig_tot(1,1,iat)+sig_tot(2,2,iat)+sig_tot(3,3,iat))/3.0d0
       end do
-      write(iw,'(A,1X,I0,4(1X,ES24.16))') 'GIAO_SHIELDING_DEBUG_ISO', iat, &
-        (sig_u(1,1,iat)+sig_u(2,2,iat)+sig_u(3,3,iat))/3.0d0, &
-        (sig_c(1,1,iat)+sig_c(2,2,iat)+sig_c(3,3,iat))/3.0d0, &
-        (sig_dia(1,1,iat)+sig_dia(2,2,iat)+sig_dia(3,3,iat))/3.0d0, &
-        (sig_tot(1,1,iat)+sig_tot(2,2,iat)+sig_tot(3,3,iat))/3.0d0
-    end do
-    write(iw,'(A)') 'GIAO_SHIELDING_DEBUG_END'
+      write(iw,'(A)') 'GIAO_SHIELDING_DEBUG_END'
+    end if
 
     ! --- Human-readable production table (GIAO isotropic shielding) ---
     write(iw,'(2/)')

--- a/source/modules/nmr_shielding.F90
+++ b/source/modules/nmr_shielding.F90
@@ -85,7 +85,7 @@ contains
     real(kind=8), allocatable :: sig_para_c(:,:,:), siso_para_c(:), siso_tot_c(:)
     real(kind=8) :: scale_exch, pb_asym, jnorm, knorm
     integer :: nvir, lvir
-    logical :: is_dft
+    logical :: is_dft, nmr_debug
     real(kind=8) :: o(3), com(3), trg, pso_diag_max, pso_asym_max
     integer :: nat, i, c, t, s, nocc, nmo
 
@@ -287,13 +287,16 @@ contains
       end do
     end block
 
-    ! ---- Phase-0 validation gates (reported as diagnostics) ----
-    write(iw,'(/4x,a)') 'Phase-0 magnetic-response gates:'
-    write(iw,'(4x,a,es12.3)') '  gate0  max|P^B + (P^B)^T|        = ', pb_asym
-    write(iw,'(4x,a,es12.3)') '  gate1  ||J(P^B)|| (Coulomb)      = ', jnorm
-    write(iw,'(4x,a,es12.3)') '  gate2  ||K(P^B)|| (exact exch.)  = ', knorm
-    write(iw,'(4x,a,2es12.3)') '  PSO    max|diag|, max|A+A^T|    = ', &
-           pso_diag_max, pso_asym_max
+    ! ---- Phase-0 validation gates (verbose>1 only; consumed by the NMR tests) ----
+    nmr_debug = infos%control%verbose > 1
+    if (nmr_debug) then
+      write(iw,'(/4x,a)') 'Phase-0 magnetic-response gates:'
+      write(iw,'(4x,a,es12.3)') '  gate0  max|P^B + (P^B)^T|        = ', pb_asym
+      write(iw,'(4x,a,es12.3)') '  gate1  ||J(P^B)|| (Coulomb)      = ', jnorm
+      write(iw,'(4x,a,es12.3)') '  gate2  ||K(P^B)|| (exact exch.)  = ', knorm
+      write(iw,'(4x,a,2es12.3)') '  PSO    max|diag|, max|A+A^T|    = ', &
+             pso_diag_max, pso_asym_max
+    end if
     call flush(iw)
 
     deallocate(amom, lfull, gdia, coords, sig_dia, siso_dia)

--- a/tests/test_nmr_coupled.py
+++ b/tests/test_nmr_coupled.py
@@ -60,7 +60,7 @@ def _input(functional):
     grid = "[dftgrid]\nrad_type=becke\n\n" if functional else ""
     return (f"[input]\nsystem=\n{GEOM}\ncharge=0\nruntype=energy\n{fxc}"
             f"basis=sto-3g\nmethod=hf\n\n[guess]\ntype=huckel\n\n"
-            f"[scf]\nmultiplicity=1\ntype=rhf\n\n{grid}"
+            f"[scf]\nmultiplicity=1\ntype=rhf\nverbose=2\n\n{grid}"
             f"[properties]\nscf_prop=nmr\n")
 
 

--- a/tests/test_nmr_giao_para_live.py
+++ b/tests/test_nmr_giao_para_live.py
@@ -59,7 +59,7 @@ def _input(functional):
     grid = "[dftgrid]\nrad_type=mhl\nrad_npts=99\nang_npts=302\n\n" if functional else ""
     return (f"[input]\nsystem=\n{GEOM}\ncharge=0\nruntype=energy\n{fxc}"
             f"basis=sto-3g\nmethod=hf\n\n[guess]\ntype=huckel\n\n"
-            f"[scf]\nmultiplicity=1\ntype=rhf\n\n{grid}[properties]\nscf_prop=\n")
+            f"[scf]\nmultiplicity=1\ntype=rhf\nverbose=2\n\n{grid}[properties]\nscf_prop=\n")
 
 
 class GIAOParaShieldingTests(unittest.TestCase):
@@ -103,7 +103,8 @@ class GIAOParaShieldingTests(unittest.TestCase):
     def _parse(text):
         nat_m = re.search(r"GIAO_SHIELDING_DEBUG_NATOM\s+(\d+)", text)
         if not nat_m:
-            raise AssertionError("GIAO_SHIELDING_DEBUG markers not found")
+            raise AssertionError(
+                "GIAO_SHIELDING_DEBUG markers not found (the records require verbose>1)")
         nat = int(nat_m.group(1))
         unc = [[[0.0] * 3 for _ in range(3)] for _ in range(nat)]
         cpl = [[[0.0] * 3 for _ in range(3)] for _ in range(nat)]

--- a/tests/test_nmr_shielding.py
+++ b/tests/test_nmr_shielding.py
@@ -49,6 +49,7 @@ type=huckel
 [scf]
 multiplicity=1
 type=rhf
+verbose=2
 
 [properties]
 scf_prop=nmr


### PR DESCRIPTION
## Problem

An ordinary NMR calculation writes a large block of developer diagnostics to the log:

```
GIAO_SHIELDING_DEBUG_PARA_UNC 4 2 1   2.5033873862017730E-02
GIAO_SHIELDING_DEBUG_PARA_CPL 4 2 1   3.5988723780111968E-02
GIAO_SHIELDING_DEBUG_DIA      4 2 1  -2.0491738057627468E-01
...
GIAO_SHIELDING_DEBUG_END
```

The `GIAO_SHIELDING_DEBUG_*` records in `nmr_giao_shielding.F90` were written unconditionally, and the production entry point `nmr_giao_shielding` forwards to `nmr_giao_shielding_debug`, so the block appeared in every run — immediately before the human-readable `NMR nuclear magnetic shielding (GIAO)` table that already reports the same isotropic values.

The common-gauge-origin path had the same issue: `nmr_shielding.F90` printed its `Phase-0 magnetic-response gates:` diagnostics (`gate0`/`gate1`/`gate2`/`PSO`) on every run.

## Change

Both blocks are now emitted only when `infos%control%verbose > 1`, matching the convention already used for developer output in `dk_scalar.F90` and `soc_mrsf.F90`. The production shielding tables are unchanged and still print at the default verbosity.

The two tests that parse these records — `tests/test_nmr_giao_para_live.py` and `tests/test_nmr_coupled.py` — set `verbose=2` in the `[scf]` section of their generated input.

No numerical behaviour changes; this only affects what is written to the log.

## Validation

Not yet compile-verified. The change is structural (one declaration, one assignment, and wrapping existing `write` statements in `if`/`end if`), but it has not been through a build — the local build tree predates the GIAO merge, and a fresh package build was out of reach on this host. **Please let CI compile it before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
