### PR TITLE
Keep only the newest CI run per branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,18 @@
 name: CI
 on: [push, pull_request]
+
+# Every push used to leave its predecessor running.  The macOS legs are the
+# scarcest runners in the matrix -- measured queue waits of 16 to 88 minutes on
+# 2026-08-22 -- so a branch pushed three times put six macOS jobs in the queue,
+# four of them already validating superseded code, and the wait they created
+# was paid by every other pull request.  Keep only the newest run per branch.
+#
+# `main` is exempt: a push there is a landed commit, and its result is worth
+# having even once another commit lands on top of it.
+concurrency:
+   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
    gcc-build:
       runs-on: ${{ matrix.os }}


### PR DESCRIPTION
`CI.yml` has no `concurrency` group, so every push leaves its predecessor running.

That is expensive here specifically because of the macOS legs. Measured on 2026-08-22 in this repository, the wait between a macOS job being created and a runner being assigned:

| created | started | wait |
|---|---|---|
| 08:44 | 09:00 | 16 min |
| 07:57 | 08:28 | 31 min |
| 07:45 | 08:25 | 39 min |
| 07:53 | 08:45 | 52 min |
| 08:03 | 08:57 | 54 min |
| 07:45 | 08:44 | 59 min |
| 07:53 | 09:14 | 80 min |
| 08:03 | 09:31 | **88 min** |

Both `macos-15` and `macos-15-intel` regularly sit over an hour. A branch pushed three times therefore puts six macOS jobs in the queue, four of them validating superseded code, and the wait they create is paid by every other open pull request. With four stacked pull requests open at once (#363, #366, #367, #368, each carrying the others' commits) the effect compounds — I watched #363's macOS jobs queue for 71 minutes behind exactly this.

```yaml
concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

`github.head_ref || github.ref` groups by source branch for `pull_request` events and by ref for `push`, so the two triggers on the same branch share one group instead of racing.

`main` is exempt from cancellation: a push there is a landed commit and its result is worth having even after another lands on top.

### What this does not do

I also looked at gating the macOS legs behind a path filter, and dropped it. The macOS job does not merely build — it runs `openqp --run_tests all`, so it is sensitive to `examples/` and `pyoqp/` as well as `source/`, `cmake/` and `external/`. The only changes safe to skip would be documentation-only ones, which is too small a win to justify the added job graph.

No required status check is affected: `main`'s protection has `required_status_checks.contexts = []`.
