### PR TITLE
fix(input): accept space-separated route components

### DIFF
--- a/examples/OQP_INPUT/H2O_MRSF_S0_OPT.oqp
+++ b/examples/OQP_INPUT/H2O_MRSF_S0_OPT.oqp
@@ -1,2 +1,2 @@
-mrsf/bhhlyp/6-31g* opt(maxit=1)
+mrsf bhhlyp 6-31g* opt(maxit=1)
 geom="h2o.xyz"

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -1015,6 +1015,26 @@ def _normalize_basis_value(value: str) -> str:
     return value.lower()
 
 
+def _split_route_token(token: str) -> List[str]:
+    """Split route separators while preserving slash-bearing component names."""
+
+    raw_parts = _split_top_level(token, "/")
+    parts: List[str] = []
+    index = 0
+    while index < len(raw_parts):
+        if (
+            index + 1 < len(raw_parts)
+            and raw_parts[index].lower() == "pbe-3"
+            and raw_parts[index + 1].lower() == "8"
+        ):
+            parts.append(raw_parts[index] + "/" + raw_parts[index + 1])
+            index += 2
+        else:
+            parts.append(raw_parts[index])
+            index += 1
+    return parts
+
+
 def _parse_route_components(
     parts: Sequence[str], route: str
 ) -> Tuple[str, Dict[str, Any], str, str]:
@@ -1074,6 +1094,10 @@ def _parse_route_components(
             "%s is not a route option for %s; use the exact section call %s(%s=...)"
             % (key, alias, section, key)
         )
+    component_values: List[str] = []
+    for part in parts[1:]:
+        parsed = _parse_value(part)
+        component_values.append(parsed if isinstance(parsed, str) else part)
     functional = ""
     basis = ""
     if model in {
@@ -1091,11 +1115,11 @@ def _parse_route_components(
             "mrsf-hf", "umrsf-hf", "sf-hf", "tda-hf", "dftb", "dftb0", "tddftb",
             "tda-dftb", "sf-dftb", "mrsf-dftb",
         } | WF_MODELS:
-            basis = parts[1]
+            basis = component_values[0]
         else:
-            functional = parts[1]
+            functional = component_values[0]
     elif len(parts) == 3:
-        functional, basis = parts[1], parts[2]
+        functional, basis = component_values
     if model in {"dft", "rks", "uks", "roks", "tddft", "tda", "mrsf", "umrsf", "sf"} and not functional:
         raise OQPInputError("%s requires a functional in the route" % model)
     normalized_basis = _normalize_basis_value(basis)
@@ -1103,7 +1127,7 @@ def _parse_route_components(
 
 
 def _parse_route(route: str) -> Tuple[str, Dict[str, Any], str, str]:
-    return _parse_route_components(_split_top_level(route, "/"), route)
+    return _parse_route_components(_split_route_token(route), route)
 
 
 def _starts_post_route_syntax(token: str) -> bool:
@@ -1150,9 +1174,9 @@ def _starts_post_route_syntax(token: str) -> bool:
         probable_route_component = any(
             char.isdigit() or char == "-" for char in raw_name
         )
-        if not probable_route_component:
-            return True
-        return bool(difflib.get_close_matches(name, call_names, n=1, cutoff=0.6))
+        if probable_route_component:
+            return False
+        return True
     return False
 
 
@@ -1162,9 +1186,8 @@ def _route_component_variants(tokens: Sequence[str]) -> List[List[str]]:
     variants: List[List[str]] = [[]]
     for token in tokens:
         choices = [[token]]
-        split = _split_top_level(token, "/")
-        # PBE-3/8 is a registered functional name, not a mixed route spelling.
-        if len(split) > 1 and token.lower() != "pbe-3/8":
+        split = _split_route_token(token)
+        if len(split) > 1:
             choices.append(split)
         variants = [
             prefix + choice

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -1102,12 +1102,22 @@ def _starts_post_route_syntax(token: str) -> bool:
     if Path(token).suffix.lower() in {".xyz", ".pdb"}:
         return True
     name = token.split("(", 1)[0].lower().replace("-", "_")
-    return (
+    known_call = (
         name in PRIMARY_ALIASES
         or name in BARE_MODIFIER_CALLS
         or name in SECTION_NAMES
         or name in {"nmr", "ir", "raman", "d4"}
     )
+    if known_call:
+        return True
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*\(.*\)", token, re.DOTALL):
+        call_names = (
+            list(PRIMARY_ALIASES)
+            + list(SECTION_NAMES)
+            + ["nmr", "ir", "raman", "d4"]
+        )
+        return bool(difflib.get_close_matches(name, call_names, n=1, cutoff=0.6))
+    return False
 
 
 def _parse_route_prefix(

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -1094,6 +1094,56 @@ def _parse_route(route: str) -> Tuple[str, Dict[str, Any], str, str]:
     return model, model_options, functional.lower(), normalized_basis
 
 
+def _starts_post_route_syntax(token: str) -> bool:
+    """Return whether *token* cannot be another route component."""
+
+    if "=" in token:
+        return True
+    if Path(token).suffix.lower() in {".xyz", ".pdb"}:
+        return True
+    name = token.split("(", 1)[0].lower().replace("-", "_")
+    return (
+        name in PRIMARY_ALIASES
+        or name in BARE_MODIFIER_CALLS
+        or name in SECTION_NAMES
+        or name in {"nmr", "ir", "raman", "d4"}
+    )
+
+
+def _parse_route_prefix(
+    tokens: Sequence[str],
+) -> Tuple[str, Dict[str, Any], str, str, int]:
+    """Parse a slash- or whitespace-separated route at the token prefix.
+
+    A route contains at most three components.  Joining only the leading
+    non-driver tokens lets ``mrsf bhhlyp 6-31g*`` and mixed spellings denote
+    the same calculation as ``mrsf/bhhlyp/6-31g*`` without consuming a bare
+    driver, a geometry file, or an explicit ``basis=...`` option.
+    """
+
+    candidates: List[Tuple[int, str]] = []
+    for count in range(1, min(len(tokens), 3) + 1):
+        if count > 1 and _starts_post_route_syntax(tokens[count - 1]):
+            break
+        candidate = "/".join(tokens[:count])
+        if len(_split_top_level(candidate, "/")) > 3:
+            break
+        candidates.append((count, candidate))
+
+    errors: List[OQPInputError] = []
+    for count, candidate in reversed(candidates):
+        try:
+            model, model_options, functional, basis = _parse_route(candidate)
+        except OQPInputError as exc:
+            errors.append(exc)
+            continue
+        return model, model_options, functional, basis, count
+
+    if errors:
+        raise errors[-1]
+    raise OQPInputError("Missing electronic-structure route")
+
+
 def looks_canonical(text: str) -> bool:
     """Return whether malformed text should be treated as canonical, not prose."""
 
@@ -1153,12 +1203,20 @@ def parse_canonical_oqp(text: str) -> CalculationSpec:
             "geom=\"h2o.xyz\" on one or more lines."
         )
     tokens = _split_top_level(cleaned)
-    model, model_options, functional, basis = _parse_route(tokens[0])
+    model, model_options, functional, basis, route_token_count = (
+        _parse_route_prefix(tokens)
+    )
     options: Dict[str, Any] = {}
     calls: List[CallSpec] = []
-    for token_index, token in enumerate(tokens[1:], start=1):
+    for token_index, token in enumerate(
+        tokens[route_token_count:], start=route_token_count
+    ):
         assignment = _split_assignment(token)
-        if token_index == 1 and assignment is None and "(" not in token:
+        if (
+            token_index == route_token_count
+            and assignment is None
+            and "(" not in token
+        ):
             positional_geom = _parse_value(token)
             if (
                 isinstance(positional_geom, str)

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -1015,8 +1015,16 @@ def _normalize_basis_value(value: str) -> str:
     return value.lower()
 
 
-def _parse_route(route: str) -> Tuple[str, Dict[str, Any], str, str]:
-    parts = _split_top_level(route, "/")
+def _parse_route_components(
+    parts: Sequence[str], route: str
+) -> Tuple[str, Dict[str, Any], str, str]:
+    """Parse already-separated route components.
+
+    Keeping this separate from the slash spelling is important for functional
+    names such as ``PBE-3/8``: whitespace supplies an unambiguous component
+    boundary that must not be lost by joining the tokens with ``/`` first.
+    """
+
     if not parts or len(parts) > 3:
         raise OQPInputError(
             "Route must be model[/functional][/basis], got: %s" % route
@@ -1094,6 +1102,10 @@ def _parse_route(route: str) -> Tuple[str, Dict[str, Any], str, str]:
     return model, model_options, functional.lower(), normalized_basis
 
 
+def _parse_route(route: str) -> Tuple[str, Dict[str, Any], str, str]:
+    return _parse_route_components(_split_top_level(route, "/"), route)
+
+
 def _starts_post_route_syntax(token: str) -> bool:
     """Return whether *token* cannot be another route component."""
 
@@ -1129,8 +1141,36 @@ def _starts_post_route_syntax(token: str) -> bool:
                 and name[-1] == name[-2]
                 and name[:-1] in call_names
             )
+        # Parenthesized basis variants have a digit or hyphen in their family
+        # name (for example 6-31g(2df,p) and def2-svp(jkfit)).  Other
+        # identifier-shaped calls must reach normal call validation even when
+        # their name is not close enough for a spelling suggestion.
+        probable_basis = any(char.isdigit() or char == "-" for char in name)
+        if not probable_basis:
+            return True
         return bool(difflib.get_close_matches(name, call_names, n=1, cutoff=0.6))
     return False
+
+
+def _route_component_variants(tokens: Sequence[str]) -> List[List[str]]:
+    """Return route-component interpretations without losing token boundaries."""
+
+    variants: List[List[str]] = [[]]
+    for token in tokens:
+        choices = [[token]]
+        split = _split_top_level(token, "/")
+        # PBE-3/8 is a registered functional name, not a mixed route spelling.
+        if len(split) > 1 and token.lower() != "pbe-3/8":
+            choices.append(split)
+        variants = [
+            prefix + choice
+            for prefix in variants
+            for choice in choices
+            if len(prefix) + len(choice) <= 3
+        ]
+    # Prefer interpretations that fill all route components.  For equal
+    # lengths, the construction order preserves whitespace-delimited tokens.
+    return sorted(variants, key=len, reverse=True)
 
 
 def _parse_route_prefix(
@@ -1144,26 +1184,31 @@ def _parse_route_prefix(
     driver, a geometry file, or an explicit ``basis=...`` option.
     """
 
-    candidates: List[Tuple[int, str]] = []
+    candidates: List[Tuple[int, List[str], str]] = []
     for count in range(1, min(len(tokens), 3) + 1):
         if count > 1 and _starts_post_route_syntax(tokens[count - 1]):
             break
-        candidate = "/".join(tokens[:count])
-        if len(_split_top_level(candidate, "/")) > 3:
-            break
-        candidates.append((count, candidate))
+        display = " ".join(tokens[:count])
+        for parts in _route_component_variants(tokens[:count]):
+            candidates.append((count, parts, display))
 
     errors: List[OQPInputError] = []
-    for count, candidate in reversed(candidates):
+    for count, parts, display in sorted(
+        candidates, key=lambda candidate: candidate[0], reverse=True
+    ):
         try:
-            model, model_options, functional, basis = _parse_route(candidate)
+            model, model_options, functional, basis = _parse_route_components(
+                parts, display
+            )
         except OQPInputError as exc:
             errors.append(exc)
             continue
         return model, model_options, functional, basis, count
 
     if errors:
-        raise errors[-1]
+        # Candidates are ordered from the most complete interpretation to the
+        # least.  Preserve the diagnostic from that best interpretation.
+        raise errors[0]
     raise OQPInputError("Missing electronic-structure route")
 
 

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -1114,14 +1114,21 @@ def _starts_post_route_syntax(token: str) -> bool:
     )
     if known_call:
         return True
-    if re.fullmatch(
+    call_shape = re.fullmatch(
         r"[A-Za-z_][A-Za-z0-9_-]*(?:\(.*\))?", token, re.DOTALL
-    ):
+    )
+    if call_shape:
         call_names = (
             list(PRIMARY_ALIASES)
             + list(SECTION_NAMES)
             + ["nmr", "ir", "raman", "d4"]
         )
+        if "(" not in token:
+            return (
+                len(name) > 1
+                and name[-1] == name[-2]
+                and name[:-1] in call_names
+            )
         return bool(difflib.get_close_matches(name, call_names, n=1, cutoff=0.6))
     return False
 

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -1099,7 +1099,11 @@ def _starts_post_route_syntax(token: str) -> bool:
 
     if "=" in token:
         return True
-    if Path(token).suffix.lower() in {".xyz", ".pdb"}:
+    token_value = _parse_value(token)
+    if (
+        isinstance(token_value, str)
+        and Path(token_value).suffix.lower() in {".xyz", ".pdb"}
+    ):
         return True
     name = token.split("(", 1)[0].lower().replace("-", "_")
     known_call = (
@@ -1110,7 +1114,9 @@ def _starts_post_route_syntax(token: str) -> bool:
     )
     if known_call:
         return True
-    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*\(.*\)", token, re.DOTALL):
+    if re.fullmatch(
+        r"[A-Za-z_][A-Za-z0-9_-]*(?:\(.*\))?", token, re.DOTALL
+    ):
         call_names = (
             list(PRIMARY_ALIASES)
             + list(SECTION_NAMES)

--- a/pyoqp/oqp/utils/oqp_input.py
+++ b/pyoqp/oqp/utils/oqp_input.py
@@ -1117,7 +1117,8 @@ def _starts_post_route_syntax(token: str) -> bool:
         and Path(token_value).suffix.lower() in {".xyz", ".pdb"}
     ):
         return True
-    name = token.split("(", 1)[0].lower().replace("-", "_")
+    raw_name = token.split("(", 1)[0].lower()
+    name = raw_name.replace("-", "_")
     known_call = (
         name in PRIMARY_ALIASES
         or name in BARE_MODIFIER_CALLS
@@ -1141,12 +1142,15 @@ def _starts_post_route_syntax(token: str) -> bool:
                 and name[-1] == name[-2]
                 and name[:-1] in call_names
             )
-        # Parenthesized basis variants have a digit or hyphen in their family
-        # name (for example 6-31g(2df,p) and def2-svp(jkfit)).  Other
-        # identifier-shaped calls must reach normal call validation even when
-        # their name is not close enough for a spelling suggestion.
-        probable_basis = any(char.isdigit() or char == "-" for char in name)
-        if not probable_basis:
+        # Parenthesized route components have a digit or hyphen in their family
+        # name (for example CAM-QTP(00), 6-31g(2df,p), and
+        # def2-svp(jkfit)). Other identifier-shaped calls must reach normal
+        # call validation even when their name is not close enough for a
+        # spelling suggestion.
+        probable_route_component = any(
+            char.isdigit() or char == "-" for char in raw_name
+        )
+        if not probable_route_component:
             return True
         return bool(difflib.get_close_matches(name, call_names, n=1, cutoff=0.6))
     return False

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -26,6 +26,94 @@ def _parse(text, source_dir=None):
     return spec, oqp_input.lower_to_legacy(spec, source_dir=source_dir)
 
 
+@pytest.mark.parametrize(
+    ("slash_route", "spaced_route"),
+    [
+        ("mrsf(nstate=5)/bhhlyp/6-31g*", "mrsf(nstate=5) bhhlyp 6-31g*"),
+        ("dft/pbe0/def2-svp", "dft pbe0 def2-svp"),
+        ("tddft(nstate=3)/pbe/6-31g", "tddft(nstate=3) pbe 6-31g"),
+        ("mrsf-tdhf(nstate=3)/6-31g*", "mrsf-tdhf(nstate=3) 6-31g*"),
+        ("mp2(reference=uhf)/cc-pvdz", "mp2(reference=uhf) cc-pvdz"),
+        ("ccsd(t)/6-31g", "ccsd(t) 6-31g"),
+        ("casscf/sto-3g", "casscf sto-3g"),
+    ],
+)
+def test_space_separated_route_components_match_slash_routes(
+    slash_route, spaced_route
+):
+    suffix = ' geom="h2o.xyz" energy'
+    slash_spec, slash_legacy = _parse(slash_route + suffix)
+    spaced_spec, spaced_legacy = _parse(spaced_route + suffix)
+
+    assert spaced_spec.model == slash_spec.model
+    assert spaced_spec.functional == slash_spec.functional
+    assert spaced_spec.basis == slash_spec.basis
+    assert spaced_spec.model_options == slash_spec.model_options
+    assert spaced_legacy == slash_legacy
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "mrsf(nstate=3)/bhhlyp 6-31g*",
+        "mrsf(nstate=3) bhhlyp/6-31g*",
+    ],
+)
+def test_mixed_route_separators_are_accepted(route):
+    spec, legacy = _parse(route + ' geom="h2o.xyz" grad(S1)')
+
+    assert spec.model == "mrsf"
+    assert spec.functional == "bhhlyp"
+    assert spec.basis == "6-31g*"
+    assert legacy["input"]["method"] == "tdhf"
+
+
+def test_space_separated_route_stops_before_explicit_basis_and_driver():
+    spec = oqp_input.parse_canonical_oqp(
+        'mrsf bhhlyp basis="FILE:My Basis.JSON" geom="h2o.xyz" energy'
+    )
+    assert spec.basis == "file:My Basis.JSON"
+
+    dftb = oqp_input.parse_canonical_oqp('dftb geom="h2o.xyz" energy')
+    assert dftb.model == "dftb"
+    assert dftb.driver.name == "energy"
+
+    with pytest.raises(OQPInputError, match="requires a basis set"):
+        oqp_input.parse_canonical_oqp('dft pbe0 geom="h2o.xyz" energy')
+    with pytest.raises(OQPInputError, match="requires a basis set"):
+        oqp_input.parse_canonical_oqp('hf geom="h2o.xyz" energy')
+
+
+@pytest.mark.parametrize(
+    ("alias", "model"), sorted(oqp_input.MODEL_ALIASES.items())
+)
+def test_every_model_alias_accepts_its_route_components_as_separate_tokens(
+    alias, model
+):
+    functional_models = {
+        "dft", "rks", "uks", "roks", "tddft", "tda", "mrsf", "umrsf", "sf"
+    }
+    component_free_models = {
+        "dftb", "dftb0", "tddftb", "tda-dftb", "sf-dftb", "mrsf-dftb"
+    }
+    if model in functional_models:
+        tokens = [alias, "pbe0", "sto-3g", "energy"]
+        expected_count = 3
+    elif model in component_free_models:
+        tokens = [alias, "energy"]
+        expected_count = 1
+    else:
+        tokens = [alias, "sto-3g", "energy"]
+        expected_count = 2
+
+    parsed_model, _, functional, basis, count = oqp_input._parse_route_prefix(tokens)
+
+    assert parsed_model == model
+    assert count == expected_count
+    assert functional == ("pbe0" if model in functional_models else "")
+    assert basis == ("" if model in component_free_models else "sto-3g")
+
+
 def test_mrsf_s1_opt_hides_reference_and_root_bookkeeping(tmp_path):
     spec, legacy = _parse(
         'mrsf(nstate=5)/bhhlyp/6-31g* geom="h2o.xyz" charge=0 '

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -86,7 +86,10 @@ def test_space_separated_route_stops_before_explicit_basis_and_driver():
 
 @pytest.mark.parametrize(
     ("misspelling", "suggestion"),
-    [("gradd(S0)", "grad"), ("scff(conv=1e-8)", "scf")],
+    [
+        ("gradd(S0)", "grad"),
+        ("scff(conv=1e-8)", "scf"),
+    ],
 )
 def test_space_separated_route_does_not_consume_call_misspellings_as_basis(
     misspelling, suggestion
@@ -97,6 +100,26 @@ def test_space_separated_route_does_not_consume_call_misspellings_as_basis(
         oqp_input.parse_canonical_oqp(
             'dft pbe0 %s geom="h2o.xyz"' % misspelling
         )
+
+
+@pytest.mark.parametrize("misspelling", ["gradd", "scff"])
+def test_space_separated_route_does_not_consume_bare_call_misspellings_as_basis(
+    misspelling,
+):
+    with pytest.raises(OQPInputError, match=r"Expected a call.*%s" % misspelling):
+        oqp_input.parse_canonical_oqp(
+            'dft pbe0 %s geom="h2o.xyz"' % misspelling
+        )
+
+
+@pytest.mark.parametrize("geometry", ['"h2o.xyz"', '"my geometry.xyz"'])
+def test_quoted_positional_geometry_stops_a_space_separated_route(geometry):
+    spec = oqp_input.parse_canonical_oqp(
+        'dft pbe0 %s basis=def2-svp energy' % geometry
+    )
+
+    assert spec.basis == "def2-svp"
+    assert spec.options["geom"] == geometry.strip('"')
 
 
 @pytest.mark.parametrize("basis", ["6-31g(2df,p)", "def2-svp(jkfit)"])

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -85,6 +85,30 @@ def test_space_separated_route_stops_before_explicit_basis_and_driver():
 
 
 @pytest.mark.parametrize(
+    ("misspelling", "suggestion"),
+    [("gradd(S0)", "grad"), ("scff(conv=1e-8)", "scf")],
+)
+def test_space_separated_route_does_not_consume_call_misspellings_as_basis(
+    misspelling, suggestion
+):
+    with pytest.raises(
+        OQPInputError, match=r"Unknown \.oqp call:.*Did you mean '%s" % suggestion
+    ):
+        oqp_input.parse_canonical_oqp(
+            'dft pbe0 %s geom="h2o.xyz"' % misspelling
+        )
+
+
+@pytest.mark.parametrize("basis", ["6-31g(2df,p)", "def2-svp(jkfit)"])
+def test_call_shaped_basis_names_remain_route_components(basis):
+    spec = oqp_input.parse_canonical_oqp(
+        'dft pbe0 %s geom="h2o.xyz" energy' % basis
+    )
+
+    assert spec.basis == basis
+
+
+@pytest.mark.parametrize(
     ("alias", "model"), sorted(oqp_input.MODEL_ALIASES.items())
 )
 def test_every_model_alias_accepts_its_route_components_as_separate_tokens(

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -142,6 +142,19 @@ def test_slash_inside_space_separated_functional_preserves_component_boundary():
     assert spec.basis == "6-31g"
 
 
+@pytest.mark.parametrize("functional", ["CAM-QTP(00)", "CAM-QTP(01)", "CAM-QTP(02)"])
+def test_parenthesized_space_separated_functional_is_a_route_component(functional):
+    spaced = oqp_input.parse_canonical_oqp(
+        'dft %s sto-3g geom="h2o.xyz" energy' % functional
+    )
+    slash = oqp_input.parse_canonical_oqp(
+        'dft/%s/sto-3g geom="h2o.xyz" energy' % functional
+    )
+
+    assert spaced.functional == slash.functional == functional.lower()
+    assert spaced.basis == slash.basis == "sto-3g"
+
+
 @pytest.mark.parametrize("geometry", ['"h2o.xyz"', '"my geometry.xyz"'])
 def test_quoted_positional_geometry_stops_a_space_separated_route(geometry):
     spec = oqp_input.parse_canonical_oqp(

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -112,6 +112,19 @@ def test_space_separated_route_does_not_consume_bare_call_misspellings_as_basis(
         )
 
 
+@pytest.mark.parametrize("functional", ["tpss", "blyp", "bp86"])
+def test_valid_functionals_resembling_bare_calls_remain_route_components(functional):
+    spaced = oqp_input.parse_canonical_oqp(
+        'dft %s 6-31g geom="h2o.xyz" energy' % functional
+    )
+    slash = oqp_input.parse_canonical_oqp(
+        'dft/%s/6-31g geom="h2o.xyz" energy' % functional
+    )
+
+    assert spaced.functional == slash.functional == functional
+    assert spaced.basis == slash.basis == "6-31g"
+
+
 @pytest.mark.parametrize("geometry", ['"h2o.xyz"', '"my geometry.xyz"'])
 def test_quoted_positional_geometry_stops_a_space_separated_route(geometry):
     spec = oqp_input.parse_canonical_oqp(

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -142,6 +142,19 @@ def test_slash_inside_space_separated_functional_preserves_component_boundary():
     assert spec.basis == "6-31g"
 
 
+@pytest.mark.parametrize(
+    "route",
+    ["dft/pbe-3/8 6-31g", "dft pbe-3/8/6-31g"],
+)
+def test_slash_bearing_functional_survives_mixed_route_separators(route):
+    spec = oqp_input.parse_canonical_oqp(
+        route + ' geom="h2o.xyz" energy'
+    )
+
+    assert spec.functional == "pbe-3/8"
+    assert spec.basis == "6-31g"
+
+
 @pytest.mark.parametrize("functional", ["CAM-QTP(00)", "CAM-QTP(01)", "CAM-QTP(02)"])
 def test_parenthesized_space_separated_functional_is_a_route_component(functional):
     spaced = oqp_input.parse_canonical_oqp(
@@ -153,6 +166,22 @@ def test_parenthesized_space_separated_functional_is_a_route_component(functiona
 
     assert spaced.functional == slash.functional == functional.lower()
     assert spaced.basis == slash.basis == "sto-3g"
+
+
+def test_parenthesized_basis_resembling_a_call_remains_a_route_component():
+    spec = oqp_input.parse_canonical_oqp(
+        'dft pbe0 dhf-SV(P) geom="h2o.xyz" energy'
+    )
+
+    assert spec.basis == "dhf-sv(p)"
+
+
+def test_quoted_space_separated_basis_is_unquoted():
+    spec = oqp_input.parse_canonical_oqp(
+        'hf "DZ (Dunning-Hay)" geom="h2o.xyz" energy'
+    )
+
+    assert spec.basis == "dz (dunning-hay)"
 
 
 @pytest.mark.parametrize("geometry", ['"h2o.xyz"', '"my geometry.xyz"'])

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -102,6 +102,13 @@ def test_space_separated_route_does_not_consume_call_misspellings_as_basis(
         )
 
 
+def test_space_separated_route_does_not_consume_unknown_call_as_basis():
+    with pytest.raises(OQPInputError, match=r"Unknown \.oqp call: force"):
+        oqp_input.parse_canonical_oqp(
+            'dft pbe0 force(S0) geom="h2o.xyz"'
+        )
+
+
 @pytest.mark.parametrize("misspelling", ["gradd", "scff"])
 def test_space_separated_route_does_not_consume_bare_call_misspellings_as_basis(
     misspelling,
@@ -123,6 +130,16 @@ def test_valid_functionals_resembling_bare_calls_remain_route_components(functio
 
     assert spaced.functional == slash.functional == functional
     assert spaced.basis == slash.basis == "6-31g"
+
+
+def test_slash_inside_space_separated_functional_preserves_component_boundary():
+    spec = oqp_input.parse_canonical_oqp(
+        'dft pbe-3/8 6-31g geom="h2o.xyz" energy'
+    )
+
+    assert spec.model == "dft"
+    assert spec.functional == "pbe-3/8"
+    assert spec.basis == "6-31g"
 
 
 @pytest.mark.parametrize("geometry", ['"h2o.xyz"', '"my geometry.xyz"'])


### PR DESCRIPTION
## Summary

- accept whitespace-separated route components such as `mrsf bhhlyp 6-31g*`
- preserve slash-separated input and accept mixed slash/whitespace spellings
- stop route parsing before drivers, geometry files, and explicit `basis=...` options
- cover every registered model alias and the functional/basis, basis-only, and component-free route families

## Validation

- `python3.11 -m pytest -q tests/test_oqp_input.py` — 312 passed
- `python3.11 -m pytest -q tests/test_oqp_input_schema_manifest.py tests/test_legacy_example_conversion.py` — 12 passed, 3 expected failures
- `python3.11 -m py_compile pyoqp/oqp/utils/oqp_input.py tests/test_oqp_input.py`
- `git diff --check`

## Contribution checklist

- [x] **Rights and provenance** — maintainer-authored change with Codex assistance; no third-party code was copied.
- [x] **BLAS/LAPACK** — not applicable; this change is confined to the pure-Python input parser and tests.
- [x] **Example** — the concise MRSF input example now exercises whitespace-separated route components.
- [x] **Python API** — no new workflow, section, keyword, or API surface; the existing parser entry point accepts the additional equivalent spelling.
- [x] **Docs** — no new keyword or workflow requiring an openqp-docs companion PR; the in-repository example documents the accepted spelling.
