### PR TITLE
docs: make README functionality tables collapsible

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ for method, keyword, and build references.
 
 ### Functionality
 
-#### Electronic-Structure Methods
+<details>
+<summary><strong>Electronic-Structure Methods</strong></summary>
 
 | Method | References / variants | Available calculations | Learn |
 | --- | --- | --- | --- |
@@ -46,7 +47,10 @@ for method, keyword, and build references.
 | CASSCF | State-specific CASSCF and state-averaged SA-CASSCF | Energies and analytic nuclear gradients: state specific, the weighted SA-CASSCF objective, and an individual averaged root through the coupled orbital/CI Z-vector; the legacy `method=casscf` plus `[state_average]` spelling stays on central differences | [Guide](https://open-quantum-platform.github.io/openqp-docs/workflows/casscf-gradient/) |
 | Multireference PT2 | SS/MS/XMS-CASPT2, `nevpt2` / `sc-nevpt2`, and MRMP2/MCQDPT2/XMCQDPT2 | Correlated energies and central-difference nuclear gradients for supported geometry workflows | [Examples](examples/WF_methods) |
 
-#### Capabilities
+</details>
+
+<details>
+<summary><strong>Capabilities</strong></summary>
 
 | Capability | Scope | Available calculations | Learn |
 | --- | --- | --- | --- |
@@ -66,7 +70,10 @@ for method, keyword, and build references.
 | Nonadiabatic dynamics | MRSF-TDDFT fewest-switches surface hopping with state tracking and decoherence | Internal-conversion trajectories through `runtype=namd` | [Examples](examples/ODP) |
 | QM/MM and SOC-NAMD-QMMM | ESPF electrostatic embedding through OpenMM with MRSF-TDDFT | Embedded energies and forces, QM/MM dynamics, and spin-orbit-coupled surface hopping | [QM/MM tutorial](https://open-quantum-platform.github.io/openqp-tutorials/qmmm-embedding/) · [Dynamics tutorial](https://open-quantum-platform.github.io/openqp-tutorials/soc-namd-qmmm/) |
 
-#### Ecosystem & Integrations
+</details>
+
+<details>
+<summary><strong>Ecosystem &amp; Integrations</strong></summary>
 
 | Integration | Purpose |
 | --- | --- |
@@ -78,6 +85,8 @@ for method, keyword, and build references.
 | [Molden](https://www.theochem.ru.nl/molden/) format | Standards-oriented geometry, basis, SCF/Dyson orbitals, and optional frequency sections for common graphics tools |
 | [OpenqpView](https://open-quantum-platform.github.io/OpenqpView/) | Browser-based inspection of log, JSON, Molden, cube, and XYZ outputs |
 | Optional [MOKIT](https://github.com/1234zou/MOKIT) | Broader external wavefunction conversion workflows |
+
+</details>
 
 ### Install
 


### PR DESCRIPTION
## Summary

- make the Electronic-Structure Methods table collapsible on GitHub
- make the Capabilities and Ecosystem & Integrations tables independently collapsible
- keep installation, quick-start, and other compact README sections visible by default

## Validation

- `git diff --check upstream/main...HEAD`
- rendered the README with GitHub's GFM API
- verified three `details` controls, three summaries, and three rendered tables
