### PR TITLE
Persist MRSF state-interaction data for post-run analysis

### DIFF
--- a/pyoqp/oqp/molecule/molecule.py
+++ b/pyoqp/oqp/molecule/molecule.py
@@ -115,6 +115,7 @@ class Molecule:
             'OQP::VEC_MO_A', 'OQP::VEC_MO_B',
             'OQP::Hcore', 'OQP::SM', 'OQP::TM', 'OQP::WAO',
             'OQP::td_abxc', 'OQP::td_bvec_mo', 'OQP::td_mrsf_density', 'OQP::td_energies',
+            'OQP::td_trans_density_mo', 'OQP::td_trans_dipole', 'OQP::td_dip_ao',
             'OQP::mrsf_ekt_density_mo', 'OQP::mrsf_ekt_lagrangian_mo', 'OQP::mrsf_ekt_fock_mo',
             'OQP::mrsf_ekt_orbitals_mo', 'OQP::mrsf_ekt_eigenvalues', 'OQP::mrsf_ekt_strengths',
             'OQP::hf_hessian',

--- a/tests/test_json_td_layout.py
+++ b/tests/test_json_td_layout.py
@@ -53,6 +53,33 @@ class TestJsonTdLayout(unittest.TestCase):
         self.assertEqual(get_data_calls, [])
         self.assertEqual(len(save_data_calls), 1)
 
+    def test_full_json_preserves_mrsf_state_interaction_data(self):
+        source = (ROOT / "pyoqp/oqp/molecule/molecule.py").read_text()
+        tree = ast.parse(source)
+        molecule = next(
+            node for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "Molecule"
+        )
+        init = next(
+            node for node in molecule.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+        )
+        tag_assignment = next(
+            node for node in ast.walk(init)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Attribute) and target.attr == "tag"
+                for target in node.targets
+            )
+        )
+        tags = {item.value for item in tag_assignment.value.elts}
+
+        self.assertTrue({
+            "OQP::td_trans_density_mo",
+            "OQP::td_trans_dipole",
+            "OQP::td_dip_ao",
+        }.issubset(tags))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- preserve the validated MRSF state-interaction 1-TDM in full JSON exports
- preserve the corresponding transition-dipole and AO dipole tags
- keep lean regression JSON behavior unchanged

## Why
Desktop and external analysis tools need the physical-root density data after the OpenQP process exits to generate S0->Sn NTO and attachment/detachment maps. Keeping these existing tags in the full JSON makes local and frozen bundled engines expose the same analysis contract.

## Verification
- `python3 tests/test_json_td_layout.py` using the Codex bundled Python: 4 tests passed
- `git diff --check`

No electronic-structure algorithm or saved lean regression reference is changed.