### PR TITLE
Canonicalize geometry controls in concise drivers

### DIFF
--- a/docs/native_optimization_recovery.md
+++ b/docs/native_optimization_recovery.md
@@ -9,13 +9,23 @@ geom="molecule.xyz"
 ```
 
 Every geometry driver implemented natively -- `opt`, `ts`, `meci`, `mecp`,
-`tci`, `neb`, `irc`, and `mep` -- uses the native optimizer when `lib` is
-omitted. The automatic native coordinate profile starts in DLC. A different
-backend remains an explicit opt-in; for example, `lib=geometric`:
+`tci`, `neb`, `irc`, and `mep` -- always uses the native optimizer. The
+automatic native coordinate profile starts in DLC. A different backend is
+available only through traditional sectioned `.inp` input; for example,
+`[optimize] lib=geometric`:
 
 ```text
-mrsf-tddftb(nstate=3) opt(S1,lib=geometric,maxit=100) dftb(model=dtcam)
-geom="molecule.xyz"
+[input]
+runtype=optimize
+method=tdhf
+functional=bhhlyp
+basis=6-31g*
+system=molecule.xyz
+
+[optimize]
+istate=1
+lib=geometric
+maxit=100
 ```
 
 ## Electronic recovery is local to one geometry

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -593,11 +593,15 @@ TOP_OPTION_ALIASES = {
 # Public compact-input driver signatures. State selectors (positional S0/S1/T0 or
 # ``root=N`` for SF) are handled separately; the sets below are the concise
 # workflow options that may live directly in the primary call.
-_OPT_OPTIONS = {
+_GEOMETRY_CONVERGENCE_OPTIONS = {
     "maxit", "rmsd_grad", "rmsd_step", "max_grad", "max_step",
-    "energy_shift", "energy_gap", "meci_search", "pen_sigma",
-    "pen_alpha", "pen_incre", "pen_delta", "pen_jump", "gap_weight", "init_scf",
+    "energy_shift", "init_scf",
 }
+_CROSSING_SEARCH_OPTIONS = {
+    "energy_gap", "meci_search", "pen_sigma",
+    "pen_alpha", "pen_incre", "pen_delta", "pen_jump", "gap_weight",
+}
+_OPT_OPTIONS = _GEOMETRY_CONVERGENCE_OPTIONS | _CROSSING_SEARCH_OPTIONS
 # gap_sigma tunes the auglag objective, so only the crossing drivers accept it;
 # mecp_search belongs to MECP alone.  Both are [optimize] schema keys, so the
 # route-driver manifest still owns them, but the driver option sets keep them
@@ -632,7 +636,9 @@ _TCI_OPTIONS = set(_OPT_OPTIONS) - {"meci_search", "pen_delta", "pen_jump"}
 DRIVER_OPTIONS = {
     "energy": set(),
     "grad": {"td_prop", "export", "title"},
-    "optimize": set(_OPT_OPTIONS) | set(_NATIVE_ENGINE_OPTIONS) | set(_NATIVE_CONSTRAINT_OPTIONS),
+    "optimize": (set(_GEOMETRY_CONVERGENCE_OPTIONS)
+                 | set(_NATIVE_ENGINE_OPTIONS)
+                 | set(_NATIVE_CONSTRAINT_OPTIONS)),
     "meci": set(_OPT_OPTIONS) | set(_MECI_PUBLIC_OPTIONS) | set(_CROSSING_OPTIONS) | set(_NATIVE_ENGINE_OPTIONS),
     # MECP reads none of the MECI-only controls, and silently ignoring them
     # would run a different objective than the input asks for.
@@ -642,7 +648,8 @@ DRIVER_OPTIONS = {
              | set(_NATIVE_ENGINE_OPTIONS)),
     "tci": set(_TCI_OPTIONS) | set(_NATIVE_ENGINE_OPTIONS),
     "mep": {"maxit", "points", "step", "mep_step", "gtol"},
-    "ts": set(_OPT_OPTIONS) | set(_NATIVE_ENGINE_OPTIONS) | {"follow", "hessian"},
+    "ts": (set(_GEOMETRY_CONVERGENCE_OPTIONS)
+           | set(_NATIVE_ENGINE_OPTIONS) | {"follow", "hessian"}),
     "irc": {"maxit", "direction", "step", "irc_step", "hessian", "gtol"},
     "neb": {
         "maxit",

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -719,6 +719,8 @@ def _fold_native_section_into_driver(
         raise OQPInputError("Duplicate modifier/section call: oqp")
 
     native = native_calls[0]
+    if native.args:
+        raise OQPInputError("Section call oqp accepts keyword arguments only")
     allowed = OQP_DRIVER_OPTIONS.get(driver.name, set())
     unsupported = set(native.kwargs) - allowed
     if unsupported:
@@ -2577,7 +2579,8 @@ def lower_to_legacy(
                     put("oqp", "mep_step", value)
                 elif key == "gtol":
                     put("oqp", "path_gtol", value)
-            elif name == "ts" and key in {"coordsys", "trust", "trust_max", "follow", "hessian"}:
+            elif name == "ts" and key in (
+                    _NATIVE_ENGINE_OPTIONS | {"follow", "hessian"}):
                 put("oqp", "init_hessian" if key == "hessian" else key, value)
             elif name == "optimize" and key in (
                     _NATIVE_ENGINE_OPTIONS | _NATIVE_CONSTRAINT_OPTIONS):

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -610,13 +610,6 @@ _NATIVE_ENGINE_OPTIONS = {
     "auto_recovery", "recovery_maxit", "recovery_trust",
 }
 _NATIVE_CONSTRAINT_OPTIONS = {"freeze"}
-_GEOMETRIC_ENGINE_OPTIONS = {
-    "coordsys", "trust", "tmax", "convergence_set", "hessian",
-}
-_OPTIMIZER_BACKEND_OPTIONS = (
-    {"lib"} | _NATIVE_ENGINE_OPTIONS | _NATIVE_CONSTRAINT_OPTIONS
-    | _GEOMETRIC_ENGINE_OPTIONS
-)
 _MECI_PUBLIC_OPTIONS = {
     "algorithm", "sigma", "alpha", "delta_beta", "beta_schedule", "gap",
 }
@@ -639,7 +632,7 @@ _TCI_OPTIONS = set(_OPT_OPTIONS) - {"meci_search", "pen_delta", "pen_jump"}
 DRIVER_OPTIONS = {
     "energy": set(),
     "grad": {"td_prop", "export", "title"},
-    "optimize": set(_OPT_OPTIONS) | set(_OPTIMIZER_BACKEND_OPTIONS),
+    "optimize": set(_OPT_OPTIONS) | set(_NATIVE_ENGINE_OPTIONS) | set(_NATIVE_CONSTRAINT_OPTIONS),
     "meci": set(_OPT_OPTIONS) | set(_MECI_PUBLIC_OPTIONS) | set(_CROSSING_OPTIONS) | set(_NATIVE_ENGINE_OPTIONS),
     # MECP reads none of the MECI-only controls, and silently ignoring them
     # would run a different objective than the input asks for.
@@ -689,9 +682,9 @@ DRIVER_OPTIONS = {
     "data": {"scf_prop", "nmr_gauge", "td_prop", "export", "title"},
 }
 
-# Exact ``oqp(...)`` section calls are accepted only when every key is consumed
-# by the selected native workflow.  This prevents valid-looking but ignored
-# controls such as ``energy oqp(init_hessian=analytical)``.
+# ``oqp(...)`` was an early concise spelling for options consumed by the native
+# geometry engine. It remains a read-time compatibility alias only: parsing
+# folds it into the primary driver and canonical rendering never writes it.
 OQP_DRIVER_OPTIONS = {
     "optimize": set(_NATIVE_ENGINE_OPTIONS) | set(_NATIVE_CONSTRAINT_OPTIONS),
     "meci": set(_NATIVE_ENGINE_OPTIONS),
@@ -705,6 +698,47 @@ OQP_DRIVER_OPTIONS = {
         "maxmove", "align", "opt_ends", "end_fmax", "neb_output",
     },
 }
+
+
+def _fold_native_section_into_driver(
+    driver: CallSpec, modifiers: Sequence[CallSpec],
+) -> Tuple[CallSpec, Tuple[CallSpec, ...]]:
+    """Convert an old ``oqp(...)`` call into its public driver spelling."""
+
+    native_calls = [call for call in modifiers if call.name == "oqp"]
+    if not native_calls:
+        return driver, tuple(modifiers)
+    if len(native_calls) > 1:
+        raise OQPInputError("Duplicate modifier/section call: oqp")
+
+    native = native_calls[0]
+    allowed = OQP_DRIVER_OPTIONS.get(driver.name, set())
+    unsupported = set(native.kwargs) - allowed
+    if unsupported:
+        key = sorted(unsupported)[0]
+        raise OQPInputError(
+            "oqp.%s is not used by the native %s workflow; place only "
+            "workflow options in %s(...)" % (key, driver.name, driver.name)
+        )
+
+    rename = {
+        "init_hessian": "hessian",
+        "path_gtol": "gtol",
+        "irc_direction": "direction",
+        "neb_dt": "dt",
+        "neb_output": "output",
+    }
+    options = dict(driver.kwargs)
+    for key, value in native.kwargs.items():
+        public_key = rename.get(key, key)
+        if public_key in options:
+            raise OQPInputError(
+                "Option '%s' is specified in both %s(...) and oqp(...)"
+                % (public_key, driver.name)
+            )
+        options[public_key] = value
+    retained = tuple(call for call in modifiers if call.name != "oqp")
+    return CallSpec(driver.name, driver.args, options, driver.explicit), retained
 
 # Route parentheses describe the electronic model, not an alternate spelling
 # for every legacy section.  Keeping this surface deliberately small prevents
@@ -1206,6 +1240,7 @@ def parse_canonical_oqp(text: str) -> CalculationSpec:
         )
     driver = primary[0] if primary else CallSpec("energy", explicit=False)
     driver = _normalize_driver_defaults(model, driver)
+    driver, modifiers = _fold_native_section_into_driver(driver, modifiers)
     spec = CalculationSpec(
         model=model,
         functional=functional,
@@ -1213,7 +1248,7 @@ def parse_canonical_oqp(text: str) -> CalculationSpec:
         model_options=model_options,
         options=options,
         driver=driver,
-        modifiers=tuple(modifiers),
+        modifiers=modifiers,
         source_text=text,
     )
     _validate_semantics(spec)
@@ -1509,15 +1544,21 @@ def _validate_semantics(spec: CalculationSpec) -> None:
                 "algorithm=auto or algorithm=baeka"
             )
     legacy_backend_options = {
+        "lib",
         "optimizer", "step_size", "step_tol", "mep_maxit",
         "k", "maxg", "avgg", "optep",
     }.intersection(options)
     if legacy_backend_options:
         key = sorted(legacy_backend_options)[0]
+        if key == "lib":
+            raise OQPInputError(
+                "lib is available only in traditional sectioned .inp files; "
+                "concise .oqp geometry drivers always use the native OpenQP engine"
+            )
         if key in {"optimizer", "step_size", "step_tol", "mep_maxit"}:
             raise OQPInputError(
                 "%s is a legacy SciPy-backend option. Concise .oqp workflows "
-                "support lib=oqp or lib=geometric." % key
+                "always use the native OpenQP engine." % key
             )
         replacement = {
             "k": "spring", "maxg": "fmax", "avgg": "frms", "optep": "opt_ends",
@@ -1531,35 +1572,9 @@ def _validate_semantics(spec: CalculationSpec) -> None:
     if unknown_driver_options:
         key = sorted(unknown_driver_options)[0]
         raise OQPInputError(
-            "%s does not define option '%s'; use the exact legacy section call for advanced options"
+            "%s does not define option '%s'; use the concise section that owns advanced options"
             % (driver.name, key)
         )
-    backend = str(options.get("lib", "oqp")).strip().lower()
-    if driver.name == "optimize":
-        if backend not in {"oqp", "geometric"}:
-            raise OQPInputError(
-                "opt lib must be oqp or geometric in concise .oqp input"
-            )
-        if backend == "geometric":
-            native_only = {
-                "trust_max", "auto_recovery", "recovery_maxit",
-                "recovery_trust", "freeze",
-            }.intersection(options)
-            if native_only:
-                raise OQPInputError(
-                    "%s is a native lib=oqp option; use geomeTRIC tmax or a "
-                    "traditional constraints file as appropriate"
-                    % sorted(native_only)[0]
-                )
-        else:
-            geometric_only = {
-                "tmax", "convergence_set", "hessian",
-            }.intersection(options)
-            if geometric_only:
-                raise OQPInputError(
-                    "%s is available only with opt(...,lib=geometric)"
-                    % sorted(geometric_only)[0]
-                )
     if driver.name in {"optimize", "meci", "mecp", "tci", "mep", "ts", "irc", "neb"}:
         if "maxit" in options:
             if not _is_positive_integer(options["maxit"]):
@@ -1571,20 +1586,7 @@ def _validate_semantics(spec: CalculationSpec) -> None:
             raise OQPInputError(
                 "coordsys must be auto, tric, dlc, ric, internal, cart, or cartesian"
             )
-        if driver.name == "optimize" and backend == "geometric":
-            try:
-                trust = float(options.get("trust", 0.1))
-                tmax = float(options.get("tmax", 0.3))
-            except (TypeError, ValueError) as exc:
-                raise OQPInputError(
-                    "geomeTRIC trust and tmax must be positive numbers"
-                ) from exc
-            if (not math.isfinite(trust) or not math.isfinite(tmax)
-                    or trust <= 0 or tmax <= 0 or trust > tmax):
-                raise OQPInputError(
-                    "geomeTRIC trust and tmax require 0 < trust <= tmax"
-                )
-        elif {"trust", "trust_max"}.intersection(options):
+        if {"trust", "trust_max"}.intersection(options):
             try:
                 trust = float(options.get("trust", 0.2))
                 trust_max = float(options.get("trust_max", 0.5))
@@ -2043,106 +2045,6 @@ def _validate_semantics(spec: CalculationSpec) -> None:
                 "Option '%s' is specified in both %s(...) and %s(...)"
                 % (sorted(overlap)[0], driver.name, call.name)
             )
-
-    oqp_call = modifier_by_name.get("oqp")
-    if oqp_call is not None:
-        allowed_oqp = OQP_DRIVER_OPTIONS.get(driver.name, set())
-        ignored = set(oqp_call.kwargs) - allowed_oqp
-        if ignored:
-            key = sorted(ignored)[0]
-            raise OQPInputError(
-                "oqp.%s is not used by the native %s workflow"
-                % (key, driver.name)
-            )
-        if "init_hessian" in oqp_call.kwargs:
-            policy = str(oqp_call.kwargs["init_hessian"]).strip().lower()
-            if policy not in {"model", "numerical", "analytical"}:
-                raise OQPInputError(
-                    "oqp.init_hessian must be model, numerical, or analytical"
-                )
-        if "irc_direction" in oqp_call.kwargs:
-            direction = str(oqp_call.kwargs["irc_direction"]).strip().lower()
-            if direction not in {"forward", "backward", "reverse"}:
-                raise OQPInputError(
-                    "oqp.irc_direction must be forward or backward"
-                )
-        if "coordsys" in oqp_call.kwargs:
-            coordsys = str(oqp_call.kwargs["coordsys"]).strip().lower()
-            if coordsys not in {
-                "auto", "tric", "dlc", "ric", "internal", "cart", "cartesian",
-            }:
-                raise OQPInputError(
-                    "oqp.coordsys must be auto, tric, dlc, ric, internal, cart, or cartesian"
-                )
-        if {"trust", "trust_max"}.intersection(oqp_call.kwargs):
-            try:
-                trust = float(oqp_call.kwargs.get("trust", 0.2))
-                trust_max = float(oqp_call.kwargs.get("trust_max", 0.5))
-            except (TypeError, ValueError) as exc:
-                raise OQPInputError("oqp.trust and oqp.trust_max must be positive numbers") from exc
-            if (not math.isfinite(trust) or not math.isfinite(trust_max)
-                    or trust <= 0 or trust_max <= 0 or trust > trust_max):
-                raise OQPInputError("oqp trust controls require 0 < trust <= trust_max")
-        if "freeze" in oqp_call.kwargs:
-            _validate_freeze_spec(oqp_call.kwargs["freeze"])
-        if "follow" in oqp_call.kwargs:
-            if not _is_non_negative_integer(oqp_call.kwargs["follow"]):
-                raise OQPInputError("oqp.follow must be a non-negative mode index")
-        for key in {
-            "spring", "fmax", "frms", "climb_fmax", "neb_dt", "maxmove",
-            "end_fmax", "irc_step", "mep_step", "path_gtol",
-        }.intersection(oqp_call.kwargs):
-            try:
-                value = float(oqp_call.kwargs[key])
-                if not math.isfinite(value) or value <= 0:
-                    raise ValueError
-            except (TypeError, ValueError) as exc:
-                raise OQPInputError("oqp.%s must be a positive number" % key) from exc
-        for key in {"climb", "align", "opt_ends"}.intersection(oqp_call.kwargs):
-            if not isinstance(oqp_call.kwargs[key], bool):
-                raise OQPInputError("oqp.%s must be true or false" % key)
-        native_aliases = {
-            "coordsys": "coordsys", "trust": "trust", "trust_max": "trust_max",
-        }
-        if driver.name == "optimize":
-            native_aliases.update({"freeze": "freeze"})
-        elif driver.name == "ts":
-            native_aliases.update({"follow": "follow", "hessian": "init_hessian"})
-        elif driver.name == "mep":
-            native_aliases.update({"step": "mep_step", "mep_step": "mep_step"})
-        elif driver.name == "irc":
-            native_aliases.update({
-                "direction": "irc_direction", "step": "irc_step", "irc_step": "irc_step",
-            })
-        elif driver.name == "neb":
-            native_aliases.update({
-                "spring": "spring", "climb": "climb", "fmax": "fmax",
-                "frms": "frms", "climb_fmax": "climb_fmax", "dt": "neb_dt",
-                "neb_dt": "neb_dt", "maxmove": "maxmove", "align": "align",
-                "opt_ends": "opt_ends", "end_fmax": "end_fmax",
-                "output": "neb_output",
-            })
-        for public_key, section_key in native_aliases.items():
-            if public_key in options and section_key in oqp_call.kwargs:
-                raise OQPInputError(
-                    "%s and oqp.%s specify the same native control; use one form"
-                    % (public_key, section_key)
-                )
-        if driver.name == "neb":
-            effective_climb = oqp_call.kwargs.get(
-                "climb", options.get("climb", True)
-            )
-            effective_fmax = float(oqp_call.kwargs.get(
-                "fmax", options.get("fmax", 2.0e-3)
-            ))
-            effective_climb_fmax = float(oqp_call.kwargs.get(
-                "climb_fmax", options.get("climb_fmax", 0.05)
-            ))
-            if effective_climb and effective_climb_fmax < effective_fmax:
-                raise OQPInputError(
-                    "neb climb_fmax must be greater than or equal to fmax when climb=true"
-                )
-
 
 def _internal_root(model: str, state: StateRef) -> int:
     if state.root is not None:
@@ -2636,16 +2538,8 @@ def lower_to_legacy(
             put("properties", key, value)
     elif name in {"optimize", "mep", "ts", "irc", "neb"}:
         put("optimize", "istate", roots[0] if roots else 0)
-        optimizer_backend = str(
-            driver_options.get("lib", "oqp")
-        ).strip().lower()
         for key, value in driver_options.items():
-            if name == "optimize" and key == "lib":
-                put("optimize", "lib", optimizer_backend)
-            elif (name == "optimize" and optimizer_backend == "geometric"
-                  and key in _GEOMETRIC_ENGINE_OPTIONS):
-                put("geometric", key, value)
-            elif name == "neb" and key in {"product", "images", "nimage"}:
+            if name == "neb" and key in {"product", "images", "nimage"}:
                 target_key = "nimage" if key in {"images", "nimage"} else "product"
                 if target_key == "product":
                     value = _resolve_path(value, source_dir)

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -1503,6 +1503,8 @@ def test_native_minimum_accepts_frozen_distance_constraints():
          "positive number"),
         ('dft/pbe0/def2-svp geom="h2o.xyz" opt(S0,trust=nan)',
          "0 < trust <= trust_max"),
+        ('dft/pbe0/def2-svp geom="h2o.xyz" opt(S0) oqp(dlc)',
+         "accepts keyword arguments only"),
     ],
 )
 def test_native_exact_section_controls_cannot_be_ignored_or_invalid(text, message):
@@ -1524,6 +1526,23 @@ def test_legacy_native_section_is_folded_into_the_canonical_driver():
     assert legacy["oqp"] == {
         "coordsys": "dlc", "trust": "0.1", "trust_max": "0.3",
     }
+
+
+def test_legacy_ts_recovery_controls_remain_in_the_native_section():
+    spec = oqp_input.parse_canonical_oqp(
+        'dft/pbe0/def2-svp geom="ts.xyz" ts(S0) '
+        'oqp(auto_recovery=false,recovery_maxit=5,recovery_trust=0.01)'
+    )
+
+    legacy = oqp_input.lower_to_legacy(spec)
+    assert legacy["oqp"] == {
+        "auto_recovery": "False",
+        "recovery_maxit": "5",
+        "recovery_trust": "0.01",
+    }
+    assert not {
+        "auto_recovery", "recovery_maxit", "recovery_trust",
+    }.intersection(legacy["optimize"])
 
 
 def test_ekt_parent_state_uses_physical_mrsf_label():

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -1424,6 +1424,27 @@ def test_default_normalization_does_not_hide_lossy_numeric_types():
         )
 
 
+@pytest.mark.parametrize("driver", ["opt(S0", "ts(S0"])
+@pytest.mark.parametrize(
+    "option",
+    [
+        "energy_gap=1e-5",
+        "meci_search=auto",
+        "pen_sigma=1",
+        "pen_alpha=0.02",
+        "pen_incre=1",
+        "pen_delta=0.025",
+        'pen_jump="10,25"',
+        "gap_weight=1",
+    ],
+)
+def test_minimum_and_ts_reject_crossing_search_options(driver, option):
+    with pytest.raises(OQPInputError, match="does not define option"):
+        oqp_input.parse_canonical_oqp(
+            f'dft/pbe0/6-31g* geom="g.xyz" {driver},{option})'
+        )
+
+
 def test_tci_retains_legacy_multiplicative_controls():
     _, legacy = _parse(
         'mrsf(nstate=5)/bhhlyp/6-31g* geom="guess.xyz" '

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -1160,7 +1160,7 @@ def test_irc_public_options_lower_to_owning_sections():
     assert legacy["oqp"]["path_gtol"] == "2e-05"
     assert legacy["hess"]["type"] == "analytical"
 
-    with pytest.raises(OQPInputError, match="does not define option 'lib'"):
+    with pytest.raises(OQPInputError, match="available only in traditional sectioned .inp"):
         oqp_input.parse_canonical_oqp(
             'dft/pbe0/def2-svp geom="ts.xyz" irc(S0,lib=geometric,step=0.1)'
         )
@@ -1238,21 +1238,20 @@ def test_geometry_drivers_are_native_and_mep_aliases_map_correctly():
         "init_hessian": "numerical", "coordsys": "dlc", "trust": "0.1",
         "trust_max": "0.3", "follow": "1",
     }
-    with pytest.raises(OQPInputError, match="does not define option 'lib'"):
+    with pytest.raises(OQPInputError, match="available only in traditional sectioned .inp"):
         oqp_input.parse_canonical_oqp(
             'dft/pbe0/def2-svp geom="ts.xyz" ts(S0,lib=geometric)'
         )
 
 
-def test_readable_opt_supports_native_recovery_and_explicit_geometric_backend():
+def test_readable_opt_supports_native_recovery_without_a_backend_selector():
     native_text = """
 mrsf-tddftb(nstate=3)
-opt(S0,lib=oqp,maxit=100,auto_recovery=true,recovery_maxit=40,recovery_trust=0.02)
+opt(S0,maxit=100,auto_recovery=true,recovery_maxit=40,recovery_trust=0.02)
 dftb(model=dtcam-tb)
 geom="c60.xyz"
 """
     native_spec, native = _parse(native_text)
-    assert native["optimize"]["lib"] == "oqp"
     assert native["oqp"]["auto_recovery"] == "True"
     assert native["oqp"]["recovery_maxit"] == "40"
     assert native["oqp"]["recovery_trust"] == "0.02"
@@ -1260,36 +1259,11 @@ geom="c60.xyz"
     assert " opt(S0,maxit=100,recovery_maxit=40)" in rendered_native
     assert rendered_native.rstrip().endswith('geom="c60.xyz"')
 
-    geometric_text = """
-mrsf-tddftb(nstate=3)
-opt(S0,lib=geometric,maxit=200,coordsys=dlc,trust=0.02,tmax=0.05,
-    convergence_set=GAU,hessian=never)
-dftb(model=dtcam-tb)
-geom="c60.xyz"
-"""
-    geometric_spec, geometric = _parse(geometric_text)
-    assert geometric["optimize"]["lib"] == "geometric"
-    assert geometric["geometric"] == {
-        "coordsys": "dlc",
-        "trust": "0.02",
-        "tmax": "0.05",
-        "convergence_set": "GAU",
-        "hessian": "never",
-    }
-    reparsed_geometric = oqp_input.parse_canonical_oqp(
-        oqp_input.render_canonical_oqp(geometric_spec)
-    )
-    # convergence_set=GAU and hessian=never restate geomeTRIC defaults, so
-    # the canonical rendering omits them without changing the request.
-    assert set(reparsed_geometric.driver.kwargs) == {
-        "lib", "maxit", "coordsys", "trust", "tmax"
-    }
-    schema = oqp_input._load_schema_defaults()
-    assert oqp_input._effective_config(
-        oqp_input.lower_to_legacy(reparsed_geometric), schema
-    ) == oqp_input._effective_config(geometric, schema)
-    assert reparsed_geometric.modifiers == geometric_spec.modifiers
-    assert reparsed_geometric.options == geometric_spec.options
+    with pytest.raises(OQPInputError, match="available only in traditional sectioned .inp"):
+        oqp_input.parse_canonical_oqp(
+            'mrsf-tddftb(nstate=3) opt(S0,lib=geometric,maxit=200) '
+            'dftb(model=dtcam-tb) geom="c60.xyz"'
+        )
 
 
 def test_dftb_preset_allows_explicit_first_try_trah_mixer():
@@ -1307,12 +1281,11 @@ geom="alanine-dipeptide.xyz"
 @pytest.mark.parametrize(
     "options,message",
     [
-        ("lib=scipy", "must be oqp or geometric"),
-        ("lib=geometric,trust=0.2,tmax=0.1", "0 < trust <= tmax"),
-        ("lib=geometric,trust_max=0.2", "native lib=oqp option"),
-        ("lib=oqp,tmax=0.1", "only with opt.*lib=geometric"),
-        ("lib=oqp,auto_recovery=1", "must be true or false"),
-        ("lib=oqp,recovery_maxit=0", "positive integer"),
+        ("lib=scipy", "available only in traditional sectioned .inp"),
+        ("lib=geometric,trust=0.2", "available only in traditional sectioned .inp"),
+        ("tmax=0.1", "does not define option 'tmax'"),
+        ("auto_recovery=1", "must be true or false"),
+        ("recovery_maxit=0", "positive integer"),
     ],
 )
 def test_readable_opt_rejects_backend_option_mismatches(options, message):
@@ -1516,6 +1489,22 @@ def test_native_exact_section_controls_cannot_be_ignored_or_invalid(text, messag
         oqp_input.parse_canonical_oqp(text)
 
 
+def test_legacy_native_section_is_folded_into_the_canonical_driver():
+    spec = oqp_input.parse_canonical_oqp(
+        'dft/pbe0/def2-svp geom="h2o.xyz" '
+        'opt(S0,maxit=40) oqp(coordsys=dlc,trust=0.1,trust_max=0.3)'
+    )
+
+    assert oqp_input.render_canonical_oqp(spec) == (
+        'dft/pbe0/def2-svp opt(maxit=40,coordsys=dlc,trust=0.1,trust_max=0.3)\n'
+        'geom="h2o.xyz"\n'
+    )
+    legacy = oqp_input.lower_to_legacy(spec)
+    assert legacy["oqp"] == {
+        "coordsys": "dlc", "trust": "0.1", "trust_max": "0.3",
+    }
+
+
 def test_ekt_parent_state_uses_physical_mrsf_label():
     _, legacy = _parse(
         'mrsf(nstate=3)/bhhlyp/6-31g* geom="h2o.xyz" ekt(S0,ip=true,ea=false)'
@@ -1669,7 +1658,7 @@ def test_mrsf_prop_has_an_explicit_or_default_physical_state():
 
 
 def test_primary_call_rejects_unknown_convenience_option_with_section_hint():
-    with pytest.raises(OQPInputError, match="exact legacy section call"):
+    with pytest.raises(OQPInputError, match="concise section that owns advanced options"):
         oqp_input.parse_canonical_oqp(
             'mrsf/bhhlyp/6-31g* geom="h2o.xyz" opt(S0,rad_npts=100)'
         )

--- a/tests/test_oqp_input_schema_manifest.py
+++ b/tests/test_oqp_input_schema_manifest.py
@@ -227,7 +227,7 @@ def test_all_generic_schema_keys_survive_parse_render_reparse_and_lower():
     assert len(checked) == 357
 
 
-def test_geometric_backend_is_canonical_only_through_opt_driver_options():
+def test_concise_geometry_drivers_reject_legacy_backend_selectors():
     oqp_input = _load_oqp_input()
 
     assert oqp_input.LEGACY_ONLY_SCHEMA_KEYS == {
@@ -238,10 +238,15 @@ def test_geometric_backend_is_canonical_only_through_opt_driver_options():
         }),
         "neb": frozenset({"k", "maxg", "avgg", "climb", "align", "optep"}),
     }
-    spec = oqp_input.parse_canonical_oqp(
-        'dft/pbe0/def2-svp opt(S0,lib=geometric,coordsys=dlc) geom="h2o.xyz"'
-    )
-    assert oqp_input.lower_to_legacy(spec)["optimize"]["lib"] == "geometric"
+    for selector in ("lib=oqp", "lib=geometric"):
+        try:
+            oqp_input.parse_canonical_oqp(
+                f'dft/pbe0/def2-svp opt(S0,{selector}) geom="h2o.xyz"'
+            )
+        except oqp_input.OQPInputError as exc:
+            assert "traditional sectioned .inp" in str(exc)
+        else:
+            raise AssertionError("concise .oqp must not expose optimizer backends")
     try:
         oqp_input.parse_canonical_oqp(
             'dft/pbe0/def2-svp opt(S0) geometric(coordsys=tric) geom="h2o.xyz"'


### PR DESCRIPTION
## Summary
- fold legacy `oqp(...)` controls into the geometry driver that consumes them
- render canonical concise inputs without a separate `oqp(...)` call
- keep legacy sectioned inputs compatible while rejecting backend selectors in concise `.oqp` files
- reject MECI/MECP crossing controls in ordinary `opt(...)` and `ts(...)` calculations

## Why
The former syntax separated native geometry settings from `opt`, `ts`, `meci`, `mecp`, `tci`, `mep`, `irc`, and `neb`, which allowed duplicate or silently unused settings. Driver ownership makes each concise input describe the calculation OpenQP actually performs.

## Documentation
Companion manual update: Open-Quantum-Platform/openqp-docs#49

## Verification
- Python compilation passed for the parser and parser tests
- all 297 shipped concise `.oqp` examples parsed successfully
- focused parser assertions passed, including TS recovery lowering, rejection of positional `oqp(...)` arguments, and rejection of crossing-only controls in `opt`/`ts`
- full package test suite was not run locally because this worktree does not have the managed OpenQP build environment