### PR TITLE
dftb: accept the dtcam-gap operator preset

### DIFF
--- a/examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.inp
+++ b/examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.inp
@@ -4,7 +4,8 @@
 # optional external openqp-dftb library (libopenqp_dftb_c) with the dtcam-gap
 # preset (Open-Quantum-Platform/openqp-dftb#37) and a DFTB parameter set.
 # Neither ships with OpenQP or its CI, so `openqp --run_tests all` skips every
-# method=dftb input.  With openqp-dftb installed, run it explicitly:
+# method=dftb input.  With a compatible openqp-dftb installed (one that
+# includes dtcam-gap), run it explicitly:
 #
 #     openqp examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.inp
 #
@@ -13,9 +14,10 @@
 # (an .opdftb file or an SKF directory) or export OPENQP_DFTB_PARAMETER_PATH.
 #
 # model=dtcam-gap is the DTCAM-TB operator refitted on singlet-triplet gaps
-# rather than vertical excitation energies.  It differs from model=dtcam only in
-# the response operator (response omega, response cam_beta, the p-p one-centre
-# term and the three spin-pair couplings); the reference SCC is identical.
+# rather than vertical excitation energies (as defined in openqp-dftb#37).  It
+# differs from model=dtcam only in the response operator (response omega,
+# response cam_beta, the p-p one-centre term and the three spin-pair
+# couplings); the reference SCC is identical.
 # Prefer it where state ordering and crossing geometry decide the outcome, such
 # as nonadiabatic dynamics; model=dtcam remains the better choice for
 # individual vertical excitation energies.

--- a/examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.inp
+++ b/examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.inp
@@ -1,0 +1,41 @@
+# MRSF-TDDFTB of triplet-reference CH2 with the dtcam-gap operator preset.
+#
+# DOCUMENTATION EXAMPLE, not a self-contained regression test.  It needs the
+# optional external openqp-dftb library (libopenqp_dftb_c) with the dtcam-gap
+# preset (Open-Quantum-Platform/openqp-dftb#37) and a DFTB parameter set.
+# Neither ships with OpenQP or its CI, so `openqp --run_tests all` skips every
+# method=dftb input.  With openqp-dftb installed, run it explicitly:
+#
+#     openqp examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.inp
+#
+# With no [dftb] parameter_path, the bundled openqp-dftb parameter set is used
+# when the installed openqp-dftb provides one; otherwise set parameter_path
+# (an .opdftb file or an SKF directory) or export OPENQP_DFTB_PARAMETER_PATH.
+#
+# model=dtcam-gap is the DTCAM-TB operator refitted on singlet-triplet gaps
+# rather than vertical excitation energies.  It differs from model=dtcam only in
+# the response operator (response omega, response cam_beta, the p-p one-centre
+# term and the three spin-pair couplings); the reference SCC is identical.
+# Prefer it where state ordering and crossing geometry decide the outcome, such
+# as nonadiabatic dynamics; model=dtcam remains the better choice for
+# individual vertical excitation energies.
+[input]
+system=
+   6   0.000000000   0.000000000   0.000000000
+   1   0.000000000   0.990000000   0.330000000
+   1   0.000000000  -0.990000000   0.330000000
+charge=0
+method=dftb
+runtype=energy
+
+[scf]
+type=rohf
+multiplicity=3
+
+[dftb]
+type=mrsf
+model=dtcam-gap
+
+[tdhf]
+type=mrsf
+nstate=3

--- a/examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.oqp
+++ b/examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.oqp
@@ -1,0 +1,2 @@
+mrsf-tddftb(nstate=3) dftb(model=dtcam-gap)
+geom="../geometries/CH2-c8bd8087ea23.xyz"

--- a/examples/DFTB/README.md
+++ b/examples/DFTB/README.md
@@ -1,0 +1,22 @@
+# DFTB examples
+
+These inputs use the OpenQP-DFTB tight-binding backend (`method=dftb`). They are
+**documentation examples**, not self-contained regression tests: they need the
+optional external openqp-dftb library (`libopenqp_dftb_c`) and a DFTB parameter
+set, neither of which OpenQP or its CI ships. `openqp --run_tests all` therefore
+skips every `method=dftb` input; the operator presets themselves are covered by
+the openqp-dftb test suite.
+
+Run one explicitly once openqp-dftb is installed:
+
+```bash
+openqp examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.inp
+```
+
+If the installed openqp-dftb does not bundle a parameter set, set
+`[dftb] parameter_path` (an `.opdftb` file or an SKF directory) or export
+`OPENQP_DFTB_PARAMETER_PATH`.
+
+| Input | What it shows |
+|---|---|
+| `CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.inp` / `.oqp` | MRSF-TDDFTB with `[dftb] model=dtcam-gap`, the DTCAM-TB operator refitted on singlet-triplet gaps (needs Open-Quantum-Platform/openqp-dftb#37) |

--- a/examples/DFTB/README.md
+++ b/examples/DFTB/README.md
@@ -7,7 +7,8 @@ set, neither of which OpenQP or its CI ships. `openqp --run_tests all` therefore
 skips every `method=dftb` input; the operator presets themselves are covered by
 the openqp-dftb test suite.
 
-Run one explicitly once openqp-dftb is installed:
+Run one explicitly once a compatible openqp-dftb is installed, meaning one
+that implements the preset the input uses:
 
 ```bash
 openqp examples/DFTB/CH2_MRSF-TDDFTB_DTCAM-GAP_ENERGY.inp

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -1542,8 +1542,10 @@ def _check_tb(config: dict[str, Any], report: CheckReport, *, section: str) -> N
                 value=model,
                 expected=", ".join(sorted(DFTB_MODELS)),
                 action="Use model=dtcam (DTCAM-TB paper vector), "
-                       "model=ob2 (conventional OB2/LC-DFTB2 protocol), or "
-                       "omit model and set the operator keys individually.",
+                       "model=dtcam-gap (DTCAM-TB refitted on singlet-triplet "
+                       "gaps), model=ob2 (conventional OB2/LC-DFTB2 "
+                       "protocol), or omit model and set the operator keys "
+                       "individually.",
             )
         if backend == "probe":
             report.add(

--- a/pyoqp/oqp/utils/input_checker.py
+++ b/pyoqp/oqp/utils/input_checker.py
@@ -46,15 +46,17 @@ DFTB_TYPES = {
 }
 DFTB_SCC_MIXERS = {"linear", "anderson", "pulay", "broyden", "auto", "diis", "trust", "trah"}
 
-# Canonical model keywords are "dtcam", "dtcam2"/"dtcam-erf" and "ob2".  The
-# historical spellings stay ACCEPTED ALIASES so committed inputs keep working;
-# "dftb+" in particular was renamed because DFTB+ is a different program and
-# the preset is really the conventional OB2 / LC-DFTB2 protocol.  This set must
-# stay in sync with openqp_dftb_preset_by_name in the native library.
+# Canonical model keywords are "dtcam", "dtcam-gap", "dtcam2"/"dtcam-erf" and
+# "ob2".  The historical spellings stay ACCEPTED ALIASES so committed inputs
+# keep working; "dftb+" in particular was renamed because DFTB+ is a different
+# program and the preset is really the conventional OB2 / LC-DFTB2 protocol.
+# This set must stay in sync with openqp_dftb_preset_by_name in the native
+# library.
 DFTB_MODELS = {
     # canonical
     "dtcam",
     "dtcam2", "dtcam-erf", "dtcam_erf", "dtcamerf",
+    "dtcam-gap", "dtcam_gap", "dtcamgap",
     "ob2",
     # legacy aliases
     "dtcam-tb", "dtcam_tb", "dtcamtb",

--- a/pyoqp/oqp/utils/state_labels.py
+++ b/pyoqp/oqp/utils/state_labels.py
@@ -102,7 +102,7 @@ DFTB_CAP_SCC_FINAL_TRUST = 4
 # openqp_dftb_resolved_options record; this tuple only feeds the settings log.
 # Canonical spellings only -- the legacy aliases ("dtcam-tb", "dtcam-tb2",
 # "dtcam-tb-erf", "dftb+") still parse but are no longer advertised.
-DFTB_KNOWN_PRESETS = ("dtcam", "dtcam2", "dtcam-erf", "ob2")
+DFTB_KNOWN_PRESETS = ("dtcam", "dtcam-gap", "dtcam2", "dtcam-erf", "ob2")
 
 
 def _section(config, name):

--- a/tests/test_dftb_model_presets.py
+++ b/tests/test_dftb_model_presets.py
@@ -1,0 +1,65 @@
+"""Input-checker coverage for the named [dftb] operator model presets.
+
+``DFTB_MODELS`` is the gate every input passes before openqp-dftb sees it: a
+name missing here is rejected with "Unknown OpenQP-DFTB operator model preset"
+even when the native library implements it.  These tests drive the real
+``[dftb]`` section check, so they fail if a preset (or one of its accepted
+spellings) is dropped from the gate, if the settings log advertises a name the
+gate rejects, or if a preset stops locking the operator keys it overrides.
+
+The native library itself is not needed: the model check runs before any
+openqp-dftb call.
+"""
+
+import pytest
+
+from oqp.utils.input_checker import CheckReport, DFTB_MODELS, _check_tb
+from oqp.utils.state_labels import DFTB_KNOWN_PRESETS
+
+
+def _config(dftb=None):
+    config = {
+        "input": {"method": "dftb", "runtype": "energy"},
+        "tdhf": {"type": "mrsf", "nstate": 3},
+        "properties": {"grad": []},
+        "optimize": {},
+        "dftb": {"backend": "native", "type": "mrsf", "model": ""},
+    }
+    if dftb:
+        config["dftb"].update(dftb)
+    return config
+
+
+def _model_errors(dftb):
+    report = CheckReport()
+    _check_tb(_config(dftb), report, section="dftb")
+    return [d for d in report.errors if d.path == "dftb.model"]
+
+
+@pytest.mark.parametrize("name", ["dtcam-gap", "dtcam_gap", "dtcamgap", "DTCAM-GAP"])
+def test_dtcam_gap_spellings_pass_the_model_gate(name):
+    # openqp-dftb lower-cases the name and accepts exactly these three spellings.
+    assert _model_errors({"model": name}) == []
+
+
+def test_unknown_model_is_still_rejected():
+    # Control: proves the check above is actually reached, so an accepted name
+    # is a real pass rather than a skipped check.
+    errors = _model_errors({"model": "dtcam-gapx"})
+    assert errors
+    assert "Unknown OpenQP-DFTB operator model preset" in errors[0].message
+
+
+@pytest.mark.parametrize("name", DFTB_KNOWN_PRESETS)
+def test_every_advertised_preset_is_accepted(name):
+    # DFTB_KNOWN_PRESETS feeds the "Available presets" settings-log line; a name
+    # listed there must never be one the input gate rejects.
+    assert name in DFTB_MODELS
+    assert _model_errors({"model": name}) == []
+
+
+def test_dtcam_gap_locks_the_operator_keys_it_overrides():
+    # dtcam-gap overrides the spin-pair couplings (among others); a user-tuned
+    # value would be silently discarded inside openqp-dftb, so it is refused.
+    errors = _model_errors({"model": "dtcam-gap", "spc_coco": 0.123456})
+    assert any("fixes the operator" in d.message for d in errors)

--- a/tests/test_dftb_model_presets.py
+++ b/tests/test_dftb_model_presets.py
@@ -7,13 +7,15 @@ even when the native library implements it.  These tests drive the real
 spellings) is dropped from the gate, if the settings log advertises a name the
 gate rejects, or if a preset stops locking the operator keys it overrides.
 
-The native library itself is not needed: the model check runs before any
-openqp-dftb call.
+The openqp-dftb library is not needed: the model check runs before any
+openqp-dftb call.  Importing ``oqp`` still loads the compiled OpenQP runtime,
+as it does in CI.
 """
 
 import pytest
 
 from oqp.utils.input_checker import CheckReport, DFTB_MODELS, _check_tb
+from oqp.utils.oqp_input import lower_to_legacy, parse_canonical_oqp
 from oqp.utils.state_labels import DFTB_KNOWN_PRESETS
 
 
@@ -38,7 +40,9 @@ def _model_errors(dftb):
 
 @pytest.mark.parametrize("name", ["dtcam-gap", "dtcam_gap", "dtcamgap", "DTCAM-GAP"])
 def test_dtcam_gap_spellings_pass_the_model_gate(name):
-    # openqp-dftb lower-cases the name and accepts exactly these three spellings.
+    # The three spellings openqp-dftb#37's openqp_dftb_preset_by_name matches
+    # after lower-casing; the upper-case case exercises pyoqp's own gate, which
+    # lower-cases too.
     assert _model_errors({"model": name}) == []
 
 
@@ -48,6 +52,8 @@ def test_unknown_model_is_still_rejected():
     errors = _model_errors({"model": "dtcam-gapx"})
     assert errors
     assert "Unknown OpenQP-DFTB operator model preset" in errors[0].message
+    # The fix-it hint names the new preset alongside dtcam and ob2.
+    assert "model=dtcam-gap" in errors[0].action
 
 
 @pytest.mark.parametrize("name", DFTB_KNOWN_PRESETS)
@@ -63,3 +69,19 @@ def test_dtcam_gap_locks_the_operator_keys_it_overrides():
     # value would be silently discarded inside openqp-dftb, so it is refused.
     errors = _model_errors({"model": "dtcam-gap", "spc_coco": 0.123456})
     assert any("fixes the operator" in d.message for d in errors)
+
+
+@pytest.mark.parametrize("name", ["dtcam-gap", "dtcam_gap", "dtcamgap"])
+def test_concise_input_with_dtcam_gap_reaches_the_model_gate(name):
+    # The .oqp route: concise text lowers to a method=dftb / type=mrsf input
+    # carrying the spelling unchanged, and that model value passes the gate.
+    spec = parse_canonical_oqp(
+        f'mrsf-tddftb(nstate=3) dftb(model={name}) geom="ch2.xyz"'
+    )
+    legacy = lower_to_legacy(spec, source_dir=None)
+    assert legacy["input"]["method"] == "dftb"
+    assert legacy["dftb"]["type"] == "mrsf"
+    assert legacy["dftb"]["model"] == name
+    # lower_to_legacy returns raw strings and the checker runs on the typed
+    # config, so pass the lowered model value through the typed helper.
+    assert _model_errors({"model": legacy["dftb"]["model"]}) == []

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -1487,7 +1487,9 @@ geom="alanine-dipeptide.xyz"
 
 @pytest.mark.parametrize("name", ["dtcam-gap", "dtcam_gap", "dtcamgap"])
 def test_dftb_dtcam_gap_preset_parses_in_concise_syntax(name):
-    """The concise form carries every accepted dtcam-gap spelling to [dftb] model."""
+    """Round trip only: the concise form carries each dtcam-gap spelling to
+    [dftb] model unchanged.  The parser accepts any model string; the preset
+    gate itself is tested in test_dftb_model_presets.py."""
     spec, config = _parse(f"""
 mrsf-tddftb(nstate=3)
 dftb(model={name})

--- a/tests/test_oqp_input.py
+++ b/tests/test_oqp_input.py
@@ -1485,6 +1485,18 @@ geom="alanine-dipeptide.xyz"
     assert "scc_mixer=trah" in oqp_input.render_canonical_oqp(spec)
 
 
+@pytest.mark.parametrize("name", ["dtcam-gap", "dtcam_gap", "dtcamgap"])
+def test_dftb_dtcam_gap_preset_parses_in_concise_syntax(name):
+    """The concise form carries every accepted dtcam-gap spelling to [dftb] model."""
+    spec, config = _parse(f"""
+mrsf-tddftb(nstate=3)
+dftb(model={name})
+geom="alanine-dipeptide.xyz"
+""")
+    assert config["dftb"]["model"] == name
+    assert f"model={name}" in oqp_input.render_canonical_oqp(spec)
+
+
 @pytest.mark.parametrize(
     "options,message",
     [

--- a/tests/test_state_labels.py
+++ b/tests/test_state_labels.py
@@ -325,3 +325,14 @@ def test_dftb_preset_log_does_not_claim_schema_defaults_are_effective():
     assert "dtcam-tb (operator resolved by openqp-dftb backend)" in text
     assert "Mixer:" not in text
     assert "CAM alpha / beta:" not in text
+
+
+def test_dftb_settings_log_advertises_the_dtcam_gap_preset():
+    # No model selected, so the only way dtcam-gap reaches this line is the
+    # advertised preset list itself.
+    config = dftb_config("mrsf", td_type="mrsf", model="")
+    text = state_labels.format_dftb_settings(config, backend="native")
+
+    lines = [line for line in text.splitlines() if "Available presets" in line]
+    assert lines, "settings log has no 'Available presets' line"
+    assert "dtcam-gap" in lines[0]


### PR DESCRIPTION
## Summary

Accepts the `dtcam-gap` operator preset that
Open-Quantum-Platform/openqp-dftb#37 adds. **Two lines of data, nothing else.**

`DFTB_MODELS` here is the gate every input file passes through first, so
without this entry `model=dtcam-gap` is rejected before it ever reaches the
library:

```
[ERROR] dftb.model: Unknown OpenQP-DFTB operator model preset.
  current: 'dtcam-gap'
  expected: dftb+, dftb_plus, dftbplus, dtcam, dtcam-erf, ... ob2
```

The comment above `DFTB_MODELS` already records the invariant this restores —
*"This set must stay in sync with `openqp_dftb_preset_by_name` in the native
library."* It also advertises the name in the settings log
(`DFTB_KNOWN_PRESETS` in `state_labels.py`), which is display-only.

## What `dtcam-gap` is

DTCAM-TB refitted against **singlet–triplet gaps** rather than vertical
excitation energies. In MRSF, `A = A⁽⁰⁾ + σA′`, so the whole S–T splitting is
carried by the spin-pairing block; an objective summing `MAE(S1) + MAE(T1)`
scores the two energies separately and largely cancels a σ-carrying term, which
leaves it close to blind to the parameters that set the splitting. Gaps improve
20% on the fitted set and 26% on held-out QUEST, for 4–10% worse vertical
energies, and it recovers the butadiene 1¹Bᵤ/2¹A_g crossing to 0.013 Å against
all-electron MRSF. Full numbers, caveats, and the fitting protocol are in the
openqp-dftb PR.

## Compatibility

Purely additive — no name removed, no default changed
(`DFTB_MODEL_DEFAULT_MRSF` is still `dtcam`). No committed input can behave
differently.

## Testing

Verified **end to end** against an openqp-dftb build carrying the preset: CH₂
triplet ROHF, MRSF-TDDFTB, `model=dtcam-gap` runs clean and the settings log
reports the intended vector —

```
Response operator
  omega / cam_alpha / cam_beta:   0.2895 / 0.0000 / 1.0977
  SPC coco / ovov / coov:         0.8000 / 0.8000 / 0.8000
  Onsite ss / sp / pp:            0.0000 / 0.0000 / 0.0146
```

— against `model=dtcam`'s `0.3200 / 0.0000 / 1.0125`, `0.5/0.5/0.5`,
`-0.0125`, giving genuinely distinct energies (T1 6.279 vs 5.353 eV). So the
name resolves to the new vector rather than silently falling back.

## Ordering

**Open-Quantum-Platform/openqp-dftb#37 must land first.** Merged alone, this PR
lets the name through pyoqp only for the library to reject it — the same error,
one layer down. Merged after, the preset works.
