### PR TITLE
Keep only the newest CI run per pull request

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,23 @@
 name: CI
 on: [push, pull_request]
+
+# Without this, every push leaves its predecessor running.  On 2026-08-22, 22 of
+# the 34 CI runs that day were still executing when a later push superseded
+# them -- about 1000 run-minutes, and 44 macOS jobs validating code that had
+# already been replaced.  The macOS legs are the scarcest runners in the matrix
+# (measured queue waits that day: 16 to 88 minutes), so that backlog is paid as
+# latency by every other open pull request.
+#
+# The key is the PR number for pull_request events rather than the branch name:
+# these PRs come from forks, and a branch name can repeat across forks while a
+# PR number cannot.  Branch pushes fall back to the ref.  A push to main gets a
+# per-commit group so that landed commits neither cancel nor queue behind each
+# other -- only one run per group may be pending, so grouping them would drop
+# the middle commit's result when three land in quick succession.
+concurrency:
+   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'shared' }}
+   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
    gcc-build:
       runs-on: ${{ matrix.os }}


### PR DESCRIPTION
`CI.yml` has no `concurrency` group, so every push leaves its predecessor running.

Measured on 2026-08-22 in this repository: **22 of that day's 34 CI runs were still executing when a later push superseded them** — about 1000 run-minutes, and 44 macOS jobs validating code that had already been replaced. Worst single case was `codex/ddx-windows-runtime`: eleven pushes, ten of them leaving a live run behind.

That backlog is paid as latency by every other open pull request, because the macOS legs are the scarcest runners in the matrix. Queue waits that day:

| created | started | wait |
|---|---|---|
| 08:44 | 09:00 | 16 min |
| 07:57 | 08:28 | 31 min |
| 07:45 | 08:25 | 39 min |
| 07:53 | 08:45 | 52 min |
| 08:03 | 08:57 | 54 min |
| 07:45 | 08:44 | 59 min |
| 07:53 | 09:14 | 80 min |
| 08:03 | 09:31 | **88 min** |

#363's macOS jobs sat queued for 71 minutes behind exactly this.

```yaml
concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'shared' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

Three deliberate choices:

* **Keyed on the PR number, not the branch name.** These pull requests come from forks. A branch name can repeat across forks; a PR number cannot. Branch pushes fall back to the ref.
* **`main` gets a per-commit group.** GitHub allows only one *pending* run per group, so grouping main's pushes would silently drop the middle commit's result when three land in quick succession. Landed commits should neither cancel nor queue behind each other.
* **Cancellation is disabled for `main`** for the same reason.

No required status check is affected: `main`'s protection has `required_status_checks.contexts = []`.

### Considered and not done

Gating the macOS legs behind a path filter. The macOS job does not merely build — it runs `openqp --run_tests all`, so it is sensitive to `examples/` and `pyoqp/` as well as `source/`, `cmake/` and `external/`. Only documentation-only changes would be safe to skip, which is too small a win for the extra job graph.

(Supersedes #374, which was keyed on the branch name and did not exempt `main` from grouping.)
