### PR TITLE
Make MRSF response-vector signs reproducible within a build (#371)

### DIFF
--- a/source/modules/tdhf_mrsf_energy.F90
+++ b/source/modules/tdhf_mrsf_energy.F90
@@ -138,6 +138,12 @@ contains
     integer :: nbf, nbf2, xvec_dim
     integer :: mxvec, ist, jst, iend, nvec, novec
     integer :: iter, nv, iv, ivec
+    !> Deterministic-phase pinning for the reported response vectors.
+    integer :: iphase_pin, iphase_pair
+    real(kind=dp) :: phase_amax
+    !> Two amplitudes this close in magnitude are treated as tied and the lower
+    !> index wins.  Same value as FCI_PHASE_TIE_RTOL / _CI_PHASE_TIE_RTOL.
+    real(kind=dp), parameter :: MRSF_PHASE_TIE_RTOL = 1.0e-8_dp
     integer :: diag_index, i
     integer :: mxiter
     logical :: tamm_dancoff
@@ -961,6 +967,41 @@ contains
     call flush(iw)
 
     call trfrmb(bvec_mo, for_trnsf_b_vec, nvec, nstates)
+
+!   Give each reported response vector a deterministic sign.  Nothing in the
+!   solve fixes the sign of an eigenvector, so every quantity built from one --
+!   transition dipoles, NACs, SOC matrix elements -- carries a sign that is not
+!   a property of the calculation: it changes with the BLAS, the thread count
+!   and the machine.  Measured on C4H6_BHHLYP_UMRSFTDDFT_ENERGY, where rerunning
+!   an unmodified tree reproduces every |mu| to 1e-9 while the stored vectors
+!   come back sign-flipped (max|d mu| = 4.658 against the committed file).
+!
+!   The rule is the largest-magnitude amplitude positive, with near-ties
+!   resolved by the LOWEST index: an exact tie is measure-zero, but two
+!   amplitudes agreeing to round-off are not, and picking by index keeps the
+!   choice stable across platforms where argmax alone would not be.
+!
+!   The tie window matches MRSF_PHASE_TIE_RTOL below, which is the value the CI
+!   convention already uses (FCI_PHASE_TIE_RTOL in fci_driver.F90,
+!   _CI_PHASE_TIE_RTOL in fci.py).  A narrower window was tried first and is not
+!   enough: at 1e-10 the same deck built against MKL ILP64 and against
+!   OpenBLAS64 -- same compiler, BLAS the only difference -- picked different
+!   largest amplitudes and so fixed opposite signs, magnitudes agreeing to
+!   4.2e-11 while the raw vectors differed by 4.651.
+    do ist = 1, nstates
+      phase_amax = maxval(abs(bvec_mo(:,ist)))
+      if (phase_amax <= 0.0_dp) cycle
+      iphase_pin = 0
+      do iphase_pair = 1, xvec_dim
+        if (abs(bvec_mo(iphase_pair,ist)) >= phase_amax*(1.0_dp - MRSF_PHASE_TIE_RTOL)) then
+          iphase_pin = iphase_pair
+          exit
+        end if
+      end do
+      if (iphase_pin > 0) then
+        if (bvec_mo(iphase_pin,ist) < 0.0_dp) bvec_mo(:,ist) = -bvec_mo(:,ist)
+      end if
+    end do
 
     select case (mrst)
       case(1)


### PR DESCRIPTION
Addresses part of #371. Supersedes #382 and #381 — see *Scope* for what changed and why.

## The defect

Nothing in the MRSF solve fixes the sign of a response vector, so the same deck run twice **on the same machine** could return opposite signs for everything built from one. Measured against pristine `main`, `C4H6_BHHLYP_UMRSFTDDFT_ENERGY` at `OMP_NUM_THREADS` 1 and 2, raw values with signs:

```
td_trans_dipole   max|d| = 4.651        (every |mu| agrees to 1e-9)
```

Pinning the sign right after `trfrmb` takes that to **5.9e-11**. The rule is the largest-magnitude amplitude positive, near-ties resolved by the lowest index, using the tie window the CI convention already uses (`FCI_PHASE_TIE_RTOL` / `_CI_PHASE_TIE_RTOL`, `1e-8`).

## What this does not do

Each of these was measured, not assumed.

**It does not make signs portable across BLAS implementations.** Same source, compiler fixed at GCC 13.3, BLAS the only variable:

| deck | GCC + OpenBLAS64 vs GCC + MKL ILP64 |
|---|---|
| `C4H6_BHHLYP_UMRSFTDDFT_ENERGY` `td_trans_dipole` | raw **2.8e-11** — portable |
| `H2O_BHHLYP_SOC` `td_trans_dipole` | raw **2.636**, magnitudes **6.4e-13** — **not** portable |

In the failing case exactly one of twelve states flips: state 10, a clean global sign reversal (`opp = 6.4e-13`). It is **not** degenerate — 3.3e-2 and 6.1e-3 Ha from its neighbours. Two amplitudes *within* its response vector are closer than `1e-8`, so each BLAS picks a different largest one. Widening the window further would begin mis-tying genuinely distinct amplitudes, so no single window fixes both cases.

**It therefore does not make it safe to store signs in a reference.** The `phase_invariant` marking on `nac` and `td_trans_dipole` stays, and **no reference is regenerated here** — the full suite passes against the committed values unchanged. An earlier revision of this work regenerated twelve references to match the new signs; that was wrong, because the stored signs would then be correct only for the BLAS that produced them.

**It does not touch the CI side.** `canonicalize_ci_phase` and `canonical_phase` (#366) already fix that convention, and a control run of pristine `main` shows the CASPT2 effective Hamiltonian is already deterministic there — **1.8e-12** between one and two threads. An earlier revision claimed this change fixed the `6.085e-03` Ha flip #363 recorded; that was measured without a control and was wrong.

## No energy is affected

The sign of an eigenvector is a gauge freedom. Every energy array in the comparisons above agrees to between 1.8e-13 and 4.7e-14. What this change buys is reproducibility of signed *derived* quantities within a build, not accuracy.

## Result

One file, `+41/-0`. Full example suite: **291 passed, 0 failed, 6 skipped**.

#371 stays open: half of it — cross-implementation sign agreement — appears not to be achievable by a tie window at all, and deserves its own discussion.
