### PR TITLE
build(external): fetch oqp-libint from the GitHub mirror

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -277,7 +277,7 @@ oqp_reuse_or_build(libint2 "${LIBINT2_LIBRARY}" "${LIBINT2_BUILD_DIR}/fortran" "
 if(NOT TARGET libint2)
 ExternalProject_Add(libint2
     PREFIX ${LIBINT2_PREFIX}
-    URL https://qchemlab.knu.ac.kr/vmironov/oqp-libint/-/archive/v${_OQP_LIBINT2_VERSION}/oqp-libint-v${_OQP_LIBINT2_VERSION}.tar.gz
+    URL https://github.com/Open-Quantum-Platform/oqp-libint/archive/refs/tags/v${_OQP_LIBINT2_VERSION}.tar.gz
     TLS_VERIFY TRUE
     SOURCE_DIR ${LIBINT2_SOURCE_DIR}
     BINARY_DIR ${LIBINT2_BUILD_DIR}


### PR DESCRIPTION
## What

Point the `libint2` `ExternalProject` at the new GitHub mirror instead of the KNU GitLab server.

```diff
-    URL https://qchemlab.knu.ac.kr/vmironov/oqp-libint/-/archive/v${_OQP_LIBINT2_VERSION}/oqp-libint-v${_OQP_LIBINT2_VERSION}.tar.gz
+    URL https://github.com/Open-Quantum-Platform/oqp-libint/archive/refs/tags/v${_OQP_LIBINT2_VERSION}.tar.gz
```

`external/CMakeLists.txt:280` — one line, no other change.

## Why

The pre-generated Libint 2.7.1 (am=4) tarball was fetched from `qchemlab.knu.ac.kr`, which is not reliably reachable from outside KNU and is a single point of failure for every build and CI run.

`Open-Quantum-Platform/oqp-libint` is a full mirror of `vmironov/oqp-libint` — all branches (`main`, `am4`) and all tags (`v2.7.1-am4`, `v2.7.1.1-am4`), pushed with `git push --mirror`. `git ls-remote` output is identical between the two hosts.

The new URL uses the same `archive/refs/tags/` form already used in this file for `tagarray`, `libecpint`, `lapack`, `opentrustregion`, `fprettify` and `ddX`.

## Verification

The fetched source is unchanged:

- Downloaded both tarballs (`v2.7.1.1-am4`, the value of `_OQP_LIBINT2_VERSION`) and extracted them: **3608 files each, `diff -r` clean** — byte-identical trees.
- The tarballs' top-level directory names differ (`oqp-libint-v2.7.1.1-am4` vs `oqp-libint-2.7.1.1-am4`). Ran a standalone `ExternalProject_Add` download test against the new URL to confirm CMake strips the single top-level directory: `SOURCE_DIR` comes out with `CMakeLists.txt`, `fortran/` and `include/` at its root, and `diff -r` against the GitLab-sourced tree is clean.

No externals-cache bump (`_OQP_EXTERNALS_CACHE_REVISION`) is needed, since the fetched content is identical.

## Notes

- No `URL_HASH` added, deliberately — the previous GitLab URL had none, so this preserves existing behaviour rather than adding a new way for the build to break. Happy to add one (`SHA256=a04a733b783214626a50a736fed336e80a4f1502b9e5732ea7e428848024af04`) if reviewers prefer consistency with the other GitHub deps.
- `.gitlab-ci.yml:1` still references `qchemlab.knu.ac.kr:5050` for its CI container image. That is unrelated to libint and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMfLidGETCXASKns4vLn3h